### PR TITLE
IR-2872 compress image menu layout fixes

### DIFF
--- a/packages/editor/src/components/assets/ImageCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ImageCompressionPanel.tsx
@@ -150,7 +150,7 @@ export default function ImageCompressionPanel({
   }
 
   return (
-    <div className="max-h-[80vh] w-[680px] overflow-y-auto rounded-xl bg-[#0E0F11]">
+    <div className="max-h-[80vh] w-full min-w-[400px] max-w-[680px] overflow-y-auto rounded-xl bg-[#0E0F11]">
       <div className="relative mb-3 flex items-center justify-center px-8 py-3">
         <Text className="leading-6">{t('editor:properties.model.transform.compressImage')}</Text>
         <Button
@@ -161,9 +161,9 @@ export default function ImageCompressionPanel({
         />
       </div>
 
-      <div className="mx-auto grid w-4/5 justify-center gap-y-2">
+      <div className="mx-auto grid w-4/5 min-w-[400px] justify-center gap-y-2">
         <InputGroup
-          containerClassName="w-full justify-start"
+          containerClassName="w-full justify-start flex-nowrap"
           labelClassName="w-24 text-theme-gray3"
           name="mode"
           label={t('editor:properties.model.transform.dst')}
@@ -172,7 +172,7 @@ export default function ImageCompressionPanel({
         </InputGroup>
         <div className="w-full border border-[#2B2C30]" />
         <InputGroup
-          containerClassName="w-full justify-start"
+          containerClassName="w-full justify-start flex-nowrap"
           labelClassName="w-20 text-theme-gray3"
           infoClassName="text-theme-gray3"
           name="mode"
@@ -191,7 +191,7 @@ export default function ImageCompressionPanel({
           />
         </InputGroup>
         <InputGroup
-          containerClassName="w-full justify-start"
+          containerClassName="w-full justify-start flex-nowrap"
           labelClassName="w-20 text-theme-gray3"
           infoClassName="text-theme-gray3"
           name="flipY"
@@ -205,7 +205,7 @@ export default function ImageCompressionPanel({
           />
         </InputGroup>
         <InputGroup
-          containerClassName="w-full justify-start"
+          containerClassName="w-full justify-start flex-nowrap"
           labelClassName="w-20 text-theme-gray3"
           infoClassName="text-theme-gray3"
           name="linear"
@@ -219,7 +219,7 @@ export default function ImageCompressionPanel({
           />
         </InputGroup>
         <InputGroup
-          containerClassName="w-full justify-start"
+          containerClassName="w-full justify-start flex-nowrap"
           labelClassName="w-20 text-theme-gray3"
           infoClassName="text-theme-gray3"
           name="mipmaps"
@@ -233,7 +233,7 @@ export default function ImageCompressionPanel({
           />
         </InputGroup>
         <InputGroup
-          containerClassName="w-full justify-start"
+          containerClassName="w-full justify-start flex-nowrap"
           labelClassName="w-20 text-theme-gray3"
           infoClassName="text-theme-gray3"
           name="normalMap"
@@ -249,7 +249,7 @@ export default function ImageCompressionPanel({
         {compressProperties.mode.value === 'ETC1S' && (
           <>
             <InputGroup
-              containerClassName="w-full justify-start"
+              containerClassName="w-full justify-start flex-nowrap"
               labelClassName="w-20 text-theme-gray3"
               infoClassName="text-theme-gray3"
               name="quality"
@@ -268,7 +268,7 @@ export default function ImageCompressionPanel({
               />
             </InputGroup>
             <InputGroup
-              containerClassName="w-full justify-start"
+              containerClassName="w-full justify-start flex-nowrap"
               labelClassName="w-20 text-theme-gray3"
               infoClassName="text-theme-gray3"
               name="compressionLevel"
@@ -291,7 +291,7 @@ export default function ImageCompressionPanel({
         {compressProperties.mode.value === 'UASTC' && (
           <>
             <InputGroup
-              containerClassName="w-full justify-start"
+              containerClassName="w-full justify-start flex-nowrap"
               labelClassName="w-20 text-theme-gray3"
               infoClassName="text-theme-gray3"
               name="uastcFlags"
@@ -306,7 +306,7 @@ export default function ImageCompressionPanel({
               />
             </InputGroup>
             <InputGroup
-              containerClassName="w-full justify-start"
+              containerClassName="w-full justify-start flex-nowrap"
               labelClassName="w-20 text-theme-gray3"
               infoClassName="text-theme-gray3"
               name="uastcZstandard"

--- a/packages/editor/src/components/assets/ImageCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ImageCompressionPanel.tsx
@@ -161,7 +161,7 @@ export default function ImageCompressionPanel({
         />
       </div>
 
-      <div className="mx-auto grid w-1/2 gap-y-2">
+      <div className="mx-auto grid w-[80%] justify-center gap-y-2">
         <InputGroup
           containerClassName="w-full justify-start"
           labelClassName="w-24 text-theme-gray3"

--- a/packages/editor/src/components/assets/ImageCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ImageCompressionPanel.tsx
@@ -161,7 +161,7 @@ export default function ImageCompressionPanel({
         />
       </div>
 
-      <div className="mx-auto grid w-[80%] justify-center gap-y-2">
+      <div className="mx-auto grid w-4/5 justify-center gap-y-2">
         <InputGroup
           containerClassName="w-full justify-start"
           labelClassName="w-24 text-theme-gray3"

--- a/packages/ui/src/primitives/tailwind/ClickawayListener/index.tsx
+++ b/packages/ui/src/primitives/tailwind/ClickawayListener/index.tsx
@@ -40,7 +40,7 @@ const ClickawayListener = (props: { children: JSX.Element }) => {
       }}
     >
       <div
-        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform"
+        className="flex h-full w-full items-center justify-center"
         onMouseEnter={() => childOver.set(true)}
         onMouseLeave={() => childOver.set(false)}
       >


### PR DESCRIPTION
menu items were being squished horizontally and taking up two vertical lines, looked bad and didn't match figma, fixing

## Summary
image compression design changes (fix)
menu items were being squished horizontally and taking up two vertical lines, looked bad and didn't match figma, fixing

problem screenshot (from mt-dev/dev):
![current dev/mt-dev](https://github.com/user-attachments/assets/f7b788de-e677-401a-b14c-0115f7995130)


fixed screenshot:
![after my adjustments](https://github.com/user-attachments/assets/8acfb7db-0e4e-4bc1-abf7-f5f96cad504f)

and if you're crazy enough to use this in a thinner screen:
![400x924](https://github.com/user-attachments/assets/16a76e4f-b145-4bfd-95e2-f776df99daf6)

## References
[https://tsu.atlassian.net/browse/IR-2872](https://tsu.atlassian.net/browse/IR-2872)

[figma reference](https://www.figma.com/design/DXwFHGa5g0peqqSjyjpxQz/Studio-Design?node-id=6149-9649&t=D3reKkRs0GeFUqVl-0)

figma screenshot:
![figma screencap](https://github.com/user-attachments/assets/74e17b04-af32-402d-a286-3c1363072dc0)


## QA Steps
go to files tab and select an image, right click it and select "compress" to bring up menu