### PR TITLE
IR-3622 fog fixes

### DIFF
--- a/packages/editor/src/services/ComponentShelfCategoriesState.ts
+++ b/packages/editor/src/services/ComponentShelfCategoriesState.ts
@@ -67,6 +67,7 @@ import { InputComponent } from '@ir-engine/spatial/src/input/components/InputCom
 import { ColliderComponent } from '@ir-engine/spatial/src/physics/components/ColliderComponent'
 import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 import { TriggerComponent } from '@ir-engine/spatial/src/physics/components/TriggerComponent'
+import { FogSettingsComponent } from '@ir-engine/spatial/src/renderer/components/FogSettingsComponent'
 import { PostProcessingComponent } from '@ir-engine/spatial/src/renderer/components/PostProcessingComponent'
 import { LookAtComponent } from '@ir-engine/spatial/src/transform/components/LookAtComponent'
 import { useEffect } from 'react'
@@ -110,7 +111,14 @@ export const ComponentShelfCategoriesState = defineState({
         // MediaSettingsComponent
         CameraSettingsComponent
       ],
-      Visual: [EnvMapBakeComponent, ScenePreviewCameraComponent, SkyboxComponent, TextComponent, LookAtComponent]
+      Visual: [
+        EnvMapBakeComponent,
+        ScenePreviewCameraComponent,
+        SkyboxComponent,
+        TextComponent,
+        LookAtComponent,
+        FogSettingsComponent
+      ]
     } as Record<string, Component[]>
   },
   reactor: () => {

--- a/packages/spatial/src/renderer/WebGLRendererSystem.test.tsx
+++ b/packages/spatial/src/renderer/WebGLRendererSystem.test.tsx
@@ -77,6 +77,7 @@ describe('WebGl Renderer System', () => {
     setComponent(rootEntity, UUIDComponent, MathUtils.generateUUID() as EntityUUID)
     setComponent(rootEntity, EntityTreeComponent)
     setComponent(rootEntity, CameraComponent)
+    setComponent(rootEntity, VisibleComponent)
     mockEngineRenderer(rootEntity)
     setComponent(rootEntity, BackgroundComponent, new Color(0xffffff))
 

--- a/packages/spatial/src/renderer/components/FogSettingsComponent.test.tsx
+++ b/packages/spatial/src/renderer/components/FogSettingsComponent.test.tsx
@@ -53,6 +53,7 @@ import { RendererComponent } from '../WebGLRendererSystem'
 import { FogSettingsComponent, FogType } from './FogSettingsComponent'
 import { FogShaders } from './FogShaders'
 import { FogComponent } from './SceneComponents'
+import { VisibleComponent } from './VisibleComponent'
 
 const FogSettingsComponentDefaults = {
   type: FogType.Disabled as FogType,
@@ -238,6 +239,7 @@ describe('FogSettingsComponent', () => {
       createEngine()
       initializeSpatialEngine()
       testEntity = createEntity()
+      setComponent(testEntity, VisibleComponent)
     })
 
     afterEach(() => {
@@ -370,6 +372,7 @@ describe('FogSettingsComponent', () => {
 
       entity = createEntity()
       setComponent(entity, UUIDComponent, MathUtils.generateUUID() as EntityUUID)
+      setComponent(entity, VisibleComponent)
       setComponent(entity, FogSettingsComponent)
       setComponent(entity, EntityTreeComponent)
 

--- a/packages/spatial/src/renderer/components/FogSettingsComponent.ts
+++ b/packages/spatial/src/renderer/components/FogSettingsComponent.ts
@@ -37,7 +37,6 @@ import {
 import { useEntityContext } from '@ir-engine/ecs/src/EntityFunctions'
 import { FogComponent } from '@ir-engine/spatial/src/renderer/components/SceneComponents'
 
-import { useHookstate } from '@ir-engine/hyperflux'
 import { FogShaders } from '../FogSystem'
 import { initBrownianMotionFogShader, initHeightFogShader, removeFogShader } from './FogShaders'
 import { VisibleComponent } from './VisibleComponent'
@@ -94,18 +93,12 @@ export const FogSettingsComponent = defineComponent({
     const entity = useEntityContext()
     const fog = useComponent(entity, FogSettingsComponent)
     const isVisible = useOptionalComponent(entity, VisibleComponent)
-    const retriggerFogType = useHookstate(0)
 
     useEffect(() => {
-      if (isVisible) {
-        retriggerFogType.set((old) => old++)
-      } else {
-        removeFogShader()
-        removeComponent(entity, FogComponent)
+      if (!isVisible) {
+        return
       }
-    }, [isVisible])
 
-    useEffect(() => {
       const fogData = fog.value
       switch (fogData.type) {
         case FogType.Linear:
@@ -137,7 +130,7 @@ export const FogSettingsComponent = defineComponent({
         removeFogShader()
         removeComponent(entity, FogComponent)
       }
-    }, [fog.type, retriggerFogType])
+    }, [fog.type, isVisible])
 
     useEffect(() => {
       getOptionalComponent(entity, FogComponent)?.color.set(fog.color.value)


### PR DESCRIPTION
## Summary
Fixing fog issues with toggling visibility (would cause webgl errors and make most scene objects invisible)
and adding FogSettingsComponent to the component shelf
## Subtasks Checklist

## References
[https://tsu.atlassian.net/browse/IR-3622](https://tsu.atlassian.net/browse/IR-3622)

## QA Steps
1. add a fog component to an entity using add component menu, or add a fog prefab through the add prefab menu
2. change fog type to Brownian Motion
3. set fog height and intensity to 1, and set color to something noticeable (this step is simply for visibility)
4. in the hierarchy view, click the eye icon on the right of the fog entity to toggle its visibility
5. observe that nothing in the scene disappears besides the fog effect
6. re-enable its visibility
7. observe fog is being applied again