### PR TITLE
Fix files navigation

### DIFF
--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -102,7 +102,7 @@ export default function FileBrowser() {
   const projectName = useMutableState(EditorState).projectName.value
   useEffect(() => {
     if (projectName) {
-      filesState.merge({ selectedDirectory: `/projects/${projectName}`, projectName: projectName })
+      filesState.merge({ selectedDirectory: `/projects/${projectName}/`, projectName: projectName })
     }
   }, [projectName])
 


### PR DESCRIPTION
## Summary

There's an issue with the initial selected directory missing / at the end which causes navigation issues in the files panel
Users cannot navigate to the current project folder and its sub-folders

https://github.com/user-attachments/assets/bbcc07f1-eeb8-49ee-a6e0-e14f349cd181


With this changes users are able to freely navigate through the projects folders 

https://github.com/user-attachments/assets/5c98ba86-fda6-4de3-a119-709fd80a5631




## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
