### PR TITLE
Adjust tooltip positions to not block content

### DIFF
--- a/packages/client-core/src/hooks/useLoadedSceneEntity.ts
+++ b/packages/client-core/src/hooks/useLoadedSceneEntity.ts
@@ -1,3 +1,28 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
 import { staticResourcePath } from '@ir-engine/common/src/schema.type.module'
 import { GLTFAssetState } from '@ir-engine/engine/src/gltf/GLTFState'
 import { useMutableState } from '@ir-engine/hyperflux'

--- a/packages/ui/src/components/editor/panels/Viewport/tools/TransformPivotTool.tsx
+++ b/packages/ui/src/components/editor/panels/Viewport/tools/TransformPivotTool.tsx
@@ -79,6 +79,7 @@ const TransformPivotTool = () => {
         content={
           transformPivotOptions.find((pivot) => pivot.value === editorHelperState.transformPivot.value)?.description
         }
+        position="right center"
       >
         <Select
           key={editorHelperState.transformPivot.value}

--- a/packages/ui/src/components/editor/panels/Viewport/tools/TransformSnapTool.tsx
+++ b/packages/ui/src/components/editor/panels/Viewport/tools/TransformSnapTool.tsx
@@ -99,7 +99,7 @@ const TransformSnapTool = () => {
           className="px-0"
         />
       </Tooltip>
-      <Tooltip content={t('editor:toolbar.transformSnapTool.info-translate')}>
+      <Tooltip content={t('editor:toolbar.transformSnapTool.info-translate')} position="right center">
         <Select
           key={editorHelperState.translationSnap.value}
           inputClassName="py-1 h-6 rounded-sm text-theme-gray3 text-xs"
@@ -109,7 +109,7 @@ const TransformSnapTool = () => {
           currentValue={editorHelperState.translationSnap.value}
         />
       </Tooltip>
-      <Tooltip content={t('editor:toolbar.transformSnapTool.info-rotate')}>
+      <Tooltip content={t('editor:toolbar.transformSnapTool.info-rotate')} position="right center">
         <Select
           key={editorHelperState.rotationSnap.value}
           inputClassName="py-1 h-6 rounded-sm text-theme-gray3 text-xs pe-9"

--- a/packages/ui/src/components/editor/panels/Viewport/tools/TransformSpaceTool.tsx
+++ b/packages/ui/src/components/editor/panels/Viewport/tools/TransformSpaceTool.tsx
@@ -72,6 +72,7 @@ const TransformSpaceTool = () => {
             : t('editor:toolbar.transformSpace.info-world')
         }
         content={t('editor:toolbar.transformSpace.description')}
+        position="right center"
       >
         <Select
           key={transformSpace.value}


### PR DESCRIPTION
## Summary

Tooltips are not allowing user to select the input in some Select menus. This PR adjusts the position of tooltips, to not block those inputs.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-4292

## QA Steps
