### PR TITLE
IR-3169:  Input field max length

### DIFF
--- a/packages/ui/src/primitives/tailwind/Input/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Input/index.tsx
@@ -43,6 +43,7 @@ export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
   variant?: 'outlined' | 'underlined' | 'onboarding'
   labelClassname?: string
   errorBorder?: boolean
+  maxLength?: number
 }
 
 const variants = {


### PR DESCRIPTION
## Summary

 Added prop to input field component to set max length 
 
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
