### PR TITLE
INT 0.8 Disable location type selector

### DIFF
--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -264,7 +264,7 @@ export default function AddEditLocationModal(props: { location?: LocationType; s
               currentValue={locationType.value}
               onChange={(value) => locationType.set(value as 'private' | 'public' | 'showroom')}
               options={locationTypeOptions}
-              disabled={isLoading}
+              disabled={true}
             />
             <Toggle
               label={t('admin:components.location.lbl-ve')}


### PR DESCRIPTION
## Summary

Private locations have issues in mutlitenancy since login credentials from
the studio subdomain don't carry over to the customer's subdomain.
Disabling ability to make private locations for now until that is resolved.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
