### PR TITLE
avatar bone recursion

### DIFF
--- a/packages/engine/src/avatar/AvatarBoneMatching.ts
+++ b/packages/engine/src/avatar/AvatarBoneMatching.ts
@@ -639,7 +639,8 @@ export const recursiveHipsLookup = (model: Object3D) => {
   }
   if (model.children.length > 0) {
     for (const child of model.children) {
-      return recursiveHipsLookup(child)
+      const results = recursiveHipsLookup(child)
+      if (results) return results
     }
   }
 }


### PR DESCRIPTION
## Summary

There is a subtle issue with some vrms, sometimes, not finding matching bone parts. There does appear to be a defect in the recursive bone search for hips that it returns on the first item of a collection. It may be that the bone order is not deterministic and that in some cases it causes a bone to fail.

It is not reproducible for me on my machine, my change however seems to work (as in not break the local instance on my machine). But there is a chance that it breaks dev.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
