### PR TITLE
Fix hierarchy panel reordering

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.test.tsx
+++ b/packages/editor/src/functions/EditorControlFunctions.test.tsx
@@ -669,11 +669,12 @@ describe('EditorControlFunctions', () => {
       const node2Entity = UUIDComponent.getEntityByUUID(node2UUID)
       const sourceID = getComponent(nodeEntity, SourceComponent)
 
-      EditorControlFunctions.reparentObject([node2Entity], null, nodeEntity)
+      EditorControlFunctions.reparentObject([node2Entity], null, null, nodeEntity)
 
       applyIncomingActions()
 
       const newSnapshot = getState(GLTFSnapshotState)[sourceID].snapshots[1]
+      console.log('newSnapshot', newSnapshot)
       assert.equal(newSnapshot.scenes![0].nodes![0], 0)
       assert.equal(newSnapshot.scenes![0].nodes.length, 1)
       assert.equal(newSnapshot.nodes![0].children![0], 1)
@@ -715,7 +716,7 @@ describe('EditorControlFunctions', () => {
       const childEntity = UUIDComponent.getEntityByUUID(childUUID)
       const sourceID = getComponent(nodeEntity, SourceComponent)
 
-      EditorControlFunctions.reparentObject([childEntity], nodeEntity, rootEntity)
+      EditorControlFunctions.reparentObject([childEntity], nodeEntity, null, rootEntity)
 
       applyIncomingActions()
 
@@ -769,7 +770,7 @@ describe('EditorControlFunctions', () => {
       const childEntity = UUIDComponent.getEntityByUUID(childUUID)
       const sourceID = getComponent(nodeEntity, SourceComponent)
 
-      EditorControlFunctions.reparentObject([node2Entity], childEntity, nodeEntity)
+      EditorControlFunctions.reparentObject([node2Entity], childEntity, null, nodeEntity)
 
       applyIncomingActions()
 
@@ -825,6 +826,7 @@ describe('EditorControlFunctions', () => {
       getMutableState(EditorState).rootEntity.set(rootEntity)
       applyIncomingActions()
 
+      const node1Entity = UUIDComponent.getEntityByUUID(node1UUID)
       const node2Entity = UUIDComponent.getEntityByUUID(node2UUID)
       const node4Entity = UUIDComponent.getEntityByUUID(node4UUID)
 
@@ -842,10 +844,11 @@ describe('EditorControlFunctions', () => {
         (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(node2Entity, UUIDComponent)
       )
 
-      EditorControlFunctions.reparentObject([node4Entity], node2Entity, rootEntity)
+      EditorControlFunctions.reparentObject([node4Entity], node2Entity, node1Entity, rootEntity)
       applyIncomingActions()
 
       const newSnapshot = getState(GLTFSnapshotState)[sourceID].snapshots[1]
+      console.log('newSnapshot', newSnapshot)
       assert.equal(newSnapshot.nodes?.length, 4)
       assert.equal(newSnapshot.nodes?.[beforeNodeIndex].name, targetNodeName)
     })

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -80,7 +80,7 @@ const getGLTFNodeByUUID = (gltf: GLTF.IGLTF, uuid: string) => {
 
 const getParentNodeByUUID = (gltf: GLTF.IGLTF, uuid: string) => {
   const nodeIndex = gltf.nodes?.findIndex((n) => n.extensions?.[UUIDComponent.jsonID] === uuid)
-  if (!nodeIndex || nodeIndex < 0) return
+  if (nodeIndex === undefined || nodeIndex < 0) return
   return gltf.nodes?.find((n) => n.children?.includes(nodeIndex))
 }
 
@@ -520,7 +520,12 @@ const scaleObject = (entities: Entity[], scales: Vector3[], overrideScale = fals
   }
 }
 
-const reparentObject = (entities: Entity[], before?: Entity | null, parent = getState(EditorState).rootEntity) => {
+const reparentObject = (
+  entities: Entity[],
+  before?: Entity | null,
+  after?: Entity | null,
+  parent = getState(EditorState).rootEntity
+) => {
   const scenes = getSourcesForEntities(entities)
 
   for (const [sceneID, entities] of Object.entries(scenes)) {
@@ -531,9 +536,9 @@ const reparentObject = (entities: Entity[], before?: Entity | null, parent = get
 
       const entityUUID = getComponent(entity, UUIDComponent)
       const nodeIndex = gltf.data.nodes!.findIndex((n) => n.extensions?.[UUIDComponent.jsonID] === entityUUID)
+
       const isCurrentlyChildOfRoot = gltf.data.scenes![0].nodes.includes(nodeIndex)
 
-      // Remove from current parent
       if (isCurrentlyChildOfRoot) {
         gltf.data.scenes![0].nodes.splice(gltf.data.scenes![0].nodes.indexOf(nodeIndex), 1)
       } else {
@@ -561,17 +566,27 @@ const reparentObject = (entities: Entity[], before?: Entity | null, parent = get
       const isParentRoot = parent === getState(EditorState).rootEntity
 
       // Add to new parent
+
       if (isParentRoot) {
         if (before) {
-          const beforeIndex = gltf.data.nodes!.findIndex(
-            (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent)
-          )
-          gltf.data.scenes![0].nodes.splice(beforeIndex, 0, nodeIndex)
-          gltf.data.nodes?.splice(beforeIndex, 0, gltf.data.nodes?.[nodeIndex])
-          gltf.data.nodes?.splice(nodeIndex + 1, 1)
+          if (after) {
+            const afterIndex = gltf.data.nodes!.findIndex(
+              (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(after, UUIDComponent)
+            )
+            gltf.data.scenes![0].nodes.splice(afterIndex, 0, nodeIndex) // insert after
+            const nodeData = gltf.data.nodes?.splice(nodeIndex, 1) // remove old node from the list right before inserting to justify afterindex postion
+            gltf.data.nodes?.splice(afterIndex, 0, nodeData![0]) // insert after
+          }
+          // we have a before but no after, means its the first in the list
+          else {
+            gltf.data.scenes![0].nodes.unshift(nodeIndex)
+            const nodeData = gltf.data.nodes?.splice(nodeIndex, 1)
+            gltf.data.nodes?.unshift(nodeData![0])
+          }
         } else {
           gltf.data.scenes![0].nodes.push(nodeIndex)
-          gltf.data.nodes?.push(gltf.data.nodes[nodeIndex])
+          const nodeData = gltf.data.nodes?.splice(nodeIndex, 1)
+          gltf.data.nodes?.push(nodeData![0])
         }
       } else {
         const newParentNode = getGLTFNodeByUUID(gltf.data, newParentUUID)
@@ -581,9 +596,19 @@ const reparentObject = (entities: Entity[], before?: Entity | null, parent = get
           const beforeIndex = newParentNode.children.findIndex(
             (n) =>
               n ===
-              gltf.data.nodes!.find((n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent))
+              gltf.data.nodes!.findIndex(
+                (n) =>
+                  n ===
+                  gltf.data.nodes!.find(
+                    (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent)
+                  )
+              )
           )
-          newParentNode.children.splice(beforeIndex, 0, nodeIndex)
+          if (after) {
+            newParentNode.children.splice(beforeIndex, 0, nodeIndex) // we extract the index of the before entity and insert the node right before it
+          } else {
+            newParentNode.children.unshift(nodeIndex)
+          }
         } else {
           newParentNode.children.push(nodeIndex)
         }

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -566,16 +566,20 @@ const reparentObject = (
       const isParentRoot = parent === getState(EditorState).rootEntity
 
       // Add to new parent
-
       if (isParentRoot) {
         if (before) {
+          const beforeIndex = gltf.data.nodes!.findIndex(
+            (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent)
+          )
           if (after) {
             const afterIndex = gltf.data.nodes!.findIndex(
               (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(after, UUIDComponent)
             )
-            gltf.data.scenes![0].nodes.splice(afterIndex, 0, nodeIndex) // insert after
+
+            const finalIndex = beforeIndex > nodeIndex ? afterIndex : beforeIndex
+            gltf.data.scenes![0].nodes.splice(finalIndex, 0, nodeIndex) // insert after
             const nodeData = gltf.data.nodes?.splice(nodeIndex, 1) // remove old node from the list right before inserting to justify afterindex postion
-            gltf.data.nodes?.splice(afterIndex, 0, nodeData![0]) // insert after
+            gltf.data.nodes?.splice(finalIndex, 0, nodeData![0]) // insert after
           }
           // we have a before but no after, means its the first in the list
           else {

--- a/packages/ui/src/components/editor/panels/Hierarchy/node/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/node/index.tsx
@@ -161,25 +161,28 @@ export const HierarchyTreeNode = (props: HierarchyTreeNodeProps) => {
   const dropItem = (node: HierarchyTreeNodeType, place: 'On' | 'Before' | 'After') => {
     let parentNode: Entity | undefined
     let beforeNode: Entity
+    let afterNode: Entity
 
-    if (place === 'Before') {
-      const entityTreeComponent = getOptionalComponent(node.entity, EntityTreeComponent)
-      parentNode = entityTreeComponent?.parentEntity
-      beforeNode = node.entity
-    } else if (place === 'After') {
-      const entityTreeComponent = getOptionalComponent(node.entity, EntityTreeComponent)
-      parentNode = entityTreeComponent?.parentEntity
-      const parentTreeComponent = getOptionalComponent(entityTreeComponent?.parentEntity!, EntityTreeComponent)
-      if (
-        parentTreeComponent &&
-        !node.lastChild &&
-        parentNode &&
-        parentTreeComponent?.children.length > node.childIndex + 1
-      ) {
+    const entityTreeComponent = getOptionalComponent(node.entity, EntityTreeComponent)
+    parentNode = entityTreeComponent?.parentEntity
+    const parentTreeComponent = getOptionalComponent(entityTreeComponent?.parentEntity!, EntityTreeComponent)
+
+    switch (place) {
+      case 'Before': // we want to place before this node
+        beforeNode = node.entity
+        if (!parentTreeComponent || !parentNode) break
+        if (0 > node.childIndex - 1) break // nothing to place after it, as node index is the first child
+        afterNode = parentTreeComponent.children[node.childIndex - 1]
+        break
+      case 'After': // we want to place after this node
+        afterNode = node.entity
+        if (!parentTreeComponent || !parentNode) break
+        if (node.lastChild) break // if it is last child, nothing to place before it
+        if (parentTreeComponent?.children.length < node.childIndex + 1) break //node index is last child
         beforeNode = parentTreeComponent.children[node.childIndex + 1]
-      }
-    } else {
-      parentNode = node.entity
+        break
+      default: //case 'on'
+        parentNode = node.entity
     }
 
     if (!parentNode)
@@ -223,6 +226,7 @@ export const HierarchyTreeNode = (props: HierarchyTreeNodeProps) => {
           ? ((item as DragItemType).value as Entity[])
           : [(item as DragItemType).value as Entity],
         beforeNode,
+        afterNode,
         parentNode === null ? undefined : parentNode
       )
     }


### PR DESCRIPTION
This pull request fixes an issue with the hierarchy panel reordering. The `reparentObject` function has been updated to include an additional parameter `after` which allows for reordering of entities in the hierarchy. The `dropItem` function in the `HierarchyTreeNode` component has also been modified to handle placing entities before or after a specific node. These changes ensure that the hierarchy panel reordering functionality works correctly.

temporary fix for now, i propose a deeper refactor 