### PR TITLE
Improved login flow to prompt associations with existing accounts

### DIFF
--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -21,7 +21,7 @@
       "username": "UserName + Password",
       "social": "Social"
     },
-    "magiklink": {
+    "magiclink": {
       "header": "Login Link",
       "descriptionEmail": "Please enter your email address and we'll send you a login link via Email.",
       "descriptionSMS": "Please enter your phone number and we'll send you a login link via SMS.",
@@ -288,16 +288,24 @@
     "oauth": {
       "authenticating": "Authenticating..."
     },
-    "magikLink": {
+    "magicLink": {
       "wait": "Please wait a moment while processing..."
     }
   },
   "oauth": {
     "error": "Unfortunately, {{name}} authentication failed.",
-    "redirectToRoot": "Return to Home"
+    "redirectToRoot": "Return to Home",
+    "promptForConnection": "Connect to existing account?",
+    "askConnection": "{{email}} is already associated with an account. Would you like to link this {{service}} Single Sign-On to that account?",
+    "acceptConnection": "Yes",
+    "declineConnection": "No (create new account)"
   },
-  "magikLink": {
-    "wait": "Please wait a moment while processing..."
+  "magicLink": {
+    "wait": "Please wait a moment while processing...",
+    "promptForConnection": "Connect to existing account?",
+    "askConnection": "{{email}} is already associated with an account. Would you like to link this magiclink login to that account?",
+    "acceptConnection": "Yes",
+    "declineConnection": "No (create new account)"
   },
   "dashboard": {
     "header": "Dashboard",

--- a/packages/client-core/src/user/components/Auth/MagicLinkEmail.tsx
+++ b/packages/client-core/src/user/components/Auth/MagicLinkEmail.tsx
@@ -107,28 +107,28 @@ const MagicLinkEmail = ({ type, isAddConnection }: Props): JSX.Element => {
   useEffect(() => {
     // Pass in a type
     if (type === 'email') {
-      descr = t('user:auth.magiklink.descriptionEmail')
-      label = t('user:auth.magiklink.lbl-email')
+      descr = t('user:auth.magiclink.descriptionEmail')
+      label = t('user:auth.magiclink.lbl-email')
       return
     } else if (type === 'sms') {
-      descr = t('user:auth.magiklink.descriptionSMS')
-      label = t('user:auth.magiklink.lbl-phone')
+      descr = t('user:auth.magiclink.descriptionSMS')
+      label = t('user:auth.magiclink.lbl-phone')
       return
     } else if (!authSetting) {
-      descr = t('user:auth.magiklink.descriptionEmail')
-      label = t('user:auth.magiklink.lbl-email')
+      descr = t('user:auth.magiclink.descriptionEmail')
+      label = t('user:auth.magiclink.lbl-email')
       return
     }
     // Auth config is using Sms and Email, so handle both
     if (authState?.value?.emailMagicLink && authState?.value?.smsMagicLink && !type) {
-      descr = t('user:auth.magiklink.descriptionEmailSMS')
-      label = t('user:auth.magiklink.lbl-emailPhone')
+      descr = t('user:auth.magiclink.descriptionEmailSMS')
+      label = t('user:auth.magiclink.lbl-emailPhone')
     } else if (authState?.value?.smsMagicLink) {
-      descr = t('user:auth.magiklink.descriptionSMSUS')
-      label = t('user:auth.magiklink.lbl-phone')
+      descr = t('user:auth.magiclink.descriptionSMSUS')
+      label = t('user:auth.magiclink.lbl-phone')
     } else {
-      descr = t('user:auth.magiklink.descriptionEmail')
-      label = t('user:auth.magiklink.lbl-email')
+      descr = t('user:auth.magiclink.descriptionEmail')
+      label = t('user:auth.magiclink.lbl-email')
     }
 
     state.set({ ...state.value, label: label, descr: descr })
@@ -138,7 +138,7 @@ const MagicLinkEmail = ({ type, isAddConnection }: Props): JSX.Element => {
     <Container component="main" maxWidth="xs">
       <div>
         <Typography component="h1" variant="h5">
-          {t('user:auth.magiklink.header')}
+          {t('user:auth.magiclink.header')}
         </Typography>
 
         <Typography variant="body2" color="textSecondary" align="center">
@@ -173,8 +173,8 @@ const MagicLinkEmail = ({ type, isAddConnection }: Props): JSX.Element => {
                 }
                 label={
                   <div className={styles.termsLink}>
-                    {t('user:auth.magiklink.agree')}
-                    <Link to={termsOfService}>{t('user:auth.magiklink.terms')}</Link>
+                    {t('user:auth.magiclink.agree')}
+                    <Link to={termsOfService}>{t('user:auth.magiclink.terms')}</Link>
                   </div>
                 }
               />
@@ -188,7 +188,7 @@ const MagicLinkEmail = ({ type, isAddConnection }: Props): JSX.Element => {
                 className={styles.submit}
                 disabled={!state.isAgreedTermsOfService.value}
               >
-                {t('user:auth.magiklink.lbl-submit')}
+                {t('user:auth.magiclink.lbl-submit')}
               </Button>
             </Grid>
           </Grid>

--- a/packages/client-core/src/user/components/MagicLink/AuthMagicLink.tsx
+++ b/packages/client-core/src/user/components/MagicLink/AuthMagicLink.tsx
@@ -27,23 +27,28 @@ import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 
+import { config } from '@ir-engine/common/src/config'
 import { InstanceID } from '@ir-engine/common/src/schema.type.module'
-import Box from '@ir-engine/ui/src/primitives/mui/Box'
-import Container from '@ir-engine/ui/src/primitives/mui/Container'
-import Typography from '@ir-engine/ui/src/primitives/mui/Typography'
 
+import Button from '@ir-engine/ui/src/primitives/mui/Button'
+import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
+import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
+import { BsFillExclamationTriangleFill } from 'react-icons/bs'
 import { AuthService } from '../../services/AuthService'
 
-interface Props {
-  //auth: any
-  type: string
-  token: string
-  instanceId: InstanceID
-  path: string
-}
-
-const AuthMagicLink = ({ token, type, instanceId, path }: Props): JSX.Element => {
+const AuthMagicLink = (): JSX.Element => {
   const { t } = useTranslation()
+
+  const search = new URLSearchParams(useLocation().search)
+  const token = search.get('token') as string
+  const type = search.get('type') as string
+  const path = search.get('path') as string
+  const instanceId = search.get('instanceId') as InstanceID
+  const promptForConnection = search.get('promptForConnection') as string
+  const loginId = search.get('loginId') as string
+  const loginToken = search.get('loginToken') as string
+  const email = search.get('associateEmail') as string
+
   useEffect(() => {
     if (type === 'login') {
       let redirectSuccess = path ? `${path}` : null
@@ -55,25 +60,71 @@ const AuthMagicLink = ({ token, type, instanceId, path }: Props): JSX.Element =>
     }
   }, [])
 
+  function doRedirect(connect = false) {
+    let redirect = /https:\/\//.test(path) ? path : path ? config.client.clientUrl + path : config.client.clientUrl
+    if (instanceId != null) redirect += `?instanceId=${instanceId}`
+    window.location.href = `${
+      config.client.serverUrl
+    }/login/${loginId}?token=${loginToken}&redirectUrl=${redirect}&associate=${connect.toString()}`
+  }
+
   return (
-    <Container component="main" maxWidth="md">
-      <Box mt={3}>
-        <Typography variant="body2" color="textSecondary" align="center">
-          {t('user:magikLink.wait')}
-        </Typography>
-      </Box>
-    </Container>
+    <div className="pointer-events-auto flex h-full w-full items-center justify-center bg-[#080808] p-2">
+      {promptForConnection === 'true' ? (
+        <div className="grid w-full gap-y-3 rounded-xl bg-[#0E0F11] p-3 sm:w-2/3 md:w-1/2 lg:w-1/3 xl:w-1/4">
+          <div className="flex flex-col items-center py-6 text-white">
+            <div className="mb-8 h-14 w-14 rounded-full bg-[#191B1F]">
+              <BsFillExclamationTriangleFill className="mx-auto my-3 h-6 w-6 text-white" />
+            </div>
+
+            <Text fontWeight="medium" fontSize="xl">
+              {t('user:magicLink.promptForConnection')}
+            </Text>
+
+            <Text className="py-2 opacity-50" fontWeight="medium" fontSize="sm">
+              {t('user:magicLink.askConnection', { email: email })}
+            </Text>
+
+            <div className="flex">
+              <Button onClick={() => doRedirect(true)}>{t('user:magicLink.acceptConnection')}</Button>
+
+              <Button onClick={() => doRedirect(false)}>{t('user:magicLink.declineConnection')}</Button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <LoadingView
+          fullScreen
+          title={t('common:loader.authenticating')}
+          titleClassname="text-white"
+          className="block h-12 w-12"
+        />
+      )}
+    </div>
   )
+
+  // return promptForConnection === 'true' ? (
+  //   <Container style={{ "pointer-events": "auto" }}>
+  //     <div>{t('user:magicLink.promptForConnection')}</div>
+  //     <div >{t('user:magicLink.askConnection', { email: email })}</div>
+  //     <div className="flex">
+  //       <Button onClick={() => doRedirect(true)} style={{ color: 'primary' }} >
+  //         {t('user:magicLink.acceptConnection')}
+  //       </Button>
+  //       <Button onClick={() => doRedirect(false)}>
+  //         {t('user:magicLink.declineConnection')}
+  //       </Button>
+  //     </div>
+  //   </Container>
+  // ) : (
+  //   <Container component="main" maxWidth="md">
+  //     <Box mt={3}>
+  //       <Typography variant="body2" color="textSecondary" align="center">
+  //         {t('user:magicLink.wait')}
+  //       </Typography>
+  //     </Box>
+  //   </Container>
+  // )
 }
 
-const AuthMagicLinkWrapper = (props: any): JSX.Element => {
-  const search = new URLSearchParams(useLocation().search)
-  const token = search.get('token') as string
-  const type = search.get('type') as string
-  const path = search.get('path') as string
-  const instanceId = search.get('instanceId') as InstanceID
-
-  return <AuthMagicLink {...props} token={token} type={type} instanceId={instanceId} path={path} />
-}
-
-export default AuthMagicLinkWrapper
+export default AuthMagicLink

--- a/packages/client-core/src/user/components/Oauth/ErrorPage.tsx
+++ b/packages/client-core/src/user/components/Oauth/ErrorPage.tsx
@@ -43,7 +43,7 @@ interface ErrorPageProps {
 
 export default function ErrorPage({ name }: ErrorPageProps) {
   const { t } = useTranslation()
-  const initialState = { error: '', token: '', email: '', promptForConnection: 'false', loginToken: '' }
+  const initialState = { error: '', token: '', email: '', promptForConnection: 'false', loginToken: '', loginId: '' }
   const [state, setState] = useState(initialState)
   const search = new URLSearchParams(useLocation().search)
   const showError = useHookstate(false)
@@ -54,6 +54,7 @@ export default function ErrorPage({ name }: ErrorPageProps) {
     const type = search.get('type') as string
     const path = search.get('path') as string
     const promptForConnection = search.get('promptForConnection') as string
+    const loginId = search.get('loginId') as string
     const loginToken = search.get('loginToken') as string
     const email = search.get('associateEmail') as string
     const instanceId = search.get('instanceId') as InstanceID
@@ -69,7 +70,7 @@ export default function ErrorPage({ name }: ErrorPageProps) {
       }
     }
 
-    setState({ ...state, error, token, promptForConnection, email, loginToken })
+    setState({ ...state, error, token, promptForConnection, email, loginToken, loginId })
   }, [])
 
   function redirectToRoot() {
@@ -78,6 +79,7 @@ export default function ErrorPage({ name }: ErrorPageProps) {
 
   function doRedirect(connect = false) {
     const path = search.get('path') as string
+    const loginId = search.get('loginId') as string
     const loginToken = search.get('loginToken') as string
     const instanceId = search.get('instanceId') as InstanceID
     let redirect = config.client.clientUrl
@@ -85,7 +87,7 @@ export default function ErrorPage({ name }: ErrorPageProps) {
     if (instanceId != null) redirect += `?instanceId=${instanceId}`
     window.location.href = `${
       config.client.serverUrl
-    }/login/${loginToken}?redirectUrl=${redirect}&associate=${connect.toString()}`
+    }/login/${loginId}?token=${loginToken}&redirectUrl=${redirect}&associate=${connect.toString()}`
   }
 
   return (

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -671,7 +671,7 @@ export const AuthService = {
         sms: 'sms-sent-msg',
         default: 'success-msg'
       }
-      NotificationService.dispatchNotify(i18n.t(`user:auth.magiklink.${message[type ?? 'default']}`).toString(), {
+      NotificationService.dispatchNotify(i18n.t(`user:auth.magiclink.${message[type ?? 'default']}`).toString(), {
         variant: 'success'
       })
     } catch (err) {
@@ -726,7 +726,7 @@ export const AuthService = {
         userId
       })) as IdentityProviderType
       if (identityProvider.userId) {
-        NotificationService.dispatchNotify(i18n.t('user:auth.magiklink.email-sent-msg').toString(), {
+        NotificationService.dispatchNotify(i18n.t('user:auth.magiclink.email-sent-msg').toString(), {
           variant: 'success'
         })
         return AuthService.loadUserData(identityProvider.userId)
@@ -754,7 +754,7 @@ export const AuthService = {
         userId
       })) as IdentityProviderType
       if (identityProvider.userId) {
-        NotificationService.dispatchNotify(i18n.t('user:auth.magiklink.sms-sent-msg').toString(), { variant: 'error' })
+        NotificationService.dispatchNotify(i18n.t('user:auth.magiclink.sms-sent-msg').toString(), { variant: 'error' })
         return AuthService.loadUserData(identityProvider.userId)
       }
     } catch (err) {

--- a/packages/common/src/schemas/user/login-token.schema.ts
+++ b/packages/common/src/schemas/user/login-token.schema.ts
@@ -26,7 +26,8 @@ Infinite Reality Engine. All Rights Reserved.
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import type { Static } from '@feathersjs/typebox'
 import { getValidator, querySyntax, Type } from '@feathersjs/typebox'
-
+import { UserID } from '@ir-engine/common/src/schemas/user/user.schema'
+import { TypedString } from '../../types/TypeboxUtils'
 import { dataValidator, queryValidator } from '../validators'
 
 export const loginTokenPath = 'login-token'
@@ -45,7 +46,12 @@ export const loginTokenSchema = Type.Object(
     }),
     expiresAt: Type.String({ format: 'date-time' }),
     createdAt: Type.String({ format: 'date-time' }),
-    updatedAt: Type.String({ format: 'date-time' })
+    updatedAt: Type.String({ format: 'date-time' }),
+    associateUserId: Type.Optional(
+      TypedString<UserID>({
+        format: 'uuid'
+      })
+    )
   },
   { $id: 'LoginToken', additionalProperties: false }
 )
@@ -64,7 +70,12 @@ export const loginTokenPatchSchema = Type.Partial(loginTokenSchema, {
 export interface LoginTokenPatch extends Static<typeof loginTokenPatchSchema> {}
 
 // Schema for allowed query properties
-export const loginTokenQueryProperties = Type.Pick(loginTokenSchema, ['id', 'token', 'identityProviderId'])
+export const loginTokenQueryProperties = Type.Pick(loginTokenSchema, [
+  'id',
+  'token',
+  'identityProviderId',
+  'associateUserId'
+])
 export const loginTokenQuerySchema = Type.Intersect(
   [
     querySyntax(loginTokenQueryProperties),

--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
@@ -39,7 +39,7 @@ import config from '../../appconfig'
 export const DISCORD_SCOPES = ['email', 'identify']
 export const GITHUB_SCOPES = ['repo', 'user', 'workflow']
 export const GOOGLE_SCOPES = ['profile', 'email']
-export const LINKEDIN_SCOPES = ['profile', 'email']
+export const LINKEDIN_SCOPES = ['openid', 'profile', 'email']
 export const APPLE_SCOPES = ['openid', 'email', 'name']
 
 export async function seed(knex: Knex): Promise<void> {

--- a/packages/server-core/src/user/login-token/migrations/20230828202954_associate-user-column.ts
+++ b/packages/server-core/src/user/login-token/migrations/20230828202954_associate-user-column.ts
@@ -1,0 +1,61 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import type { Knex } from 'knex'
+
+import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  const associateUserColumnExists = await knex.schema.hasColumn(loginTokenPath, 'associateUserId')
+  if (!associateUserColumnExists) {
+    await knex.schema.alterTable(loginTokenPath, async (table) => {
+      //@ts-ignore
+      table.uuid('associateUserId').collate('utf8mb4_bin').nullable().index()
+      table.foreign('associateUserId').references('id').inTable('user').onDelete('CASCADE').onUpdate('CASCADE')
+    })
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('SET FOREIGN_KEY_CHECKS=0')
+
+  const associateUserColumnExists = await knex.schema.hasColumn(loginTokenPath, 'associateUserId')
+
+  if (associateUserColumnExists) {
+    await knex.schema.alterTable(loginTokenPath, async (table) => {
+      table.dropColumn('associateUserId')
+    })
+  }
+
+  await knex.raw('SET FOREIGN_KEY_CHECKS=1')
+}

--- a/packages/server-core/src/user/login/login.ts
+++ b/packages/server-core/src/user/login/login.ts
@@ -56,9 +56,9 @@ async function redirect(ctx, next) {
     if (data.error) return ctx.redirect(`${redirectPath || originPath}/?error=${data.error as string}`)
     if (data.promptForConnection) {
       return ctx.redirect(
-        `${originPath}/auth/magiclink?loginId=${data.loginId}&loginToken=${data.loginToken as string}&promptForConnection=true&associateEmail=${
-          data.associateEmail
-        }${redirectQuery}`
+        `${originPath}/auth/magiclink?loginId=${data.loginId}&loginToken=${
+          data.loginToken as string
+        }&promptForConnection=true&associateEmail=${data.associateEmail}${redirectQuery}`
       )
     } else return ctx.redirect(`${originPath}/auth/magiclink?type=login&token=${data.token as string}${redirectQuery}`)
   } catch (err) {

--- a/packages/server-core/src/user/login/login.ts
+++ b/packages/server-core/src/user/login/login.ts
@@ -53,10 +53,14 @@ async function redirect(ctx, next) {
       originPath = new URL(ctx.query.redirectUrl).origin
     }
 
-    if (data.error) {
-      return ctx.redirect(`${redirectPath || originPath}/?error=${data.error as string}`)
-    }
-    return ctx.redirect(`${originPath}/auth/magiclink?type=login&token=${data.token as string}${redirectQuery}`)
+    if (data.error) return ctx.redirect(`${redirectPath || originPath}/?error=${data.error as string}`)
+    if (data.promptForConnection) {
+      return ctx.redirect(
+        `${originPath}/auth/magiclink?loginId=${data.loginId}&loginToken=${data.loginToken as string}&promptForConnection=true&associateEmail=${
+          data.associateEmail
+        }${redirectQuery}`
+      )
+    } else return ctx.redirect(`${originPath}/auth/magiclink?type=login&token=${data.token as string}${redirectQuery}`)
   } catch (err) {
     logger.error(err)
     throw err

--- a/packages/server-core/src/user/magic-link/magic-link.class.ts
+++ b/packages/server-core/src/user/magic-link/magic-link.class.ts
@@ -58,11 +58,15 @@ export class MagicLinkService implements ServiceInterface<MagicLinkParams> {
    * A function used to sent an email
    *
    * @param toEmail email of reciever
-   * @param token generated token
+   * @param id generated login id
+   * @param token generated login token
+   * @param redirectUrl URL to redirect to after login
    * @returns {function} sent email
    */
-  async sendEmail(toEmail: string, token: string, redirectUrl?: string): Promise<void> {
-    const hashLink = `${config.server.url}/login/${token}${redirectUrl ? `?redirectUrl=${redirectUrl}` : ''}`
+  async sendEmail(toEmail: string, id: string, token: string, redirectUrl?: string): Promise<void> {
+    const hashLink = `${config.server.url}/login/${id}?token=${token}${
+      redirectUrl ? `&redirectUrl=${redirectUrl}` : ''
+    }`
 
     const templatePath = path.join(emailAccountTemplatesPath, 'magiclink-email.pug')
 
@@ -89,12 +93,16 @@ export class MagicLinkService implements ServiceInterface<MagicLinkParams> {
    * A function which used to send sms
    *
    * @param mobile of receiver user
-   * @param token generated token
+   * @param id generated login id
+   * @param token generated login token
+   * @param redirectUrl URL to redirect to after login
    * @returns {function}  send sms
    */
 
-  async sendSms(mobile: string, token: string, redirectUrl?: string): Promise<void> {
-    const hashLink = `${config.server.url}/login/${token}${redirectUrl ? `?redirectUrl=${redirectUrl}` : ''}`
+  async sendSms(mobile: string, id: string, token: string, redirectUrl?: string): Promise<void> {
+    const hashLink = `${config.server.url}/login/${id}?token=${token}${
+      redirectUrl ? `&redirectUrl=${redirectUrl}` : ''
+    }`
     const templatePath = path.join(emailAccountTemplatesPath, 'magiclink-sms.pug')
     const compiledHTML = pug
       .compileFile(templatePath)({
@@ -175,9 +183,9 @@ export class MagicLinkService implements ServiceInterface<MagicLinkParams> {
       })
 
       if (data.type === 'email') {
-        await this.sendEmail(data.email, loginToken.token, data.redirectUrl)
+        await this.sendEmail(data.email, loginToken.id, loginToken.token, data.redirectUrl)
       } else if (data.type === 'sms') {
-        await this.sendSms(data.mobile, loginToken.token, data.redirectUrl)
+        await this.sendSms(data.mobile, loginToken.id, loginToken.token, data.redirectUrl)
       }
     }
     return data

--- a/packages/server-core/src/user/strategies/apple.ts
+++ b/packages/server-core/src/user/strategies/apple.ts
@@ -27,8 +27,11 @@ import { AuthenticationRequest, AuthenticationResult } from '@feathersjs/authent
 import { Paginated, Params } from '@feathersjs/feathers'
 
 import { identityProviderPath } from '@ir-engine/common/src/schemas/user/identity-provider.schema'
+import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
 import { userApiKeyPath, UserApiKeyType } from '@ir-engine/common/src/schemas/user/user-api-key.schema'
 import { InviteCode, UserName, userPath } from '@ir-engine/common/src/schemas/user/user.schema'
+import { toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import moment from 'moment/moment'
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import { RedirectConfig } from '../../types/OauthStrategies'
@@ -55,13 +58,14 @@ export class AppleStrategy extends CustomOAuthStrategy {
     const identityProvider = authResult[identityProviderPath] ? authResult[identityProviderPath] : authResult
     const userId = identityProvider ? identityProvider.userId : params?.query ? params.query.userId : undefined
 
-    return {
+    const returned = {
       ...baseData,
       accountIdentifier: profile.email ? profile.email : profile.sub,
       type: 'apple',
-      userId,
-      email: profile.email
+      userId
     }
+    if (profile.email) returned.email = profile.email
+    return returned
   }
 
   async updateEntity(entity: any, profile: any, params: Params): Promise<any> {
@@ -111,7 +115,38 @@ export class AppleStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest') await this.app.service(identityProviderPath).remove(entity.id)
+      if (entity.type === 'guest' && profile.email) {
+        const profileEmail = profile.email
+        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+          query: {
+            $or: [
+              {
+                email: profileEmail
+              },
+              {
+                token: profileEmail
+              }
+            ],
+            id: {
+              $ne: newIP.id
+            }
+          }
+        })
+        if (existingIdentityProviders.total > 0) {
+          const loginToken = await this.app.service(loginTokenPath).create({
+            identityProviderId: newIP.id,
+            associateUserId: existingIdentityProviders.data[0].userId,
+            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+          })
+          return {
+            ...entity,
+            associateEmail: profileEmail,
+            loginToken: loginToken.token,
+            promptForConnection: true
+          }
+        }
+      }
+      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
@@ -136,15 +171,28 @@ export class AppleStrategy extends CustomOAuthStrategy {
       return this.handleErrorRedirect(data, params, redirectConfig, redirectDomain)
     }
 
-    const loginType = params.query?.userId ? 'connection' : 'login'
-    let redirectUrl = `${redirectDomain}?token=${(data as AuthenticationResult).accessToken}&type=${loginType}`
-    if (redirectPath) {
-      redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+    if (data[identityProviderPath]?.promptForConnection) {
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
+
+      return redirectUrl
+    } else {
+      const loginType = params.query?.userId ? 'connection' : 'login'
+      let redirectUrl = `${redirectDomain}?token=${(data as AuthenticationResult).accessToken}&type=${loginType}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
+
+      return redirectUrl
     }
-    if (redirectInstanceId) {
-      redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
-    }
-    return redirectUrl
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
@@ -158,7 +206,26 @@ export class AppleStrategy extends CustomOAuthStrategy {
         )
     }
     await this.validateSignInUser(authentication, originalParams, 'apple')
-    return super.authenticate(authentication, originalParams)
+    const entity: string = this.configuration.entity
+    const { provider, ...params } = originalParams
+    const profile = await super.getProfile(authentication, params)
+    const existingEntity = (await super.findEntity(profile, params)) || (await super.getCurrentEntity(params))
+
+    const authEntity = !existingEntity
+      ? await this.createEntity(profile, params)
+      : await this.updateEntity(existingEntity, profile, params)
+
+    const fetchedEntity = await super.getEntity(authEntity, originalParams)
+    if (authEntity.promptForConnection) {
+      fetchedEntity.promptForConnection = authEntity.promptForConnection
+      fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginToken = authEntity.loginToken
+    }
+
+    return {
+      authentication: { strategy: this.name! },
+      [entity]: fetchedEntity
+    }
   }
 }
 export default AppleStrategy

--- a/packages/server-core/src/user/strategies/apple.ts
+++ b/packages/server-core/src/user/strategies/apple.ts
@@ -115,38 +115,40 @@ export class AppleStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest' && profile.email) {
-        const profileEmail = profile.email
-        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
-          query: {
-            $or: [
-              {
-                email: profileEmail
-              },
-              {
-                token: profileEmail
+      if (entity.type === 'guest') {
+        if (profile.email) {
+          const profileEmail = profile.email
+          const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+            query: {
+              $or: [
+                {
+                  email: profileEmail
+                },
+                {
+                  token: profileEmail
+                }
+              ],
+              id: {
+                $ne: newIP.id
               }
-            ],
-            id: {
-              $ne: newIP.id
+            }
+          })
+          if (existingIdentityProviders.total > 0) {
+            const loginToken = await this.app.service(loginTokenPath).create({
+              identityProviderId: newIP.id,
+              associateUserId: existingIdentityProviders.data[0].userId,
+              expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+            })
+            return {
+              ...entity,
+              associateEmail: profileEmail,
+              loginToken: loginToken.token,
+              promptForConnection: true
             }
           }
-        })
-        if (existingIdentityProviders.total > 0) {
-          const loginToken = await this.app.service(loginTokenPath).create({
-            identityProviderId: newIP.id,
-            associateUserId: existingIdentityProviders.data[0].userId,
-            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
-          })
-          return {
-            ...entity,
-            associateEmail: profileEmail,
-            loginToken: loginToken.token,
-            promptForConnection: true
-          }
         }
+        await this.app.service(identityProviderPath).remove(entity.id)
       }
-      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {

--- a/packages/server-core/src/user/strategies/apple.ts
+++ b/packages/server-core/src/user/strategies/apple.ts
@@ -73,22 +73,24 @@ export class AppleStrategy extends CustomOAuthStrategy {
       { accessToken: params?.authentication?.accessToken },
       {}
     )
-    if (!entity.userId) {
-      const code = (await getFreeInviteCode(this.app)) as InviteCode
-      const newUser = await this.app.service(userPath).create({
-        name: '' as UserName,
-        isGuest: false,
-        inviteCode: code
-      })
-      entity.userId = newUser.id
-      await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id,
-        email: entity.email
-      })
-    } else
-      await this.app.service(identityProviderPath)._patch(entity.id, {
-        email: entity.email
-      })
+    if (entity.type === 'apple') {
+      if (!entity.userId) {
+        const code = (await getFreeInviteCode(this.app)) as InviteCode
+        const newUser = await this.app.service(userPath).create({
+          name: '' as UserName,
+          isGuest: false,
+          inviteCode: code
+        })
+        entity.userId = newUser.id
+        await this.app.service(identityProviderPath).patch(entity.id, {
+          userId: newUser.id,
+          email: entity.email
+        })
+      } else
+        await this.app.service(identityProviderPath)._patch(entity.id, {
+          email: entity.email
+        })
+    }
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -142,6 +144,7 @@ export class AppleStrategy extends CustomOAuthStrategy {
             return {
               ...entity,
               associateEmail: profileEmail,
+              loginId: loginToken.id,
               loginToken: loginToken.token,
               promptForConnection: true
             }
@@ -174,7 +177,7 @@ export class AppleStrategy extends CustomOAuthStrategy {
     }
 
     if (data[identityProviderPath]?.promptForConnection) {
-      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}&loginId=${data[identityProviderPath].loginId}`
       if (redirectPath) {
         redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
       }
@@ -221,6 +224,7 @@ export class AppleStrategy extends CustomOAuthStrategy {
     if (authEntity.promptForConnection) {
       fetchedEntity.promptForConnection = authEntity.promptForConnection
       fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginId = authEntity.loginId
       fetchedEntity.loginToken = authEntity.loginToken
     }
 

--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -115,38 +115,40 @@ export class DiscordStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest' && profile.email) {
-        const profileEmail = profile.email
-        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
-          query: {
-            $or: [
-              {
-                email: profileEmail
-              },
-              {
-                token: profileEmail
+      if (entity.type === 'guest') {
+        if (profile.email) {
+          const profileEmail = profile.email
+          const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+            query: {
+              $or: [
+                {
+                  email: profileEmail
+                },
+                {
+                  token: profileEmail
+                }
+              ],
+              id: {
+                $ne: newIP.id
               }
-            ],
-            id: {
-              $ne: newIP.id
+            }
+          })
+          if (existingIdentityProviders.total > 0) {
+            const loginToken = await this.app.service(loginTokenPath).create({
+              identityProviderId: newIP.id,
+              associateUserId: existingIdentityProviders.data[0].userId,
+              expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+            })
+            return {
+              ...entity,
+              associateEmail: profileEmail,
+              loginToken: loginToken.token,
+              promptForConnection: true
             }
           }
-        })
-        if (existingIdentityProviders.total > 0) {
-          const loginToken = await this.app.service(loginTokenPath).create({
-            identityProviderId: newIP.id,
-            associateUserId: existingIdentityProviders.data[0].userId,
-            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
-          })
-          return {
-            ...entity,
-            associateEmail: profileEmail,
-            loginToken: loginToken.token,
-            promptForConnection: true
-          }
         }
+        await this.app.service(identityProviderPath).remove(entity.id)
       }
-      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {

--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -73,22 +73,24 @@ export class DiscordStrategy extends CustomOAuthStrategy {
       { accessToken: params?.authentication?.accessToken },
       {}
     )
-    if (!entity.userId) {
-      const code = (await getFreeInviteCode(this.app)) as InviteCode
-      const newUser = await this.app.service(userPath).create({
-        name: '' as UserName,
-        isGuest: false,
-        inviteCode: code
-      })
-      entity.userId = newUser.id
-      await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id,
-        email: entity.email
-      })
-    } else
-      await this.app.service(identityProviderPath)._patch(entity.id, {
-        email: entity.email
-      })
+    if (entity.type === 'discord') {
+      if (!entity.userId) {
+        const code = (await getFreeInviteCode(this.app)) as InviteCode
+        const newUser = await this.app.service(userPath).create({
+          name: '' as UserName,
+          isGuest: false,
+          inviteCode: code
+        })
+        entity.userId = newUser.id
+        await this.app.service(identityProviderPath).patch(entity.id, {
+          userId: newUser.id,
+          email: entity.email
+        })
+      } else
+        await this.app.service(identityProviderPath)._patch(entity.id, {
+          email: entity.email
+        })
+    }
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -142,6 +144,7 @@ export class DiscordStrategy extends CustomOAuthStrategy {
             return {
               ...entity,
               associateEmail: profileEmail,
+              loginId: loginToken.id,
               loginToken: loginToken.token,
               promptForConnection: true
             }
@@ -175,7 +178,7 @@ export class DiscordStrategy extends CustomOAuthStrategy {
     }
 
     if (data[identityProviderPath]?.promptForConnection) {
-      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}&loginId=${data[identityProviderPath].loginId}`
       if (redirectPath) {
         redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
       }
@@ -220,6 +223,7 @@ export class DiscordStrategy extends CustomOAuthStrategy {
     if (authEntity.promptForConnection) {
       fetchedEntity.promptForConnection = authEntity.promptForConnection
       fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginId = authEntity.loginId
       fetchedEntity.loginToken = authEntity.loginToken
     }
 

--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -30,6 +30,9 @@ import { identityProviderPath } from '@ir-engine/common/src/schemas/user/identit
 import { userApiKeyPath, UserApiKeyType } from '@ir-engine/common/src/schemas/user/user-api-key.schema'
 import { InviteCode, UserName, userPath } from '@ir-engine/common/src/schemas/user/user.schema'
 
+import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
+import { toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import moment from 'moment/moment'
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import { RedirectConfig } from '../../types/OauthStrategies'
@@ -54,12 +57,15 @@ export class DiscordStrategy extends CustomOAuthStrategy {
     const identityProvider = authResult[identityProviderPath] ? authResult[identityProviderPath] : authResult
     const userId = identityProvider ? identityProvider.userId : params?.query ? params.query.userId : undefined
 
-    return {
+    console.log('discord profile', profile)
+    const returned = {
       ...baseData,
       accountIdentifier: `${profile.username}#${profile.discriminator}`,
       type: 'discord',
       userId
     }
+    if (profile.email) returned.email = profile.email
+    return returned
   }
 
   async updateEntity(entity: any, profile: any, params: Params): Promise<any> {
@@ -76,9 +82,13 @@ export class DiscordStrategy extends CustomOAuthStrategy {
       })
       entity.userId = newUser.id
       await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id
+        userId: newUser.id,
+        email: entity.email
       })
-    }
+    } else
+      await this.app.service(identityProviderPath)._patch(entity.id, {
+        email: entity.email
+      })
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -99,15 +109,45 @@ export class DiscordStrategy extends CustomOAuthStrategy {
       await this.app.service(identityProviderPath).remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
       await this.userLoginEntry(entity, params)
-
       return super.updateEntity(entity, profile, params)
     }
     const existingEntity = await super.findEntity(profile, params)
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest') await this.app.service(identityProviderPath).remove(entity.id)
-      await this.userLoginEntry(entity, params)
+      if (entity.type === 'guest' && profile.email) {
+        const profileEmail = profile.email
+        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+          query: {
+            $or: [
+              {
+                email: profileEmail
+              },
+              {
+                token: profileEmail
+              }
+            ],
+            id: {
+              $ne: newIP.id
+            }
+          }
+        })
+        if (existingIdentityProviders.total > 0) {
+          const loginToken = await this.app.service(loginTokenPath).create({
+            identityProviderId: newIP.id,
+            associateUserId: existingIdentityProviders.data[0].userId,
+            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+          })
+          return {
+            ...entity,
+            associateEmail: profileEmail,
+            loginToken: loginToken.token,
+            promptForConnection: true
+          }
+        }
+      }
+      await this.app.service(identityProviderPath).remove(entity.id)
+      await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
       await this.userLoginEntry(existingEntity, params)
@@ -132,16 +172,28 @@ export class DiscordStrategy extends CustomOAuthStrategy {
       return redirectDomain + `?error=${err}`
     }
 
-    const loginType = params.query?.userId ? 'connection' : 'login'
-    let redirectUrl = `${redirectDomain}?token=${data.accessToken}&type=${loginType}`
-    if (redirectPath) {
-      redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
-    }
-    if (redirectInstanceId) {
-      redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
-    }
+    if (data[identityProviderPath]?.promptForConnection) {
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
 
-    return redirectUrl
+      return redirectUrl
+    } else {
+      const loginType = params.query?.userId ? 'connection' : 'login'
+      let redirectUrl = `${redirectDomain}?token=${data.accessToken}&type=${loginType}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
+
+      return redirectUrl
+    }
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
@@ -153,7 +205,26 @@ export class DiscordStrategy extends CustomOAuthStrategy {
             authentication.error
         )
     }
-    return super.authenticate(authentication, originalParams)
+    const entity: string = this.configuration.entity
+    const { provider, ...params } = originalParams
+    const profile = await super.getProfile(authentication, params)
+    const existingEntity = (await super.findEntity(profile, params)) || (await super.getCurrentEntity(params))
+
+    const authEntity = !existingEntity
+      ? await this.createEntity(profile, params)
+      : await this.updateEntity(existingEntity, profile, params)
+
+    const fetchedEntity = await super.getEntity(authEntity, originalParams)
+    if (authEntity.promptForConnection) {
+      fetchedEntity.promptForConnection = authEntity.promptForConnection
+      fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginToken = authEntity.loginToken
+    }
+
+    return {
+      authentication: { strategy: this.name! },
+      [entity]: fetchedEntity
+    }
   }
 }
 export default DiscordStrategy

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -115,38 +115,40 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest' && profile.email) {
-        const profileEmail = profile.email
-        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
-          query: {
-            $or: [
-              {
-                email: profileEmail
-              },
-              {
-                token: profileEmail
+      if (entity.type === 'guest') {
+        if (profile.email) {
+          const profileEmail = profile.email
+          const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+            query: {
+              $or: [
+                {
+                  email: profileEmail
+                },
+                {
+                  token: profileEmail
+                }
+              ],
+              id: {
+                $ne: newIP.id
               }
-            ],
-            id: {
-              $ne: newIP.id
+            }
+          })
+          if (existingIdentityProviders.total > 0) {
+            const loginToken = await this.app.service(loginTokenPath).create({
+              identityProviderId: newIP.id,
+              associateUserId: existingIdentityProviders.data[0].userId,
+              expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+            })
+            return {
+              ...entity,
+              associateEmail: profileEmail,
+              loginToken: loginToken.token,
+              promptForConnection: true
             }
           }
-        })
-        if (existingIdentityProviders.total > 0) {
-          const loginToken = await this.app.service(loginTokenPath).create({
-            identityProviderId: newIP.id,
-            associateUserId: existingIdentityProviders.data[0].userId,
-            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
-          })
-          return {
-            ...entity,
-            associateEmail: profileEmail,
-            loginToken: loginToken.token,
-            promptForConnection: true
-          }
         }
+        await this.app.service(identityProviderPath).remove(entity.id)
       }
-      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -30,6 +30,9 @@ import { identityProviderPath } from '@ir-engine/common/src/schemas/user/identit
 import { userApiKeyPath, UserApiKeyType } from '@ir-engine/common/src/schemas/user/user-api-key.schema'
 import { InviteCode, UserName, userPath } from '@ir-engine/common/src/schemas/user/user.schema'
 
+import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
+import { toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import moment from 'moment/moment'
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import { RedirectConfig } from '../../types/OauthStrategies'
@@ -54,12 +57,15 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     const identityProvider = authResult[identityProviderPath] ? authResult[identityProviderPath] : authResult
     const userId = identityProvider ? identityProvider.userId : params?.query ? params.query.userId : undefined
 
-    return {
+    console.log('Facebook profile', profile)
+    const returned = {
       ...baseData,
       accountIdentifier: profile.name,
       type: 'facebook',
       userId
     }
+    if (profile.email) returned.email = profile.email
+    return returned
   }
 
   async updateEntity(entity: any, profile: any, params: Params): Promise<any> {
@@ -76,9 +82,13 @@ export class FacebookStrategy extends CustomOAuthStrategy {
       })
       entity.userId = newUser.id
       await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id
+        userId: newUser.id,
+        email: entity.email
       })
-    }
+    } else
+      await this.app.service(identityProviderPath)._patch(entity.id, {
+        email: entity.email
+      })
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -105,7 +115,38 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest') await this.app.service(identityProviderPath).remove(entity.id)
+      if (entity.type === 'guest' && profile.email) {
+        const profileEmail = profile.email
+        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+          query: {
+            $or: [
+              {
+                email: profileEmail
+              },
+              {
+                token: profileEmail
+              }
+            ],
+            id: {
+              $ne: newIP.id
+            }
+          }
+        })
+        if (existingIdentityProviders.total > 0) {
+          const loginToken = await this.app.service(loginTokenPath).create({
+            identityProviderId: newIP.id,
+            associateUserId: existingIdentityProviders.data[0].userId,
+            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+          })
+          return {
+            ...entity,
+            associateEmail: profileEmail,
+            loginToken: loginToken.token,
+            promptForConnection: true
+          }
+        }
+      }
+      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
@@ -131,16 +172,28 @@ export class FacebookStrategy extends CustomOAuthStrategy {
       return redirectDomain + `?error=${err}`
     }
 
-    const loginType = params.query?.userId ? 'connection' : 'login'
-    let redirectUrl = `${redirectDomain}?token=${data.accessToken}&type=${loginType}`
-    if (redirectPath) {
-      redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
-    }
-    if (redirectInstanceId) {
-      redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
-    }
+    if (data[identityProviderPath]?.promptForConnection) {
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
 
-    return redirectUrl
+      return redirectUrl
+    } else {
+      const loginType = params.query?.userId ? 'connection' : 'login'
+      let redirectUrl = `${redirectDomain}?token=${data.accessToken}&type=${loginType}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
+
+      return redirectUrl
+    }
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
@@ -152,7 +205,26 @@ export class FacebookStrategy extends CustomOAuthStrategy {
           'There was a problem with the Facebook OAuth login flow: ' + authentication.error?.error?.message
         )
     }
-    return super.authenticate(authentication, originalParams)
+    const entity: string = this.configuration.entity
+    const { provider, ...params } = originalParams
+    const profile = await super.getProfile(authentication, params)
+    const existingEntity = (await super.findEntity(profile, params)) || (await super.getCurrentEntity(params))
+
+    const authEntity = !existingEntity
+      ? await this.createEntity(profile, params)
+      : await this.updateEntity(existingEntity, profile, params)
+
+    const fetchedEntity = await super.getEntity(authEntity, originalParams)
+    if (authEntity.promptForConnection) {
+      fetchedEntity.promptForConnection = authEntity.promptForConnection
+      fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginToken = authEntity.loginToken
+    }
+
+    return {
+      authentication: { strategy: this.name! },
+      [entity]: fetchedEntity
+    }
   }
 }
 export default FacebookStrategy

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -73,22 +73,24 @@ export class FacebookStrategy extends CustomOAuthStrategy {
       { accessToken: params?.authentication?.accessToken },
       {}
     )
-    if (!entity.userId) {
-      const code = (await getFreeInviteCode(this.app)) as InviteCode
-      const newUser = await this.app.service(userPath).create({
-        name: '' as UserName,
-        isGuest: false,
-        inviteCode: code
-      })
-      entity.userId = newUser.id
-      await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id,
-        email: entity.email
-      })
-    } else
-      await this.app.service(identityProviderPath)._patch(entity.id, {
-        email: entity.email
-      })
+    if (entity.type === 'facebook') {
+      if (!entity.userId) {
+        const code = (await getFreeInviteCode(this.app)) as InviteCode
+        const newUser = await this.app.service(userPath).create({
+          name: '' as UserName,
+          isGuest: false,
+          inviteCode: code
+        })
+        entity.userId = newUser.id
+        await this.app.service(identityProviderPath).patch(entity.id, {
+          userId: newUser.id,
+          email: entity.email
+        })
+      } else
+        await this.app.service(identityProviderPath)._patch(entity.id, {
+          email: entity.email
+        })
+    }
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -142,6 +144,7 @@ export class FacebookStrategy extends CustomOAuthStrategy {
             return {
               ...entity,
               associateEmail: profileEmail,
+              loginId: loginToken.id,
               loginToken: loginToken.token,
               promptForConnection: true
             }
@@ -175,7 +178,7 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     }
 
     if (data[identityProviderPath]?.promptForConnection) {
-      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}&loginId=${data[identityProviderPath].loginId}`
       if (redirectPath) {
         redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
       }
@@ -220,6 +223,7 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     if (authEntity.promptForConnection) {
       fetchedEntity.promptForConnection = authEntity.promptForConnection
       fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginId = authEntity.loginId
       fetchedEntity.loginToken = authEntity.loginToken
     }
 

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -33,6 +33,9 @@ import { userApiKeyPath, UserApiKeyType } from '@ir-engine/common/src/schemas/us
 import { InviteCode, UserName, userPath } from '@ir-engine/common/src/schemas/user/user.schema'
 import { getDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
 
+import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
+import { toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import moment from 'moment/moment'
 import { Octokit } from 'octokit'
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
@@ -157,10 +160,41 @@ export class GithubStrategy extends CustomOAuthStrategy {
       profile.oauthToken = params.access_token
       profile.oauthRefreshToken = params.refresh_token
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest') await this.app.service(identityProviderPath)._remove(entity.id)
+      if (entity.type === 'guest') {
+        const profileEmail = profile.email
+        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+          query: {
+            $or: [
+              {
+                email: profileEmail
+              },
+              {
+                token: profileEmail
+              }
+            ],
+            id: {
+              $ne: newIP.id
+            }
+          }
+        })
+        if (existingIdentityProviders.total > 0) {
+          const loginToken = await this.app.service(loginTokenPath).create({
+            identityProviderId: newIP.id,
+            associateUserId: existingIdentityProviders.data[0].userId,
+            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+          })
+          return {
+            ...entity,
+            associateEmail: profileEmail,
+            loginToken: loginToken.token,
+            promptForConnection: true
+          }
+        }
+      }
       if (!config.kubernetes.enabled)
         await this.app.service(githubRepoAccessRefreshPath).find(Object.assign({}, params, { user }))
       else await this.createRefreshJob(user.id)
+      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
@@ -182,23 +216,34 @@ export class GithubStrategy extends CustomOAuthStrategy {
       redirectConfig = {}
     }
     let { domain: redirectDomain, path: redirectPath, instanceId: redirectInstanceId } = redirectConfig
-
     redirectDomain = redirectDomain ? `${redirectDomain}/auth/oauth/github` : config.authentication.callback.github
 
     if (data instanceof Error || Object.getPrototypeOf(data) === Error.prototype) {
       return this.handleErrorRedirect(data, params, redirectConfig, redirectDomain)
     }
 
-    const loginType = params.query?.userId ? 'connection' : 'login'
-    let redirectUrl = `${redirectDomain}?token=${(data as AuthenticationResult).accessToken}&type=${loginType}`
-    if (redirectPath) {
-      redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
-    }
-    if (redirectInstanceId) {
-      redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
-    }
+    if (data[identityProviderPath]?.promptForConnection) {
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
 
-    return redirectUrl
+      return redirectUrl
+    } else {
+      const loginType = params.query?.userId ? 'connection' : 'login'
+      let redirectUrl = `${redirectDomain}?token=${(data as AuthenticationResult).accessToken}&type=${loginType}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
+
+      return redirectUrl
+    }
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: CustomOAuthParams) {
@@ -210,7 +255,26 @@ export class GithubStrategy extends CustomOAuthStrategy {
     await this.validateSignInUser(authentication, originalParams, 'github')
     originalParams.access_token = authentication.access_token
     originalParams.refresh_token = authentication.refresh_token
-    return super.authenticate(authentication, originalParams)
+    const entity: string = this.configuration.entity
+    const { provider, ...params } = originalParams
+    const profile = await super.getProfile(authentication, params)
+    const existingEntity = (await super.findEntity(profile, params)) || (await super.getCurrentEntity(params))
+
+    const authEntity = !existingEntity
+      ? await this.createEntity(profile, params)
+      : await this.updateEntity(existingEntity, profile, params)
+
+    const fetchedEntity = await super.getEntity(authEntity, originalParams)
+    if (authEntity.promptForConnection) {
+      fetchedEntity.promptForConnection = authEntity.promptForConnection
+      fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginToken = authEntity.loginToken
+    }
+
+    return {
+      authentication: { strategy: this.name! },
+      [entity]: fetchedEntity
+    }
   }
 }
 export default GithubStrategy

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -108,6 +108,7 @@ export class GithubStrategy extends CustomOAuthStrategy {
       { accessToken: params?.authentication?.accessToken },
       {}
     )
