### PR TITLE
IR-4077 removing three references from ecs package

### DIFF
--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -17,7 +17,6 @@
     "@ir-engine/common": "^1.6.0",
     "@ir-engine/hyperflux": "^1.6.0",
     "bitecs": "0.3.40",
-    "three": "0.158.0",
     "uuid": "9.0.0"
   },
   "devDependencies": {

--- a/packages/ecs/src/Engine.ts
+++ b/packages/ecs/src/Engine.ts
@@ -25,7 +25,6 @@ Infinite Reality Engine. All Rights Reserved.
 
 import * as bitECS from 'bitecs'
 import { getAllEntities } from 'bitecs'
-import { Cache } from 'three'
 
 import { API } from '@ir-engine/common'
 import * as Hyperflux from '@ir-engine/hyperflux'
@@ -95,8 +94,6 @@ export function createEngine(hyperstore = createHyperStore({ publicPath: '' })) 
 }
 
 export async function destroyEngine() {
-  Cache.clear()
-
   getState(ECSState).timer?.clear()
 
   if (API.instance) {

--- a/packages/ecs/src/UUIDComponent.ts
+++ b/packages/ecs/src/UUIDComponent.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { MathUtils } from 'three'
+import { v4 as uuidv4 } from 'uuid'
 
 import { hookstate, NO_PROXY_STEALTH, State, useHookstate } from '@ir-engine/hyperflux'
 
@@ -88,7 +88,7 @@ export const UUIDComponent = defineComponent({
   },
 
   generateUUID() {
-    return MathUtils.generateUUID() as EntityUUID
+    return uuidv4() as EntityUUID
   }
 })
 

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@ir-engine/common": "^1.6.0",
     "@ir-engine/ecs": "^1.6.0",
+    "three": "0.158.0",
     "@ir-engine/hyperflux": "^1.6.0"
   },
   "devDependencies": {

--- a/packages/spatial/src/resources/ResourceState.ts
+++ b/packages/spatial/src/resources/ResourceState.ts
@@ -115,12 +115,15 @@ type Resource = {
 export const ResourceState = defineState({
   name: 'ResourceManagerState',
 
-  initial: () => ({
-    resources: {} as Record<string, Resource>,
-    totalVertexCount: 0,
-    totalBufferCount: 0,
-    debug: false
-  }),
+  initial: () => {
+    Cache.clear()
+    return {
+      resources: {} as Record<string, Resource>,
+      totalVertexCount: 0,
+      totalBufferCount: 0,
+      debug: false
+    }
+  },
 
   debugLog: (...data: any[]) => {
     if (getState(ResourceState).debug) console.log(...data)


### PR DESCRIPTION
## Summary
Removing three references from ecs package
- moving Cache.clear() to ResourceState initialization
- changing MathUtils.generateUUID to uuidv4() from 'uuid' package (v4)

## References
[https://tsu.atlassian.net/browse/IR-4077](https://tsu.atlassian.net/browse/IR-4077)

