### PR TITLE
remove slugifiedName from locationData

### DIFF
--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -142,7 +142,6 @@ export default function AddEditLocationModal(props: { location?: LocationType; s
 
     const locationData: LocationData = {
       name: name.value,
-      slugifiedName: '',
       sceneId: scene.value,
       maxUsersPerInstance: maxUsers.value,
       locationSetting: {

--- a/packages/common/src/schemas/social/location.schema.ts
+++ b/packages/common/src/schemas/social/location.schema.ts
@@ -88,7 +88,6 @@ export interface LocationDatabaseType
 export const locationDataProperties = Type.Pick(locationSchema, [
   'name',
   'sceneId',
-  'slugifiedName',
   'isLobby',
   'isFeatured',
   'maxUsersPerInstance'

--- a/packages/server-core/src/matchmaking/match-instance/match-instance.test.ts
+++ b/packages/server-core/src/matchmaking/match-instance/match-instance.test.ts
@@ -107,7 +107,6 @@ describe.skip('matchmaking match-instance service', () => {
 
     location = await app.service(locationPath).create({
       name: `game-${gameMode}`,
-      slugifiedName: `game-${gameMode}`,
       maxUsersPerInstance: 20,
       sceneId: `test/game-${gameMode}`,
       locationSetting: commonlocationSetting,

--- a/packages/server-core/src/social/location/location.test.ts
+++ b/packages/server-core/src/social/location/location.test.ts
@@ -63,7 +63,6 @@ describe('location.test', () => {
     const item = await app.service(locationPath).create(
       {
         name,
-        slugifiedName: '',
         sceneId: scene.data[0].id,
         maxUsersPerInstance: 20,
         locationSetting: {

--- a/packages/server-core/tests/util/createTestLocation.ts
+++ b/packages/server-core/tests/util/createTestLocation.ts
@@ -41,7 +41,6 @@ export const createTestLocation = async (app: Application, params = { isInternal
   return await app.service(locationPath).create(
     {
       name,
-      slugifiedName: '',
       sceneId: scene.data[0].id,
       maxUsersPerInstance: 20,
       locationSetting: {


### PR DESCRIPTION
## Summary

Removes `slugifiedName` from `LocationData` type, because it's populated by resolvers anyway.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