+    console.log('updating github entity', entity)
     if (!entity.userId) {
       const code = (await getFreeInviteCode(this.app)) as InviteCode
       const newUser = await this.app.service(userPath).create({
@@ -129,6 +130,7 @@ export class GithubStrategy extends CustomOAuthStrategy {
         email: entity.email
       })
     const identityProvider = authResult[identityProviderPath]
+    console.log('identityProvider to potentially remove', identityProvider)
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
     if (user.isGuest)
@@ -145,6 +147,7 @@ export class GithubStrategy extends CustomOAuthStrategy {
         userId: entity.userId
       })
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
+      console.log('removing guest identity-provider', identityProvider)
       await this.app.service(identityProviderPath)._remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
       if (!config.kubernetes.enabled)
@@ -190,11 +193,12 @@ export class GithubStrategy extends CustomOAuthStrategy {
             promptForConnection: true
           }
         }
+        console.log('removing entity', entity)
+        await this.app.service(identityProviderPath).remove(entity.id)
       }
       if (!config.kubernetes.enabled)
         await this.app.service(githubRepoAccessRefreshPath).find(Object.assign({}, params, { user }))
       else await this.createRefreshJob(user.id)
-      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -108,29 +108,29 @@ export class GithubStrategy extends CustomOAuthStrategy {
       { accessToken: params?.authentication?.accessToken },
       {}
     )
