### PR TITLE
detect scene json in project upload

### DIFF
--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1626,7 +1626,7 @@ const migrateResourcesJson = (projectName: string, resourceJsonPath: string) => 
 const getResourceType = (key: string, resource?: ResourceType) => {
   // TODO: figure out a better way of handling thumbnails rather than by convention
   if (key.startsWith('public/thumbnails') || key.endsWith('.thumbnail.jpg')) return 'thumbnail'
-  if (key.startsWith('public/scenes') && key.endsWith('.gltf')) return 'scene'
+  if (key.startsWith('public/scenes') && (key.endsWith('.gltf') || key.endsWith('.scene.json'))) return 'scene'
   if (!resource) return 'file'
   if (staticResourceClasses.includes(FileToAssetType(key))) return 'asset'
   if (resource.type) return resource.type


### PR DESCRIPTION
When loading old projects, scene.json files will be detected as scene assets, allowing the "scene" tab to be populated correctly
