### PR TITLE
IR-4327 correcting the descriptions of grid height and translation snapping/grid size

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -140,7 +140,7 @@
     "transformSnapTool": {
       "toggleBBoxSnap": "[B] Toggle Bounding Box Snap",
       "toggleSnapMode": "[C] Toggle Grid Snap",
-      "info-translate": "Translate objects by a unit of measurement.",
+      "info-translate": "Grid and translation snap size (meters).",
       "info-rotate": "Snap rotation angle"
     },
     "placement": {
@@ -179,7 +179,8 @@
     },
     "grid": {
       "info-toggleGridVisibility": "Toggle Grid Visibility",
-      "info-gridSpacing": "Set grid spacing meters",
+      "info-gridSpacing": "Set grid spacing (meters)",
+      "info-gridHeight": "Set grid height (meters)",
       "info-incrementHeight": "Increment Grid Height",
       "info-decrementHeight": "Decrement Grid Height"
     },

--- a/packages/editor/src/panels/viewport/tools/GridTool.tsx
+++ b/packages/editor/src/panels/viewport/tools/GridTool.tsx
@@ -57,7 +57,7 @@ const GridTool = () => {
           className="px-0"
         />
       </Tooltip>
-      <Tooltip content={t('editor:toolbar.grid.info-gridSpacing')}>
+      <Tooltip content={t('editor:toolbar.grid.info-gridHeight')}>
         <NumericInput
           value={rendererState.gridHeight.value}
           onChange={(value) => rendererState.gridHeight.set(value)}


### PR DESCRIPTION
## Summary
correcting the descriptions of grid height and translation snapping/grid size

## References
[https://tsu.atlassian.net/browse/IR-4327](https://tsu.atlassian.net/browse/IR-4327)

## QA Steps
check tooltip descriptions for grid height and translation snapping
![image](https://github.com/user-attachments/assets/f8315d18-a7cf-42b4-b178-a63eb8abb934)

![image](https://github.com/user-attachments/assets/120a594d-d137-49d2-8059-24bc5aceeb61)