-    console.log('updating github entity', entity)
-    if (!entity.userId) {
-      const code = (await getFreeInviteCode(this.app)) as InviteCode
-      const newUser = await this.app.service(userPath).create({
-        name: '' as UserName,
-        isGuest: false,
-        inviteCode: code
-      })
-      entity.userId = newUser.id
-      await this.app.service(identityProviderPath)._patch(entity.id, {
-        userId: newUser.id,
-        oauthToken: params.access_token,
-        oauthRefreshToken: params.refresh_token,
-        email: entity.email
-      })
-    } else
-      await this.app.service(identityProviderPath)._patch(entity.id, {
-        oauthToken: params.access_token,
-        oauthRefreshToken: params.refresh_token,
-        email: entity.email
-      })
+    if (entity.type === 'github') {
+      if (!entity.userId) {
+        const code = (await getFreeInviteCode(this.app)) as InviteCode
+        const newUser = await this.app.service(userPath).create({
+          name: '' as UserName,
+          isGuest: false,
+          inviteCode: code
+        })
+        entity.userId = newUser.id
+        await this.app.service(identityProviderPath)._patch(entity.id, {
+          userId: newUser.id,
+          oauthToken: params.access_token,
+          oauthRefreshToken: params.refresh_token,
+          email: entity.email
+        })
+      } else
+        await this.app.service(identityProviderPath)._patch(entity.id, {
+          oauthToken: params.access_token,
+          oauthRefreshToken: params.refresh_token,
+          email: entity.email
+        })
+    }
     const identityProvider = authResult[identityProviderPath]
