### PR TITLE
improve thumbnail names

### DIFF
--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -108,7 +108,8 @@ const uploadThumbnail = async (src: string, projectName: string, staticResourceI
   if (!blob) return
   const thumbnailMode = 'automatic'
   const thumbnailKey = `${decodeURI(stripSearchFromURL(src).replace(/^.*?\/projects\//, ''))
-    .replaceAll(/[^a-zA-Z0-9\.\-_\s]/g, '')
+    .replace(projectName + '/', '')
+    .replaceAll(/[^a-zA-Z0-9\.\-_\s]/g, '_')
     .replaceAll(/\s/g, '-')}-thumbnail.png`
   const file = new File([blob], thumbnailKey)
   const thumbnailURL = new URL(


### PR DESCRIPTION
## Summary

- the thumbnail key already has the project name in it, so we can remove the duplicate
- slashes are replaced with underscores rather than just removed

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
