### PR TITLE
Decouple screen share target from model and improve export settings design

### DIFF
--- a/packages/editor/src/services/ComponentShelfCategoriesState.ts
+++ b/packages/editor/src/services/ComponentShelfCategoriesState.ts
@@ -47,6 +47,7 @@ import { PrimitiveGeometryComponent } from '@ir-engine/engine/src/scene/componen
 import { RenderSettingsComponent } from '@ir-engine/engine/src/scene/components/RenderSettingsComponent'
 import { ScenePreviewCameraComponent } from '@ir-engine/engine/src/scene/components/ScenePreviewCamera'
 import { SceneSettingsComponent } from '@ir-engine/engine/src/scene/components/SceneSettingsComponent'
+import { ScreenshareTargetComponent } from '@ir-engine/engine/src/scene/components/ScreenshareTargetComponent'
 import { ShadowComponent } from '@ir-engine/engine/src/scene/components/ShadowComponent'
 import { SkyboxComponent } from '@ir-engine/engine/src/scene/components/SkyboxComponent'
 import { SpawnPointComponent } from '@ir-engine/engine/src/scene/components/SpawnPointComponent'
@@ -94,7 +95,8 @@ export const ComponentShelfCategoriesState = defineState({
         MountPointComponent,
         InteractableComponent,
         InputComponent,
-        GrabbableComponent
+        GrabbableComponent,
+        ScreenshareTargetComponent
       ],
       Lighting: [
         AmbientLightComponent,

--- a/packages/ui/src/components/editor/properties/model/index.tsx
+++ b/packages/ui/src/components/editor/properties/model/index.tsx
@@ -45,14 +45,16 @@ import { recursiveHipsLookup } from '@ir-engine/engine/src/avatar/AvatarBoneMatc
 import { getEntityErrors } from '@ir-engine/engine/src/scene/components/ErrorComponent'
 import { ModelComponent } from '@ir-engine/engine/src/scene/components/ModelComponent'
 import { getState, useState } from '@ir-engine/hyperflux'
+import { IoIosArrowBack, IoIosArrowDown } from 'react-icons/io'
+import Accordion from '../../../../primitives/tailwind/Accordion'
 import Button from '../../../../primitives/tailwind/Button'
+import LoadingView from '../../../../primitives/tailwind/LoadingView'
 import BooleanInput from '../../input/Boolean'
 import InputGroup from '../../input/Group'
 import ModelInput from '../../input/Model'
 import SelectInput from '../../input/Select'
 import StringInput from '../../input/String'
 import NodeEditor from '../nodeEditor'
-import ScreenshareTargetNodeEditor from '../screenShareTarget'
 import ModelTransformProperties from './transform'
 
 /**
@@ -172,47 +174,58 @@ export const ModelNodeEditor: EditorComponentType = (props) => {
           />
         </InputGroup>
       )}
-      {!exporting.value && (
-        <div className="m-2 flex flex-col rounded-md p-1">
-          <div className="property-group-header">{t('editor:properties.model.lbl-export')}</div>
-          <InputGroup name="Export Project" label="Project">
-            <SelectInput
-              value={srcProject.value}
-              options={
-                loadedProjects.value.map((project) => ({
-                  label: project,
-                  value: project
-                })) ?? []
-              }
-              onChange={(val) => srcProject.set(val as string)}
-            />
-          </InputGroup>
-          <InputGroup name="File Path" label="File Path">
-            <StringInput value={srcPath.value} onChange={srcPath.set} />
-          </InputGroup>
-          <InputGroup name="Export Type" label={t('editor:properties.model.lbl-exportType')}>
-            <SelectInput
-              options={[
-                {
-                  label: 'glB',
-                  value: 'glb'
-                },
-                {
-                  label: 'glTF',
-                  value: 'gltf'
+
+      <Accordion
+        className="space-y-4 p-4"
+        title={t('editor:properties.model.lbl-export')}
+        expandIcon={<IoIosArrowBack className="text-xl text-gray-300" />}
+        shrinkIcon={<IoIosArrowDown className="text-xl text-gray-300" />}
+        titleClassName="text-gray-300"
+        titleFontSize="base"
+      >
+        {!exporting.value && (
+          <>
+            <InputGroup name="Export Project" label="Project">
+              <SelectInput
+                value={srcProject.value}
+                options={
+                  loadedProjects.value.map((project) => ({
+                    label: project,
+                    value: project
+                  })) ?? []
                 }
-              ]}
-              value={exportType.value}
-              onChange={(val) => exportType.set(val as string)}
-            />
-          </InputGroup>
-          <Button className="self-end" onClick={onExportModel}>
-            {t('editor:properties.model.saveChanges')}
-          </Button>
-        </div>
-      )}
-      {exporting.value && <p>Exporting...</p>}
-      <ScreenshareTargetNodeEditor entity={props.entity} multiEdit={props.multiEdit} />
+                onChange={(val) => srcProject.set(val as string)}
+              />
+            </InputGroup>
+            <InputGroup name="File Path" label="File Path">
+              <StringInput value={srcPath.value} onChange={srcPath.set} />
+            </InputGroup>
+            <InputGroup name="Export Type" label={t('editor:properties.model.lbl-exportType')}>
+              <SelectInput
+                options={[
+                  {
+                    label: 'glB',
+                    value: 'glb'
+                  },
+                  {
+                    label: 'glTF',
+                    value: 'gltf'
+                  }
+                ]}
+                value={exportType.value}
+                onChange={(val) => exportType.set(val as string)}
+              />
+            </InputGroup>
+            <Button className="self-end" onClick={onExportModel}>
+              {t('editor:properties.model.saveChanges')}
+            </Button>
+          </>
+        )}
+        {exporting.value && (
+          <LoadingView fullSpace className="mb-2 flex h-[20%] w-[20%] justify-center" title=" Exporting..." />
+        )}
+      </Accordion>
+
       {gltfTransformFeatureFlag && (
         <ModelTransformProperties entity={entity} onChangeModel={commitProperty(ModelComponent, 'src')} />
       )}


### PR DESCRIPTION
This pull request decouples the screen share target from the model and improves the design of the export settings. It introduces a new component into the component shelf called ScreenshareTargetComponent and updates the export settings UI to use an accordion layout. Additionally, it adds icons for expanding and shrinking the accordion sections. This change enhances the modularity and usability of the codebase.