-    console.log('identityProvider to potentially remove', identityProvider)
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
     if (user.isGuest)
@@ -147,7 +147,6 @@ export class GithubStrategy extends CustomOAuthStrategy {
         userId: entity.userId
       })
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
-      console.log('removing guest identity-provider', identityProvider)
       await this.app.service(identityProviderPath)._remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
       if (!config.kubernetes.enabled)
@@ -189,11 +188,11 @@ export class GithubStrategy extends CustomOAuthStrategy {
           return {
             ...entity,
             associateEmail: profileEmail,
+            loginId: loginToken.id,
             loginToken: loginToken.token,
             promptForConnection: true
           }
         }
-        console.log('removing entity', entity)
         await this.app.service(identityProviderPath).remove(entity.id)
       }
       if (!config.kubernetes.enabled)
@@ -227,7 +226,7 @@ export class GithubStrategy extends CustomOAuthStrategy {
     }
 
     if (data[identityProviderPath]?.promptForConnection) {
-      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}&loginId=${data[identityProviderPath].loginId}`
       if (redirectPath) {
         redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
       }
@@ -272,6 +271,7 @@ export class GithubStrategy extends CustomOAuthStrategy {
     if (authEntity.promptForConnection) {
       fetchedEntity.promptForConnection = authEntity.promptForConnection
       fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginId = authEntity.loginId
       fetchedEntity.loginToken = authEntity.loginToken
     }
 

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -72,22 +72,25 @@ export class Googlestrategy extends CustomOAuthStrategy {
       { accessToken: params?.authentication?.accessToken },
       {}
     )
-    if (!entity.userId) {
-      const code = (await getFreeInviteCode(this.app)) as InviteCode
-      const newUser = await this.app.service(userPath).create({
-        name: '' as UserName,
-        isGuest: false,
-        inviteCode: code
-      })
-      entity.userId = newUser.id
-      await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id,
-        email: entity.email
-      })
-    } else
-      await this.app.service(identityProviderPath)._patch(entity.id, {
-        email: entity.email
-      })
+
+    if (entity.type === 'google') {
+      if (!entity.userId) {
+        const code = (await getFreeInviteCode(this.app)) as InviteCode
+        const newUser = await this.app.service(userPath).create({
+          name: '' as UserName,
+          isGuest: false,
+          inviteCode: code
+        })
+        entity.userId = newUser.id
+        await this.app.service(identityProviderPath).patch(entity.id, {
+          userId: newUser.id,
+          email: entity.email
+        })
+      } else
+        await this.app.service(identityProviderPath)._patch(entity.id, {
+          email: entity.email
+        })
+    }
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -141,6 +144,7 @@ export class Googlestrategy extends CustomOAuthStrategy {
             return {
               ...entity,
               associateEmail: profileEmail,
+              loginId: loginToken.id,
               loginToken: loginToken.token,
               promptForConnection: true
             }
@@ -173,7 +177,7 @@ export class Googlestrategy extends CustomOAuthStrategy {
     }
 
     if (data[identityProviderPath]?.promptForConnection) {
-      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}&loginId=${data[identityProviderPath].loginId}`
       if (redirectPath) {
         redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
       }
