### PR TITLE
fix shift selection in hierarchy panel

### DIFF
--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -137,6 +137,9 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
       if (entity) entities.push(entity)
     }
     setSelectedNode(entities)
+    if (!selectionState.selectedEntities.value.length) {
+      setFirstClickedNode(null)
+    }
   }, [selectionState.selectedEntities])
 
   useHotkeys(`${cmdOrCtrlString}+d`, (e) => {
@@ -458,10 +461,6 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
 
     if (!selectionState.selectedEntities.value.includes(getComponent(renamingNode.entity, UUIDComponent))) {
       onRenameSubmit(renamingNode.entity, renamingNode.name)
-    }
-
-    if (!selectionState.selectedEntities.value.length) {
-      setFirstClickedNode(null)
     }
   }, [selectionState.selectedEntities, renamingNode])
   /* Rename functions */

--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -113,7 +113,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
   const [contextSelectedItem, setContextSelectedItem] = React.useState<undefined | Entity>(undefined)
   const [anchorEvent, setAnchorEvent] = React.useState<undefined | React.MouseEvent<HTMLDivElement>>(undefined)
 
-  const [prevClickedNode, setPrevClickedNode] = useState<Entity | null>(null)
+  const [firstClickedNode, setFirstClickedNode] = useState<Entity | null>(null)
   const onUpload = useUpload(uploadOptions)
   const [renamingNode, setRenamingNode] = useState<RenameNodeData | null>(null)
   const expandedNodes = useHookstate(getMutableState(EditorState).expandedNodes)
@@ -276,8 +276,8 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
         if ((e.ctrlKey && usesCtrlKey()) || (e.metaKey && !usesCtrlKey())) {
           if (entity === rootEntity) return
           EditorControlFunctions.toggleSelection([getComponent(entity, UUIDComponent)])
-        } else if (e.shiftKey && prevClickedNode) {
-          const startIndex = entityHierarchy.value.findIndex((n) => n.entity === prevClickedNode)
+        } else if (e.shiftKey && firstClickedNode) {
+          const startIndex = entityHierarchy.value.findIndex((n) => n.entity === firstClickedNode)
           const endIndex = entityHierarchy.value.findIndex((n) => n.entity === entity)
           const range = entityHierarchy.value.slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1)
           const entityUuids = range.filter((n) => n.entity).map((n) => getComponent(n.entity!, UUIDComponent))
@@ -287,8 +287,8 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
           if (!selected) {
             EditorControlFunctions.replaceSelection([getComponent(entity, UUIDComponent)])
           }
+          setFirstClickedNode(entity)
         }
-        setPrevClickedNode(entity)
       } else if (e.detail === 2) {
         if (entity && getOptionalComponent(entity, CameraOrbitComponent)) {
           const editorCameraState = getMutableComponent(Engine.instance.cameraEntity, CameraOrbitComponent)
@@ -297,7 +297,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
         }
       }
     },
-    [prevClickedNode, entityHierarchy]
+    [firstClickedNode, entityHierarchy]
   )
 
   const onToggle = useCallback(
@@ -458,6 +458,10 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
 
     if (!selectionState.selectedEntities.value.includes(getComponent(renamingNode.entity, UUIDComponent))) {
       onRenameSubmit(renamingNode.entity, renamingNode.name)
+    }
+
+    if (!selectionState.selectedEntities.value.length) {
+      setFirstClickedNode(null)
     }
   }, [selectionState.selectedEntities, renamingNode])
   /* Rename functions */


### PR DESCRIPTION
## Summary

include shift selection in hierarchy panel to include selection starting from the first clicked node (instead of the previous node)

## References

closes https://tsu.atlassian.net/browse/IR-4336



## QA Steps



https://github.com/user-attachments/assets/227a431d-728b-4813-8942-a8cfc15ca6b3

