### PR TITLE
Changes to fix vite.config.extension import in projects

### DIFF
--- a/packages/client-core/src/common/services/RouterService.tsx
+++ b/packages/client-core/src/common/services/RouterService.tsx
@@ -94,6 +94,8 @@ export const useSearchParamState = () => {
         const params = new URLSearchParams(location.search)
         const current = Object.fromEntries([...params.entries()])
 
+        if (current[props.keyID] === value) return
+
         setSearchParams({ ...current, [props.keyID]: value })
 
         return () => {

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -124,10 +124,19 @@ import('ts-node').then((tsnode) => {
 })
 
 const getProjectConfigExtensions = async (config: UserConfig) => {
-  const projects = fs
-    .readdirSync(path.resolve(__dirname, '../projects/projects/'), { withFileTypes: true })
-    .filter((dirent) => dirent.isDirectory())
-    .map((dirent) => dirent.name)
+  const projects = fs.existsSync(path.resolve(__dirname, '../projects/projects'))
+    ? fs
+        .readdirSync(path.resolve(__dirname, '../projects/projects'), { withFileTypes: true })
+        .filter((orgDir) => orgDir.isDirectory())
+        .map((orgDir) => {
+          return fs
+            .readdirSync(path.resolve(__dirname, '../projects/projects', orgDir.name), { withFileTypes: true })
+            .filter((projectDir) => projectDir.isDirectory())
+            .map((projectDir) => `${orgDir.name}/${projectDir.name}`)
+        })
+        .flat()
+    : []
+
   for (const project of projects) {
     const staticPath = path.resolve(__dirname, `../projects/projects/`, project, 'vite.config.extension.ts')
     if (fs.existsSync(staticPath)) {


### PR DESCRIPTION
## Summary

This PR fixed 2 things:

1. vite.config.extension import in projects not working properly.
2. RouterState.Navigate having issue when navigating to a url like `RouterState.navigate('/pricing?productName=basic')`

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