@@ -216,6 +220,7 @@ export class Googlestrategy extends CustomOAuthStrategy {
     if (authEntity.promptForConnection) {
       fetchedEntity.promptForConnection = authEntity.promptForConnection
       fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginId = authEntity.loginId
       fetchedEntity.loginToken = authEntity.loginToken
     }
 

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -30,6 +30,9 @@ import { identityProviderPath } from '@ir-engine/common/src/schemas/user/identit
 import { userApiKeyPath, UserApiKeyType } from '@ir-engine/common/src/schemas/user/user-api-key.schema'
 import { InviteCode, UserName, userPath } from '@ir-engine/common/src/schemas/user/user.schema'
 
+import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
+import { toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import moment from 'moment/moment'
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import { RedirectConfig } from '../../types/OauthStrategies'
@@ -45,7 +48,6 @@ export class Googlestrategy extends CustomOAuthStrategy {
 
   async getEntityData(profile: any, entity: any, params: Params): Promise<any> {
     const baseData = await super.getEntityData(profile, null, {})
-
     const authResult = entity
       ? entity
       : await (this.app.service('authentication') as any).strategies.jwt.authenticate(
@@ -54,13 +56,15 @@ export class Googlestrategy extends CustomOAuthStrategy {
         )
     const identityProvider = authResult[identityProviderPath] ? authResult[identityProviderPath] : authResult
     const userId = identityProvider ? identityProvider.userId : params?.query ? params.query.userId : undefined
-    return {
+
+    const returned = {
       ...baseData,
       accountIdentifier: profile.email,
       type: 'google',
-      email: profile.email,
       userId
     }
+    if (profile.email) returned.email = profile.email
+    return returned
   }
 
   async updateEntity(entity: any, profile: any, params: Params): Promise<any> {
@@ -110,7 +114,38 @@ export class Googlestrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest') await this.app.service(identityProviderPath).remove(entity.id)
+      if (entity.type === 'guest' && profile.email) {
+        const profileEmail = profile.email
+        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+          query: {
+            $or: [
+              {
+                email: profileEmail
+              },
+              {
+                token: profileEmail
+              }
+            ],
+            id: {
+              $ne: newIP.id
+            }
+          }
+        })
+        if (existingIdentityProviders.total > 0) {
+          const loginToken = await this.app.service(loginTokenPath).create({
+            identityProviderId: newIP.id,
+            associateUserId: existingIdentityProviders.data[0].userId,
+            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+          })
+          return {
+            ...entity,
+            associateEmail: profileEmail,
+            loginToken: loginToken.token,
+            promptForConnection: true
+          }
+        }
+      }
+      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
@@ -135,16 +170,28 @@ export class Googlestrategy extends CustomOAuthStrategy {
       return this.handleErrorRedirect(data, params, redirectConfig, redirectDomain)
     }
 
-    const loginType = params.query?.userId ? 'connection' : 'login'
-    let redirectUrl = `${redirectDomain}?token=${(data as AuthenticationResult).accessToken}&type=${loginType}`
-    if (redirectPath) {
-      redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
-    }
-    if (redirectInstanceId) {
-      redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
-    }
+    if (data[identityProviderPath]?.promptForConnection) {
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
 
-    return redirectUrl
+      return redirectUrl
+    } else {
+      const loginType = params.query?.userId ? 'connection' : 'login'
+      let redirectUrl = `${redirectDomain}?token=${(data as AuthenticationResult).accessToken}&type=${loginType}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
+
+      return redirectUrl
+    }
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
@@ -154,7 +201,26 @@ export class Googlestrategy extends CustomOAuthStrategy {
           authentication.error
       )
     await this.validateSignInUser(authentication, originalParams, 'google')
-    return super.authenticate(authentication, originalParams)
+    const entity: string = this.configuration.entity
+    const { provider, ...params } = originalParams
+    const profile = await super.getProfile(authentication, params)
+    const existingEntity = (await super.findEntity(profile, params)) || (await super.getCurrentEntity(params))
+
+    const authEntity = !existingEntity
+      ? await this.createEntity(profile, params)
+      : await this.updateEntity(existingEntity, profile, params)
+
+    const fetchedEntity = await super.getEntity(authEntity, originalParams)
+    if (authEntity.promptForConnection) {
+      fetchedEntity.promptForConnection = authEntity.promptForConnection
+      fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginToken = authEntity.loginToken
+    }
+
+    return {
+      authentication: { strategy: this.name! },
+      [entity]: fetchedEntity
+    }
   }
 }
 export default Googlestrategy

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -114,38 +114,40 @@ export class Googlestrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest' && profile.email) {
-        const profileEmail = profile.email
-        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
-          query: {
-            $or: [
-              {
-                email: profileEmail
-              },
-              {
-                token: profileEmail
+      if (entity.type === 'guest') {
+        if (profile.email) {
+          const profileEmail = profile.email
+          const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+            query: {
+              $or: [
+                {
+                  email: profileEmail
+                },
+                {
+                  token: profileEmail
+                }
+              ],
+              id: {
+                $ne: newIP.id
               }
-            ],
-            id: {
-              $ne: newIP.id
+            }
+          })
+          if (existingIdentityProviders.total > 0) {
+            const loginToken = await this.app.service(loginTokenPath).create({
+              identityProviderId: newIP.id,
+              associateUserId: existingIdentityProviders.data[0].userId,
+              expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+            })
+            return {
+              ...entity,
+              associateEmail: profileEmail,
+              loginToken: loginToken.token,
+              promptForConnection: true
             }
           }
-        })
-        if (existingIdentityProviders.total > 0) {
-          const loginToken = await this.app.service(loginTokenPath).create({
-            identityProviderId: newIP.id,
-            associateUserId: existingIdentityProviders.data[0].userId,
-            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
-          })
-          return {
-            ...entity,
-            associateEmail: profileEmail,
-            loginToken: loginToken.token,
-            promptForConnection: true
-          }
         }
+        await this.app.service(identityProviderPath).remove(entity.id)
       }
-      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -30,6 +30,9 @@ import { identityProviderPath } from '@ir-engine/common/src/schemas/user/identit
 import { userApiKeyPath, UserApiKeyType } from '@ir-engine/common/src/schemas/user/user-api-key.schema'
 import { InviteCode, UserName, userPath } from '@ir-engine/common/src/schemas/user/user.schema'
 
+import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
+import { toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import moment from 'moment/moment'
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import { RedirectConfig } from '../../types/OauthStrategies'
@@ -54,12 +57,14 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
     const identityProvider = authResult[identityProviderPath] ? authResult[identityProviderPath] : authResult
     const userId = identityProvider ? identityProvider.userId : params?.query ? params.query.userId : undefined
 
-    return {
+    const returned = {
       ...baseData,
       accountIdentifier: `${profile.localizedFirstName} ${profile.localizedLastName}`,
       type: 'linkedin',
       userId
     }
+    if (profile.email) returned.email = profile.email
+    return returned
   }
 
   async updateEntity(entity: any, profile: any, params: Params): Promise<any> {
@@ -76,9 +81,13 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
       })
       entity.userId = newUser.id
       await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id
+        userId: newUser.id,
+        email: entity.email
       })
-    }
+    } else
+      await this.app.service(identityProviderPath)._patch(entity.id, {
+        email: entity.email
+      })
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -105,7 +114,38 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest') await this.app.service(identityProviderPath).remove(entity.id)
+      if (entity.type === 'guest' && profile.email) {
+        const profileEmail = profile.email
+        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+          query: {
+            $or: [
+              {
+                email: profileEmail
+              },
+              {
+                token: profileEmail
+              }
+            ],
+            id: {
+              $ne: newIP.id
+            }
+          }
+        })
+        if (existingIdentityProviders.total > 0) {
+          const loginToken = await this.app.service(loginTokenPath).create({
+            identityProviderId: newIP.id,
+            associateUserId: existingIdentityProviders.data[0].userId,
+            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+          })
+          return {
+            ...entity,
+            associateEmail: profileEmail,
+            loginToken: loginToken.token,
+            promptForConnection: true
+          }
+        }
+      }
+      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
@@ -131,16 +171,28 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
       return redirectDomain + `?error=${err}`
     }
 
-    const loginType = params.query?.userId ? 'connection' : 'login'
-    let redirectUrl = `${redirectDomain}?token=${data.accessToken}&type=${loginType}`
-    if (redirectPath) {
-      redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
-    }
-    if (redirectInstanceId) {
-      redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
-    }
+    if (data[identityProviderPath]?.promptForConnection) {
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
 
-    return redirectUrl
+      return redirectUrl
+    } else {
+      const loginType = params.query?.userId ? 'connection' : 'login'
+      let redirectUrl = `${redirectDomain}?token=${data.accessToken}&type=${loginType}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
+
+      return redirectUrl
+    }
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
@@ -153,7 +205,26 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
             authentication.error
         )
     }
-    return super.authenticate(authentication, originalParams)
+    const entity: string = this.configuration.entity
+    const { provider, ...params } = originalParams
+    const profile = await super.getProfile(authentication, params)
+    const existingEntity = (await super.findEntity(profile, params)) || (await super.getCurrentEntity(params))
+
+    const authEntity = !existingEntity
+      ? await this.createEntity(profile, params)
+      : await this.updateEntity(existingEntity, profile, params)
+
+    const fetchedEntity = await super.getEntity(authEntity, originalParams)
+    if (authEntity.promptForConnection) {
+      fetchedEntity.promptForConnection = authEntity.promptForConnection
+      fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginToken = authEntity.loginToken
+    }
+
+    return {
+      authentication: { strategy: this.name! },
+      [entity]: fetchedEntity
+    }
   }
 }
 export default LinkedInStrategy

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -114,38 +114,40 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest' && profile.email) {
-        const profileEmail = profile.email
-        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
-          query: {
-            $or: [
-              {
-                email: profileEmail
-              },
-              {
-                token: profileEmail
+      if (entity.type === 'guest') {
+        if (profile.email) {
+          const profileEmail = profile.email
+          const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+            query: {
+              $or: [
+                {
+                  email: profileEmail
+                },
+                {
+                  token: profileEmail
+                }
+              ],
+              id: {
+                $ne: newIP.id
               }
-            ],
-            id: {
-              $ne: newIP.id
+            }
+          })
+          if (existingIdentityProviders.total > 0) {
+            const loginToken = await this.app.service(loginTokenPath).create({
+              identityProviderId: newIP.id,
+              associateUserId: existingIdentityProviders.data[0].userId,
+              expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+            })
+            return {
+              ...entity,
+              associateEmail: profileEmail,
+              loginToken: loginToken.token,
+              promptForConnection: true
             }
           }
-        })
-        if (existingIdentityProviders.total > 0) {
-          const loginToken = await this.app.service(loginTokenPath).create({
-            identityProviderId: newIP.id,
-            associateUserId: existingIdentityProviders.data[0].userId,
-            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
-          })
-          return {
-            ...entity,
-            associateEmail: profileEmail,
-            loginToken: loginToken.token,
-            promptForConnection: true
-          }
         }
+        await this.app.service(identityProviderPath).remove(entity.id)
       }
