### PR TITLE
fix: share instance by invite

### DIFF
--- a/packages/client-core/src/social/services/InviteService.ts
+++ b/packages/client-core/src/social/services/InviteService.ts
@@ -144,12 +144,15 @@ export const InviteService = {
     }
 
     try {
+      const { spawnDetails, ...query } = data
       const existingInviteResult = (await API.instance.service(invitePath).find({
-        query: { ...data, action: 'sent' }
+        query: {
+          ...query,
+          action: 'sent'
+        }
       })) as Paginated<InviteType>
 
-      let inviteResult
-      if (existingInviteResult.total === 0) inviteResult = await API.instance.service(invitePath).create(data)
+      if (existingInviteResult.total === 0) await API.instance.service(invitePath).create(data)
 
       NotificationService.dispatchNotify('Invite Sent', { variant: 'success' })
       getMutableState(InviteState).sentUpdateNeeded.set(true)

--- a/packages/common/src/schemas/social/invite.schema.ts
+++ b/packages/common/src/schemas/social/invite.schema.ts
@@ -39,11 +39,7 @@ export const inviteMethods = ['create', 'find', 'remove', 'patch', 'get'] as con
 
 export const spawnDetailsSchema = Type.Object(
   {
-    inviteCode: Type.Optional(
-      TypedString<InviteCode>({
-        format: 'uuid'
-      })
-    ),
+    inviteCode: Type.Optional(TypedString<InviteCode>()),
     spawnPoint: Type.Optional(Type.String()),
     spectate: Type.Optional(Type.String())
   },


### PR DESCRIPTION
## Summary
This update resolves the issue with sharing an instance via invite. The problem stemmed from the incorrect format of the `inviteCode` in the schema, and the query for retrieving existing invites included unnecessary properties, causing the request to fail.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
- Go to an existing location
- Click on the share button 
- Input an email address 
- Click on send 
It should send an invite to the recipient. 
![image](https://github.com/user-attachments/assets/c0923c14-2abb-4a8f-bc27-b281d31adccd)
