### PR TITLE
Fixed a bug with consumer state change.

### DIFF
--- a/packages/common/src/transports/mediasoup/MediasoupMediaProducerConsumerState.tsx
+++ b/packages/common/src/transports/mediasoup/MediasoupMediaProducerConsumerState.tsx
@@ -460,7 +460,8 @@ export const NetworkMediaConsumer = (props: { networkID: NetworkID; consumerID: 
 
   useEffect(() => {
     const consumer = consumerObjectState.value as any
-    const producerID = consumerState.producerID.value
+    const producerID = consumerState.producerID?.value
+    if (producerID == null) return
     const producer = getState(MediasoupMediaProducersConsumersObjectsState).producers[producerID]
     if (!consumer || consumer.closed || consumer._closed || !producer || producer?.closed || producer?._closed) return
 


### PR DESCRIPTION
## Summary

In intermittent situations, usually with >=4 users connected to a media instancserver, one user leaving would put every producer in an un-consumable state. The main error showing up was that some consumers' producerID would be undefined, and trying to get the .value of it was throwing errors, and possibly triggering all of the other errors. Made that value read conditional and returning if consumer.producerID is null/undefined; hopefully this solves it.

Resolves IR-4431

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
