### PR TITLE
IR-3984 viewer transition problems

### DIFF
--- a/packages/client-core/src/hooks/useEngineCanvas.ts
+++ b/packages/client-core/src/hooks/useEngineCanvas.ts
@@ -24,14 +24,16 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { getComponent } from '@ir-engine/ecs'
-import { getState, useHookstate } from '@ir-engine/hyperflux'
+import { getState, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { EngineState } from '@ir-engine/spatial/src/EngineState'
-import { destroySpatialEngine, initializeSpatialEngine } from '@ir-engine/spatial/src/initializeEngine'
+import { destroySpatialViewer, initializeSpatialViewer } from '@ir-engine/spatial/src/initializeEngine'
 import { RendererComponent } from '@ir-engine/spatial/src/renderer/WebGLRendererSystem'
 import { useEffect, useLayoutEffect } from 'react'
 
 export const useEngineCanvas = (ref: React.RefObject<HTMLElement>) => {
   const lastRef = useHookstate(() => ref.current)
+
+  const engineState = useMutableState(EngineState)
 
   useLayoutEffect(() => {
     if (ref.current !== lastRef.value) {
@@ -41,12 +43,13 @@ export const useEngineCanvas = (ref: React.RefObject<HTMLElement>) => {
 
   useLayoutEffect(() => {
     if (!lastRef.value) return
+    if (!engineState.localFloorEntity || !engineState.originEntity) return
 
     const parent = lastRef.value as HTMLElement
 
     const canvas = document.getElementById('engine-renderer-canvas') as HTMLCanvasElement
     const originalParent = canvas.parentElement
-    initializeSpatialEngine(canvas)
+    initializeSpatialViewer(canvas)
     parent.appendChild(canvas)
 
     const observer = new ResizeObserver(() => {
@@ -56,12 +59,12 @@ export const useEngineCanvas = (ref: React.RefObject<HTMLElement>) => {
     observer.observe(parent)
 
     return () => {
-      destroySpatialEngine()
+      destroySpatialViewer()
       observer.disconnect()
       parent.removeChild(canvas)
       originalParent?.appendChild(canvas)
     }
-  }, [lastRef.value])
+  }, [lastRef.value, engineState.localFloorEntity, engineState.originEntity])
 }
 
 export const useRemoveEngineCanvas = () => {

--- a/packages/client/src/pages/location/location.tsx
+++ b/packages/client/src/pages/location/location.tsx
@@ -24,7 +24,7 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { t } from 'i18next'
-import React, { Suspense, useRef } from 'react'
+import React, { Suspense, useEffect, useRef } from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import '../../engine'
@@ -33,10 +33,19 @@ import Debug from '@ir-engine/client-core/src/components/Debug'
 import { useEngineInjection } from '@ir-engine/client-core/src/components/World/EngineHooks'
 import { useEngineCanvas } from '@ir-engine/client-core/src/hooks/useEngineCanvas'
 import LocationPage from '@ir-engine/client-core/src/world/Location'
+import { destroySpatialEngine, initializeSpatialEngine } from '@ir-engine/spatial/src/initializeEngine'
 import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
 
 const LocationRoutes = () => {
   const ref = useRef<HTMLElement>(document.body)
+
+  useEffect(() => {
+    initializeSpatialEngine()
+    return () => {
+      destroySpatialEngine()
+    }
+  }, [])
+
   useEngineCanvas(ref)
 
   const projectsLoaded = useEngineInjection()

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -56,6 +56,7 @@ import { FeatureFlags } from '@ir-engine/common/src/constants/FeatureFlags'
 import { EntityUUID } from '@ir-engine/ecs'
 import useFeatureFlags from '@ir-engine/engine/src/useFeatureFlags'
 import { EngineState } from '@ir-engine/spatial/src/EngineState'
+import { destroySpatialEngine, initializeSpatialEngine } from '@ir-engine/spatial/src/initializeEngine'
 import Button from '@ir-engine/ui/src/primitives/tailwind/Button'
 import 'rc-dock/dist/rc-dock.css'
 import { useTranslation } from 'react-i18next'
@@ -168,12 +169,19 @@ const EditorContainer = () => {
     }
   }, [scenePath.value])
 
-  const viewerEntity = useMutableState(EngineState).viewerEntity.value
+  useEffect(() => {
+    initializeSpatialEngine()
+    return () => {
+      destroySpatialEngine()
+    }
+  }, [])
+
+  const originEntity = useMutableState(EngineState).originEntity.value
 
   useEffect(() => {
-    if (!sceneAssetID.value || !currentLoadedSceneURL.value || !viewerEntity) return
+    if (!sceneAssetID.value || !currentLoadedSceneURL.value || !originEntity) return
     return setCurrentEditorScene(currentLoadedSceneURL.value, sceneAssetID.value as EntityUUID)
-  }, [viewerEntity, currentLoadedSceneURL.value])
+  }, [originEntity, currentLoadedSceneURL.value])
 
   const errorState = useHookstate(getMutableState(EditorErrorState).error)
 

--- a/packages/engine/src/avatar/functions/moveAvatar.test.tsx
+++ b/packages/engine/src/avatar/functions/moveAvatar.test.tsx
@@ -38,7 +38,7 @@ import { applyIncomingActions, dispatchAction, getMutableState } from '@ir-engin
 import { Network, NetworkPeerFunctions, NetworkState, NetworkWorldUserStateSystem } from '@ir-engine/network'
 import { createMockNetwork } from '@ir-engine/network/tests/createMockNetwork'
 import { EventDispatcher } from '@ir-engine/spatial/src/common/classes/EventDispatcher'
-import { initializeSpatialEngine } from '@ir-engine/spatial/src/initializeEngine'
+import { initializeSpatialEngine, initializeSpatialViewer } from '@ir-engine/spatial/src/initializeEngine'
 import { Physics, PhysicsWorld } from '@ir-engine/spatial/src/physics/classes/Physics'
 import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 
@@ -56,6 +56,7 @@ describe('moveAvatar function tests', () => {
   beforeEach(async () => {
     createEngine()
     initializeSpatialEngine()
+    initializeSpatialViewer()
     await Physics.load()
     Engine.instance.store.userID = 'userId' as UserID
     sceneEntity = loadEmptyScene()

--- a/packages/engine/src/avatar/functions/spawnAvatarReceptor.test.tsx
+++ b/packages/engine/src/avatar/functions/spawnAvatarReceptor.test.tsx
@@ -37,7 +37,7 @@ import { ReactorReconciler, applyIncomingActions, dispatchAction } from '@ir-eng
 import { Network, NetworkPeerFunctions, NetworkState, NetworkWorldUserStateSystem } from '@ir-engine/network'
 import { createMockNetwork } from '@ir-engine/network/tests/createMockNetwork'
 import { EventDispatcher } from '@ir-engine/spatial/src/common/classes/EventDispatcher'
-import { initializeSpatialEngine } from '@ir-engine/spatial/src/initializeEngine'
+import { initializeSpatialEngine, initializeSpatialViewer } from '@ir-engine/spatial/src/initializeEngine'
 import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics'
 import {
   RigidBodyComponent,
@@ -58,6 +58,7 @@ describe('spawnAvatarReceptor', () => {
   beforeEach(async () => {
     createEngine()
     initializeSpatialEngine()
+    initializeSpatialViewer()
     Engine.instance.store.defaultDispatchDelay = () => 0
     await Physics.load()
     Engine.instance.store.userID = 'user' as UserID

--- a/packages/spatial/src/input/systems/ClientInputSystem.tsx
+++ b/packages/spatial/src/input/systems/ClientInputSystem.tsx
@@ -29,12 +29,13 @@ import { Quaternion, Ray, Raycaster, Vector3 } from 'three'
 
 import { isClient } from '@ir-engine/common/src/utils/getEnvironment'
 import { getComponent, getMutableComponent, hasComponent } from '@ir-engine/ecs/src/ComponentFunctions'
-import { UndefinedEntity } from '@ir-engine/ecs/src/Entity'
+import { Entity, UndefinedEntity } from '@ir-engine/ecs/src/Entity'
 import { QueryReactor, defineQuery } from '@ir-engine/ecs/src/QueryFunctions'
 import { defineSystem } from '@ir-engine/ecs/src/SystemFunctions'
 import { InputSystemGroup, PresentationSystemGroup } from '@ir-engine/ecs/src/SystemGroups'
 import { getMutableState, getState } from '@ir-engine/hyperflux'
 
+import { entityExists, removeEntity } from '@ir-engine/ecs'
 import { CameraComponent } from '../../camera/components/CameraComponent'
 import { ObjectDirection } from '../../common/constants/MathConstants'
 import { RaycastArgs } from '../../physics/classes/Physics'
@@ -106,9 +107,16 @@ const execute = () => {
     getMutableComponent(eid, InputComponent).inputSources.set([])
   }
 
+  const stalePointers: Entity[] = []
+
   // update 2D screen-based (driven by pointer api) input sources
   for (const eid of pointersQuery()) {
     const pointer = getComponent(eid, InputPointerComponent)
+    // check if pointer camera entity still exists
+    if (!pointer.cameraEntity || !entityExists(pointer.cameraEntity)) {
+      stalePointers.push(eid)
+      continue
+    }
     const inputSource = getComponent(eid, InputSourceComponent)
     const camera = getComponent(pointer.cameraEntity, CameraComponent)
     pointer.movement.copy(pointer.position).sub(pointer.lastPosition)
@@ -123,6 +131,11 @@ const execute = () => {
     TransformComponent.rotation.z[eid] = _rayRotation.z
     TransformComponent.rotation.w[eid] = _rayRotation.w
     TransformComponent.dirtyTransforms[eid] = true
+  }
+
+  // remove stale pointers
+  for (const stalePointer of stalePointers) {
+    removeEntity(stalePointer)
   }
 
   // update xr input sources

--- a/packages/spatial/src/transform/components/EntityTree.test.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.test.tsx
@@ -435,12 +435,12 @@ describe('useTreeQuery', () => {
     const { rerender, unmount } = render(tag)
 
     assert.equal(ents.length, 1, 'root entity not populated')
-    assert.equal(ents[0], rootEntity, 'root entity not populated')
+    assert.equal(ents.includes(rootEntity), true, 'root entity not populated')
 
     await act(() => rerender(tag))
 
     assert.equal(ents.length, 1, 'root entity not populated after re-querying')
-    assert.equal(ents[0], rootEntity, 'root entity not populated')
+    assert.equal(ents.includes(rootEntity), true, 'root entity not populated')
 
     const childEntity = createEntity()
     setComponent(childEntity, EntityTreeComponent, { parentEntity: rootEntity })
@@ -448,8 +448,8 @@ describe('useTreeQuery', () => {
     await act(() => rerender(tag))
 
     assert.equal(ents.length, 2, 'query incorrect after adding child')
-    assert.equal(ents[0], rootEntity, 'root entity not populated')
-    assert.equal(ents[1], childEntity, 'child entity not populated')
+    assert.equal(ents.includes(rootEntity), true, 'root entity not populated')
+    assert.equal(ents.includes(childEntity), true, 'child entity not populated')
 
     const deepChildEntity = createEntity()
     setComponent(deepChildEntity, EntityTreeComponent, { parentEntity: childEntity })
@@ -457,9 +457,9 @@ describe('useTreeQuery', () => {
     await act(() => rerender(tag))
 
     assert.equal(ents.length, 3, 'query incorrect after adding deep child')
-    assert.equal(ents[0], rootEntity, 'root entity not populated')
-    assert.equal(ents[1], childEntity, 'child entity not populated')
-    assert.equal(ents[2], deepChildEntity, 'deep child entity not populated')
+    assert.equal(ents.includes(rootEntity), true, 'root entity not populated')
+    assert.equal(ents.includes(childEntity), true, 'child entity not populated')
+    assert.equal(ents.includes(deepChildEntity), true, 'deep child entity not populated')
 
     const deepChildEntity2 = createEntity()
     setComponent(deepChildEntity2, EntityTreeComponent, { parentEntity: childEntity })
@@ -479,30 +479,30 @@ describe('useTreeQuery', () => {
     await act(() => rerender(tag))
 
     assert.equal(ents.length, 3, 'query incorrect after adding remove second deep child')
-    assert.equal(ents[0], rootEntity, 'root entity not populated')
-    assert.equal(ents[1], childEntity, 'child entity not populated')
-    assert.equal(ents[2], deepChildEntity, 'deep child entity not populated')
-    assert.equal(ents[3], undefined, 'deep child 2 entity still populated')
+    assert.equal(ents.includes(rootEntity), true, 'root entity not populated')
+    assert.equal(ents.includes(childEntity), true, 'child entity not populated')
+    assert.equal(ents.includes(deepChildEntity), true, 'deep child entity not populated')
+    assert.equal(ents.includes(deepChildEntity2), false, 'deep child 2 entity still populated')
 
     removeEntity(childEntity)
 
     await act(() => rerender(tag))
 
     assert.equal(ents.length, 1, 'query incorrect after adding removing child')
-    assert.equal(ents[0], rootEntity, 'root entity not populated')
-    assert.equal(ents[1], undefined, 'child entity still populated')
-    assert.equal(ents[2], undefined, 'deep child entity still populated')
-    assert.equal(ents[3], undefined, 'deep child 2 entity still populated')
+    assert.equal(ents.includes(rootEntity), true, 'root entity not populated')
+    assert.equal(ents.includes(childEntity), false, 'child entity still populated')
+    assert.equal(ents.includes(deepChildEntity), false, 'deep child entity still populated')
+    assert.equal(ents.includes(deepChildEntity2), false, 'deep child 2 entity still populated')
 
     removeEntity(rootEntity)
 
     await act(() => rerender(tag))
 
     assert.equal(ents.length, 0, 'query incorrect after adding removing all entities')
-    assert.equal(ents[0], undefined, 'root entity still populated')
-    assert.equal(ents[1], undefined, 'child entity still populated')
-    assert.equal(ents[2], undefined, 'deep child entity still populated')
-    assert.equal(ents[3], undefined, 'deep child 2 entity still populated')
+    assert.equal(ents.includes(rootEntity), false, 'root entity still populated')
+    assert.equal(ents.includes(childEntity), false, 'child entity still populated')
+    assert.equal(ents.includes(deepChildEntity), false, 'deep child entity still populated')
+    assert.equal(ents.includes(deepChildEntity2), false, 'deep child 2 entity still populated')
 
     unmount()
   })

--- a/packages/spatial/tests/util/mockSpatialEngine.ts
+++ b/packages/spatial/tests/util/mockSpatialEngine.ts
@@ -26,13 +26,14 @@ Infinite Reality Engine. All Rights Reserved.
 import { ECSState, Timer, setComponent } from '@ir-engine/ecs'
 import { getMutableState, getState } from '@ir-engine/hyperflux'
 import { EngineState } from '../../src/EngineState'
-import { initializeSpatialEngine } from '../../src/initializeEngine'
+import { initializeSpatialEngine, initializeSpatialViewer } from '../../src/initializeEngine'
 import { RendererComponent } from '../../src/renderer/WebGLRendererSystem'
 import { XRState } from '../../src/xr/XRState'
 import { mockEngineRenderer } from './MockEngineRenderer'
 
 export const mockSpatialEngine = () => {
   initializeSpatialEngine()
+  initializeSpatialViewer()
 
   const timer = Timer((time, xrFrame) => {
     getMutableState(XRState).xrFrame.set(xrFrame)


### PR DESCRIPTION
Fixes for bugs observed when switching between engine viewer canvases in the wizard. 

Pointer entities are generated in ClientInputHooks which get lost when viewer canvas gets unmounted. Since this data is only tracked in a one way reference from the PointerComponent to the camera entity associated with a viewer, the simplest fix is to detect stale pointers by checking if their camera entity still exists each frame

Also, the initialization of the viewer and of the origin have been split apart so that the scene doesn't need to be unloaded and reloaded every time a canvas is created or destroyed. Instead the base spatial environment is initialized on its own in initializeSpatialEngine, and a new function, initializeSpatialViewer, initializes the viewer. This way we can create and destroy viewers and preserve the underlying scene

Closes https://tsu.atlassian.net/browse/IR-3984