### PR TITLE
fix hierarchy context menu hotkeys positioning

### DIFF
--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -588,6 +588,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
             {t('editor:hierarchy.lbl-rename')}
           </Button>
           <Button
+            fullWidth
             size="small"
             variant="transparent"
             className="text-left text-xs"
@@ -597,6 +598,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
             {t('editor:hierarchy.lbl-duplicate')}
           </Button>
           <Button
+            fullWidth
             size="small"
             variant="transparent"
             className="text-left text-xs"
@@ -606,6 +608,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
             {t('editor:hierarchy.lbl-group')}
           </Button>
           <Button
+            fullWidth
             size="small"
             variant="transparent"
             className="text-left text-xs"
@@ -615,6 +618,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
             {t('editor:hierarchy.lbl-copy')}
           </Button>
           <Button
+            fullWidth
             size="small"
             variant="transparent"
             className="text-left text-xs"


### PR DESCRIPTION
## Summary

The hierarchy panel's context menu's hotkeys are now correctly positioned to the extreme right.

## QA Steps

![image](https://github.com/user-attachments/assets/96b7a5ab-a81e-483d-9b36-14d4bb52d4fd)