-      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -72,22 +72,24 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
       { accessToken: params?.authentication?.accessToken },
       {}
     )
-    if (!entity.userId) {
-      const code = (await getFreeInviteCode(this.app)) as InviteCode
-      const newUser = await this.app.service(userPath).create({
-        name: '' as UserName,
-        isGuest: false,
-        inviteCode: code
-      })
-      entity.userId = newUser.id
-      await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id,
-        email: entity.email
-      })
-    } else
-      await this.app.service(identityProviderPath)._patch(entity.id, {
-        email: entity.email
-      })
+    if (entity.type === 'linkedin') {
+      if (!entity.userId) {
+        const code = (await getFreeInviteCode(this.app)) as InviteCode
+        const newUser = await this.app.service(userPath).create({
+          name: '' as UserName,
+          isGuest: false,
+          inviteCode: code
+        })
+        entity.userId = newUser.id
+        await this.app.service(identityProviderPath).patch(entity.id, {
+          userId: newUser.id,
+          email: entity.email
+        })
+      } else
+        await this.app.service(identityProviderPath)._patch(entity.id, {
+          email: entity.email
+        })
+    }
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -141,6 +143,7 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
             return {
               ...entity,
               associateEmail: profileEmail,
+              loginId: loginToken.id,
               loginToken: loginToken.token,
               promptForConnection: true
             }
