### PR TITLE
v0.8 Fix nested transforms. Fix avatar collider removal(find ticket)

### DIFF
--- a/packages/engine/src/avatar/components/AvatarControllerComponent.ts
+++ b/packages/engine/src/avatar/components/AvatarControllerComponent.ts
@@ -36,7 +36,7 @@ import {
 } from '@ir-engine/ecs/src/ComponentFunctions'
 import { Engine } from '@ir-engine/ecs/src/Engine'
 import { Entity, UndefinedEntity } from '@ir-engine/ecs/src/Entity'
-import { entityExists, useEntityContext } from '@ir-engine/ecs/src/EntityFunctions'
+import { entityExists, removeEntity, useEntityContext } from '@ir-engine/ecs/src/EntityFunctions'
 import { getState, matches } from '@ir-engine/hyperflux'
 import { FollowCameraComponent } from '@ir-engine/spatial/src/camera/components/FollowCameraComponent'
 import { TargetCameraRotationComponent } from '@ir-engine/spatial/src/camera/components/TargetCameraRotationComponent'
@@ -158,5 +158,16 @@ export const AvatarColliderComponent = defineComponent({
   onSet(entity, component, json) {
     if (!json) return
     if (matches.number.test(json.colliderEntity)) component.colliderEntity.set(json.colliderEntity)
+  },
+  reactor() {
+    const entity = useEntityContext()
+    const avatarColliderComponent = getComponent(entity, AvatarColliderComponent)
+    useEffect(() => {
+      return () => {
+        removeEntity(
+          avatarColliderComponent.colliderEntity
+        ) /** @todo Aidan said to figure out why this isn't cleaned up with EntityTree */
+      }
+    }, [])
   }
 })

--- a/packages/spatial/src/physics/systems/PhysicsPreTransformSystem.ts
+++ b/packages/spatial/src/physics/systems/PhysicsPreTransformSystem.ts
@@ -106,8 +106,9 @@ export const lerpTransformFromRigidbody = (entity: Entity, alpha: number) => {
   /** convert the local space transform to scene space */
   transform.matrixWorld.multiplyMatrices(parentTransform.matrixWorld, transform.matrix)
 
+  /** @todo Whatever this math is doing is incorrect and we'll fix it v0.9. */
   /** convert the scene space transform to world space */
-  transform.matrixWorld.premultiply(sceneRelParentMatrix)
+  //transform.matrixWorld.premultiply(sceneRelParentMatrix)
 
   /** set all children dirty deeply, but set this entity to clean */
   iterateEntityNode(entity, setDirty)


### PR DESCRIPTION
## Summary
Removed a line of math that was causing issues with nested transforms @HexaField We gotta figure out what we're missing but the expected behavior works without that premultiply.

I also went ahead and fixed the issue of avatar colliders not being cleaned up when toggling preview.(gotta find the ticket for this one)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
