### PR TITLE
Fixed a bug in creating new guest users

### DIFF
--- a/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
@@ -170,7 +170,7 @@ async function validateAuthParams(context: HookContext<IdentityProviderService>)
         { accessToken: context.params.authentication.accessToken },
         {}
       )
-      if (userId !== authResult[appConfig.authentication.entity]?.userId)
+      if (userId !== '' && userId !== authResult[appConfig.authentication.entity]?.userId)
         throw new BadRequest('Cannot make identity-providers on other users')
     } else {
       if (userId && existingUser)


### PR DESCRIPTION
## Summary

If a now-invalid JWT was signing a request to make a new guest user with a userId of empty string, it was throwing an error when checking if that userID matched the userId of the JWT. This would cause the client to hang indefinitely until a refresh. Now specifically excluding userId of empty string from that check, as that will always create a new guest user, which is not a security hole.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