@@ -174,7 +177,7 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
     }
 
     if (data[identityProviderPath]?.promptForConnection) {
-      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}&loginId=${data[identityProviderPath].loginId}`
       if (redirectPath) {
         redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
       }
@@ -220,6 +223,7 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
     if (authEntity.promptForConnection) {
       fetchedEntity.promptForConnection = authEntity.promptForConnection
       fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginId = authEntity.loginId
       fetchedEntity.loginToken = authEntity.loginToken
     }
 

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -115,38 +115,40 @@ export class TwitterStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest' && profile.email != null) {
-        const profileEmail = profile.email
-        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
-          query: {
-            $or: [
-              {
-                email: profileEmail
-              },
-              {
-                token: profileEmail
+      if (entity.type === 'guest') {
+        if (profile.email) {
+          const profileEmail = profile.email
+          const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+            query: {
+              $or: [
+                {
+                  email: profileEmail
+                },
+                {
+                  token: profileEmail
+                }
+              ],
+              id: {
+                $ne: newIP.id
               }
-            ],
-            id: {
-              $ne: newIP.id
+            }
+          })
+          if (existingIdentityProviders.total > 0) {
+            const loginToken = await this.app.service(loginTokenPath).create({
+              identityProviderId: newIP.id,
+              associateUserId: existingIdentityProviders.data[0].userId,
+              expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+            })
+            return {
+              ...entity,
+              associateEmail: profileEmail,
+              loginToken: loginToken.token,
+              promptForConnection: true
             }
           }
-        })
-        if (existingIdentityProviders.total > 0) {
-          const loginToken = await this.app.service(loginTokenPath).create({
-            identityProviderId: newIP.id,
-            associateUserId: existingIdentityProviders.data[0].userId,
-            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
-          })
-          return {
-            ...entity,
-            associateEmail: profileEmail,
-            loginToken: loginToken.token,
-            promptForConnection: true
-          }
         }
+        await this.app.service(identityProviderPath).remove(entity.id)
       }
-      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -73,22 +73,24 @@ export class TwitterStrategy extends CustomOAuthStrategy {
       { accessToken: params?.authentication?.accessToken },
       {}
     )
-    if (!entity.userId) {
-      const code = (await getFreeInviteCode(this.app)) as InviteCode
-      const newUser = await this.app.service(userPath).create({
-        name: '' as UserName,
-        isGuest: false,
-        inviteCode: code
-      })
-      entity.userId = newUser.id
-      await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id,
-        email: entity.email
-      })
-    } else
-      await this.app.service(identityProviderPath)._patch(entity.id, {
-        email: entity.email
-      })
+    if (entity.type === 'twitter') {
+      if (!entity.userId) {
+        const code = (await getFreeInviteCode(this.app)) as InviteCode
+        const newUser = await this.app.service(userPath).create({
+          name: '' as UserName,
+          isGuest: false,
+          inviteCode: code
+        })
+        entity.userId = newUser.id
+        await this.app.service(identityProviderPath).patch(entity.id, {
+          userId: newUser.id,
+          email: entity.email
+        })
+      } else
+        await this.app.service(identityProviderPath)._patch(entity.id, {
+          email: entity.email
+        })
+    }
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -142,6 +144,7 @@ export class TwitterStrategy extends CustomOAuthStrategy {
             return {
               ...entity,
               associateEmail: profileEmail,
+              loginId: loginToken.id,
               loginToken: loginToken.token,
               promptForConnection: true
             }
@@ -175,7 +178,7 @@ export class TwitterStrategy extends CustomOAuthStrategy {
     }
 
     if (data[identityProviderPath]?.promptForConnection) {
-      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}&loginId=${data[identityProviderPath].loginId}`
       if (redirectPath) {
         redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
       }
