### PR TITLE
corrected the execution order so the kill height logic runs before th…

### DIFF
--- a/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
@@ -26,14 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import { Not } from 'bitecs'
 import { Vector3 } from 'three'
 
-import {
-  defineQuery,
-  defineSystem,
-  getComponent,
-  setComponent,
-  SimulationSystemGroup,
-  UUIDComponent
-} from '@ir-engine/ecs'
+import { defineQuery, defineSystem, getComponent, setComponent, UUIDComponent } from '@ir-engine/ecs'
 import { getState } from '@ir-engine/hyperflux'
 import { NetworkObjectAuthorityTag } from '@ir-engine/network'
 import { SpawnPoseState, TransformComponent } from '@ir-engine/spatial'
@@ -45,14 +38,13 @@ import { XRState } from '@ir-engine/spatial/src/xr/XRState'
 
 import { SceneComponent } from '@ir-engine/spatial/src/renderer/components/SceneComponents'
 import { getAncestorWithComponent } from '@ir-engine/spatial/src/transform/components/EntityTree'
-import { AvatarComponent } from '../../avatar/components/AvatarComponent'
+import { TransformDirtyUpdateSystem } from '@ir-engine/spatial/src/transform/systems/TransformSystem'
 import { updateReferenceSpaceFromAvatarMovement } from '../../avatar/functions/moveAvatar'
 import { SceneSettingsComponent } from '../components/SceneSettingsComponent'
 
 const heightKillApplicableQuery = defineQuery([
   RigidBodyComponent,
   NetworkObjectAuthorityTag,
-  Not(AvatarComponent),
   Not(RigidBodyFixedTagComponent)
 ])
 
@@ -100,6 +92,6 @@ const execute = () => {
 
 export const SceneKillHeightSystem = defineSystem({
   uuid: 'ee.engine.SceneKillHeightSystem',
-  insert: { before: SimulationSystemGroup },
+  insert: { before: TransformDirtyUpdateSystem },
   execute
 })


### PR DESCRIPTION
…e the transform dirty update

removed the condition that the object is does not have an Avatar Component, so it will work for the avatar
https://tsu.atlassian.net/browse/IR-4148
## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