@@ -221,6 +224,7 @@ export class TwitterStrategy extends CustomOAuthStrategy {
     if (authEntity.promptForConnection) {
       fetchedEntity.promptForConnection = authEntity.promptForConnection
       fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginId = authEntity.loginId
       fetchedEntity.loginToken = authEntity.loginToken
     }
 

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -30,6 +30,9 @@ import { identityProviderPath } from '@ir-engine/common/src/schemas/user/identit
 import { userApiKeyPath, UserApiKeyType } from '@ir-engine/common/src/schemas/user/user-api-key.schema'
 import { InviteCode, UserName, userPath } from '@ir-engine/common/src/schemas/user/user.schema'
 
+import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
+import { toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import moment from 'moment/moment'
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import { RedirectConfig } from '../../types/OauthStrategies'
@@ -54,12 +57,15 @@ export class TwitterStrategy extends CustomOAuthStrategy {
     const identityProvider = authResult[identityProviderPath] ? authResult[identityProviderPath] : authResult
     const userId = identityProvider ? identityProvider.userId : params?.query ? params.query.userId : undefined
 
-    return {
+    console.log('profile', profile)
+    const returned = {
       ...baseData,
       accountIdentifier: profile.screen_name,
       type: 'twitter',
       userId
     }
+    if (profile.email) returned.email = profile.email
+    return returned
   }
 
   async updateEntity(entity: any, profile: any, params: Params): Promise<any> {
@@ -76,9 +82,13 @@ export class TwitterStrategy extends CustomOAuthStrategy {
       })
       entity.userId = newUser.id
       await this.app.service(identityProviderPath).patch(entity.id, {
-        userId: newUser.id
+        userId: newUser.id,
+        email: entity.email
       })
-    }
+    } else
+      await this.app.service(identityProviderPath)._patch(entity.id, {
+        email: entity.email
+      })
     const identityProvider = authResult[identityProviderPath]
     const user = await this.app.service(userPath).get(entity.userId)
     await makeInitialAdmin(this.app, user.id)
@@ -105,7 +115,38 @@ export class TwitterStrategy extends CustomOAuthStrategy {
     if (!existingEntity) {
       profile.userId = user.id
       const newIP = await super.createEntity(profile, params)
-      if (entity.type === 'guest') await this.app.service(identityProviderPath).remove(entity.id)
+      if (entity.type === 'guest' && profile.email != null) {
+        const profileEmail = profile.email
+        const existingIdentityProviders = await this.app.service(identityProviderPath).find({
+          query: {
+            $or: [
+              {
+                email: profileEmail
+              },
+              {
+                token: profileEmail
+              }
+            ],
+            id: {
+              $ne: newIP.id
+            }
+          }
+        })
+        if (existingIdentityProviders.total > 0) {
+          const loginToken = await this.app.service(loginTokenPath).create({
+            identityProviderId: newIP.id,
+            associateUserId: existingIdentityProviders.data[0].userId,
+            expiresAt: toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
+          })
+          return {
+            ...entity,
+            associateEmail: profileEmail,
+            loginToken: loginToken.token,
+            promptForConnection: true
+          }
+        }
+      }
+      await this.app.service(identityProviderPath).remove(entity.id)
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
@@ -131,16 +172,28 @@ export class TwitterStrategy extends CustomOAuthStrategy {
       return redirectDomain + `?error=${err}`
     }
 
-    const loginType = params.query?.userId ? 'connection' : 'login'
-    let redirectUrl = `${redirectDomain}?token=${data.accessToken}&type=${loginType}`
-    if (redirectPath) {
-      redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
-    }
-    if (redirectInstanceId) {
-      redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
-    }
+    if (data[identityProviderPath]?.promptForConnection) {
+      let redirectUrl = `${redirectDomain}?promptForConnection=true&associateEmail=${data[identityProviderPath].associateEmail}&loginToken=${data[identityProviderPath].loginToken}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
 
-    return redirectUrl
+      return redirectUrl
+    } else {
+      const loginType = params.query?.userId ? 'connection' : 'login'
+      let redirectUrl = `${redirectDomain}?token=${data.accessToken}&type=${loginType}`
+      if (redirectPath) {
+        redirectUrl = redirectUrl.concat(`&path=${redirectPath}`)
+      }
+      if (redirectInstanceId) {
+        redirectUrl = redirectUrl.concat(`&instanceId=${redirectInstanceId}`)
+      }
+
+      return redirectUrl
+    }
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
@@ -153,7 +206,26 @@ export class TwitterStrategy extends CustomOAuthStrategy {
           'There was a problem with the Twitter OAuth login flow: ' + error?.errors[0].message || error?.errors[0]
         )
     }
-    return super.authenticate(authentication, originalParams)
+    const entity: string = this.configuration.entity
+    const { provider, ...params } = originalParams
+    const profile = await super.getProfile(authentication, params)
+    const existingEntity = (await super.findEntity(profile, params)) || (await super.getCurrentEntity(params))
+
+    const authEntity = !existingEntity
+      ? await this.createEntity(profile, params)
+      : await this.updateEntity(existingEntity, profile, params)
+
+    const fetchedEntity = await super.getEntity(authEntity, originalParams)
+    if (authEntity.promptForConnection) {
+      fetchedEntity.promptForConnection = authEntity.promptForConnection
+      fetchedEntity.associateEmail = authEntity.associateEmail
+      fetchedEntity.loginToken = authEntity.loginToken
+    }
+
+    return {
+      authentication: { strategy: this.name! },
+      [entity]: fetchedEntity
+    }
   }
 }
 export default TwitterStrategy


### PR DESCRIPTION
## Summary

If a new account's identity provider is associated with an email address that is associated with other identity providers, the user is now prompted to associate their new login with the existing identity-provider. This only happens the first time; if they decline, then any subsequent logins will skip that step, and are kept as a separate account.

Fixed a bug with getting backend errors out of query params. The code was reading SearchParamState.error, which is a separate property that usually returns undefined. Now getting the .value of the state before reading the keyID.

Changed magiclink login flow to use ID as the /login identifier and token is now passed as a query param, instead of the token being the identifier. This should make it nearly impossible to brute-force guess a magiclink.

Resolves IR-3991

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
