### PR TITLE
New Camera functions, bbox function, and EntityTree functions/tests

### DIFF
--- a/packages/spatial/src/camera/components/FollowCameraComponent.ts
+++ b/packages/spatial/src/camera/components/FollowCameraComponent.ts
@@ -224,22 +224,24 @@ const computeCameraFollow = (cameraEntity: Entity, referenceEntity: Entity) => {
 
   // Run only if not in first person mode
   let obstacleDistance = Infinity
+  let obstacleHit = false
   if (follow.raycastProps.enabled && follow.mode !== FollowCameraMode.FirstPerson) {
     const distanceResults = getMaxCamDistance(cameraEntity, follow.currentTargetPosition)
     if (distanceResults.maxDistance > 0.1) {
       obstacleDistance = distanceResults.maxDistance
     }
     isInsideWall = distanceResults.targetHit
+    obstacleHit = distanceResults.targetHit
   }
 
   if (follow.mode === FollowCameraMode.FirstPerson) {
     follow.effectiveMinDistance = follow.effectiveMaxDistance = 0
   } else if (follow.mode === FollowCameraMode.ThirdPerson || follow.mode === FollowCameraMode.ShoulderCam) {
-    follow.effectiveMaxDistance = Math.min(obstacleDistance * 0.8, follow.thirdPersonMaxDistance)
+    follow.effectiveMaxDistance = Math.min(obstacleDistance * (obstacleHit ? 0.8 : 1), follow.thirdPersonMaxDistance)
     follow.effectiveMinDistance = Math.min(follow.thirdPersonMinDistance, follow.effectiveMaxDistance)
   } else if (follow.mode === FollowCameraMode.TopDown) {
     follow.effectiveMinDistance = follow.effectiveMaxDistance = Math.min(
-      obstacleDistance * 0.9,
+      obstacleDistance * (obstacleHit ? 0.9 : 1),
       follow.thirdPersonMaxDistance
     )
   }

--- a/packages/spatial/src/camera/functions/CameraFunctions.ts
+++ b/packages/spatial/src/camera/functions/CameraFunctions.ts
@@ -26,6 +26,8 @@ Infinite Reality Engine. All Rights Reserved.
 import { ComponentType, getOptionalComponent, setComponent } from '@ir-engine/ecs/src/ComponentFunctions'
 import { Entity } from '@ir-engine/ecs/src/Entity'
 
+import { Box3, PerspectiveCamera, Sphere, Vector3 } from 'three'
+import { getBoundingBoxVertices } from '../../transform/functions/BoundingBoxFunctions'
 import { TargetCameraRotationComponent } from '../components/TargetCameraRotationComponent'
 
 export const setTargetCameraRotation = (entity: Entity, phi: number, theta: number, time = 0.3) => {
@@ -45,4 +47,41 @@ export const setTargetCameraRotation = (entity: Entity, phi: number, theta: numb
     cameraRotationTransition.theta = theta
     cameraRotationTransition.time = time
   }
+}
+
+/**
+ * Computes the distance and center of the camera required to fit the points in the camera's view
+ * @param camera - PerspectiveCamera
+ * @param pointsToFocus - Points to fit in the camera's view
+ * @param padding - Padding value to fit the points in the camera's view
+ */
+export function computeCameraDistanceAndCenter(
+  camera: PerspectiveCamera,
+  pointsToFocus: Vector3[],
+  padding: number = 1.1
+) {
+  // Create a bounding sphere from the points
+  const boundingSphere = new Sphere().setFromPoints(pointsToFocus)
+
+  const center = boundingSphere.center
+  const radius = boundingSphere.radius
+
+  // Compute the distance required to fit the sphere in the camera's vertical FOV
+  const fov = camera.fov * (Math.PI / 180) // Convert FOV to radians
+  // const distance = radius / Math.sin(fov / 2);
+
+  // Calculate the distance needed to fit the object in the camera's view, padding value of 1.1 is a good fit for most cases
+  const distance = (radius / 2 / Math.tan(fov / 2)) * padding
+  return { distance, center }
+}
+
+/**
+ * Computes the distance and center of the camera required to fit the box in the camera's view
+ * @param camera - PerspectiveCamera
+ * @param box - Box3 to fit in the camera's view
+ * @param padding - Padding value to fit the box in the camera's view
+ */
+export function computeCameraDistanceAndCenterFromBox(camera: PerspectiveCamera, box: Box3, padding: number = 1.1) {
+  const points = getBoundingBoxVertices(box)
+  return computeCameraDistanceAndCenter(camera, points, padding)
 }

--- a/packages/spatial/src/transform/components/EntityTree.test.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.test.tsx
@@ -367,7 +367,7 @@ describe('EntityTreeFunctions', () => {
 
       const visited = [] as Entity[]
 
-      traverseEntityNodeParent(nodes[nodes.length - 1], (parent) => visited.push(parent))
+      traverseEntityNodeParent(nodes[nodes.length - 1], (parent) => (visited.push(parent), undefined))
 
       assert.equal(visited.length, 4)
       assert.equal(visited[0], nodes[2])

--- a/packages/spatial/src/transform/components/EntityTree.test.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.test.tsx
@@ -513,7 +513,6 @@ describe('useTreeQuery', () => {
   })
 })
 
-
 describe('getAncestorWithComponents', () => {
   // Run before every test case
   beforeEach(() => {
@@ -626,7 +625,6 @@ describe('getAncestorWithComponents', () => {
     destroyEntityTree(rootEntity)
   })
 })
-
 
 describe('useChildWithComponent', () => {
   // Run before every test case
@@ -1126,7 +1124,7 @@ describe('useAncestorWithComponents', () => {
     let child_1 = createEntity()
     let child_2 = createEntity()
     let result = UndefinedEntity
-    
+
     setComponent(rootEntity, EntityTreeComponent)
     setComponent(rootEntity, NameComponent, 'rootEntity')
 
@@ -1145,17 +1143,18 @@ describe('useAncestorWithComponents', () => {
     const tag = <Reactor />
 
     assert.equal(UndefinedEntity, result)
-    
+
     const R1 = render(tag)
     assert.equal(rootEntity, result, `Case1: Did not return the correct entity. result = ${result}`)
-    
+    R1.unmount()
+
     removeComponent(rootEntity, NameComponent)
-    R1.rerender(tag)
+    const R2 = render(tag)
     assert.equal(child_1, result, `Case2: Did not return the correct entity. result = ${result}`)
+    R2.unmount()
 
     destroyEntityTree(rootEntity)
   })
-  
 
   // test for includeSelf = false
   it('returns the closest ancestor entity excluding self', async () => {
@@ -1163,7 +1162,7 @@ describe('useAncestorWithComponents', () => {
     let child_1 = createEntity()
     let child_2 = createEntity()
     let result = UndefinedEntity
-    
+
     setComponent(rootEntity, EntityTreeComponent)
     setComponent(rootEntity, NameComponent, 'rootEntity')
 
@@ -1184,28 +1183,26 @@ describe('useAncestorWithComponents', () => {
     }
 
     const tag = <Reactor />
-  
+
     assert.equal(UndefinedEntity, result)
 
     const R1 = render(tag)
     assert.equal(child_1, result, `Case1: Did not return the correct entity. result = ${result}`)
-    
+    R1.unmount()
+
     removeComponent(child_2, NameComponent)
-    R1.rerender(tag)
+    const R2 = render(tag)
     assert.equal(child_1, result, `Case2: Did not return the correct entity. result = ${result}`)
+    R2.unmount()
 
     removeComponent(child_1, NameComponent)
-    R1.rerender(tag)
+    const R3 = render(tag)
     assert.equal(rootEntity, result, `Case3: Did not return the correct entity. result = ${result}`)
-
-    R1.unmount()
-    assert.equal(UndefinedEntity, result, `Case4: Did not return the correct entity. result = ${result}`)
+    R3.unmount()
 
     destroyEntityTree(rootEntity)
-
   })
 })
-
 
 describe('getChildrenWithComponents', () => {
   // Run before every test case

--- a/packages/spatial/src/transform/components/EntityTree.test.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.test.tsx
@@ -42,6 +42,8 @@ import {
   destroyEntityTree,
   EntityTreeComponent,
   findIndexOfEntityNode,
+  getAncestorWithComponents,
+  getChildrenWithComponents,
   iterateEntityNode,
   removeFromEntityTree,
   traverseEntityNode,
@@ -1000,5 +1002,211 @@ describe('useAncestorWithComponent', () => {
     // Case1: Terminate
     destroyEntityTree(parent_1)
     R5.unmount()
+  })
+})
+
+describe('getAncestorWithComponents', () => {
+  // Run before every test case
+  beforeEach(() => {
+    createEngine()
+  })
+  afterEach(() => {
+    return destroyEngine()
+  })
+
+  it('returns the closest ancestor entity that has the requested component', async () => {
+    // Initialize with dummy data for the test
+    let rootEntity = createEntity()
+    let child_1 = createEntity()
+    let child_2 = createEntity()
+    let result = UndefinedEntity
+    const component = HighlightComponent
+    const component2 = VisibleComponent
+
+    /**
+     * @description Case 1:  rootEntity (with) -> child_1 (with) -> child_2 (empty) - get closest
+     */
+    // Case 1: Initialize
+
+    setComponent(rootEntity, EntityTreeComponent)
+    setComponent(rootEntity, NameComponent, 'rootEntity')
+    setComponent(rootEntity, component)
+    setComponent(rootEntity, component2)
+
+    setComponent(child_1, EntityTreeComponent, { parentEntity: rootEntity })
+    setComponent(child_1, NameComponent, 'child_1')
+    setComponent(child_1, component)
+    setComponent(child_1, component2)
+
+    setComponent(child_2, EntityTreeComponent, { parentEntity: child_1 })
+    setComponent(child_2, NameComponent, 'child_2')
+
+    result = getAncestorWithComponents(child_2, [component, component2], true)
+
+    // Case1: Validate
+    assertEntityHierarchy('rootEntity', rootEntity)
+    assertEntityHierarchy('child_1', child_1, rootEntity)
+    assertEntityHierarchy('child_2', child_2, child_1)
+    assert.equal(
+      true,
+      hasComponents(child_1, [component, component2]),
+      'Case1: The parent entity did not get its test component set correctly'
+    )
+    assert.equal(
+      true,
+      hasComponents(rootEntity, [component, component2]),
+      'Case1: The parent entity did not get its test component set correctly'
+    )
+    // Case1: Check
+    assertEntityHierarchy('Case1: result', result, rootEntity)
+    assert.equal(child_1, result, `Case1: Did not return the correct entity. result = ${result}`)
+    // Case1: Terminate
+    destroyEntityTree(rootEntity)
+
+    /**
+     * @description Case 2:  rootEntity (with) -> child_1 (with) -> child_2 (empty) - get farthest
+     */
+    rootEntity = createEntity()
+    child_1 = createEntity()
+    child_2 = createEntity()
+    result = UndefinedEntity
+
+    setComponent(rootEntity, EntityTreeComponent)
+    setComponent(rootEntity, NameComponent, 'rootEntity')
+    setComponent(rootEntity, component)
+    setComponent(rootEntity, component2)
+
+    setComponent(child_1, EntityTreeComponent, { parentEntity: rootEntity })
+    setComponent(child_1, NameComponent, 'child_1')
+    setComponent(child_1, component)
+    setComponent(child_1, component2)
+
+    setComponent(child_2, EntityTreeComponent, { parentEntity: child_1 })
+    setComponent(child_2, NameComponent, 'child_2')
+
+    result = getAncestorWithComponents(child_2, [component, component2], false)
+
+    // Case2: Validate
+    assertEntityHierarchy('rootEntity', rootEntity)
+    assertEntityHierarchy('child_1', child_1, rootEntity)
+    assertEntityHierarchy('child_2', child_2, child_1)
+    assert.equal(
+      true,
+      hasComponents(child_1, [component, component2]),
+      'Case2: The parent entity did not get its test component set correctly'
+    )
+    assert.equal(
+      true,
+      hasComponents(rootEntity, [component, component2]),
+      'Case2: The parent entity did not get its test component set correctly'
+    )
+    // Case2: Check
+    assertEntityHierarchy('Case2: result', result)
+    assert.equal(rootEntity, result, `Case2: Did not return the correct entity. result = ${result}`)
+    // Case2: Terminate
+    destroyEntityTree(rootEntity)
+  })
+})
+
+describe('getChildrenWithComponents', () => {
+  // Run before every test case
+  beforeEach(() => {
+    createEngine()
+  })
+  afterEach(() => {
+    return destroyEngine()
+  })
+
+  it('returns the closest ancestor entity that has the requested component', async () => {
+    // Initialize with dummy data for the test
+    let rootEntity = createEntity()
+    let child_1 = createEntity()
+    let child_2 = createEntity()
+    let results = [] as Entity[]
+    const component = HighlightComponent
+    const component2 = VisibleComponent
+
+    /**
+     * @description Case 1:  rootEntity (empty) -> child_1 (with) -> child_2 (with) - get closest
+     */
+    // Case 1: Initialize
+
+    setComponent(rootEntity, EntityTreeComponent)
+    setComponent(rootEntity, NameComponent, 'rootEntity')
+
+    setComponent(child_1, EntityTreeComponent, { parentEntity: rootEntity })
+    setComponent(child_1, NameComponent, 'child_1')
+    setComponent(child_1, component)
+    setComponent(child_1, component2)
+
+    setComponent(child_2, EntityTreeComponent, { parentEntity: child_1 })
+    setComponent(child_2, NameComponent, 'child_2')
+    setComponent(child_2, component)
+    setComponent(child_2, component2)
+
+    results = getChildrenWithComponents(rootEntity, [component, component2])
+
+    // Case1: Validate
+    assertEntityHierarchy('rootEntity', rootEntity)
+    assertEntityHierarchy('child_1', child_1, rootEntity)
+    assertEntityHierarchy('child_2', child_2, child_1)
+    assert.equal(
+      true,
+      hasComponents(child_1, [component, component2]),
+      'Case1: The child1 entity did not get its test component set correctly'
+    )
+    assert.equal(
+      true,
+      hasComponents(child_2, [component, component2]),
+      'Case1: The child2 entity did not get its test component set correctly'
+    )
+    // Case1: Check
+
+    assert.equal(true, results.includes(child_1), 'Case1: The child1 entity was not found correctly')
+    assert.equal(true, results.includes(child_2), 'Case1: The child2 entity was not found correctly')
+
+    // Case1: Terminate
+    destroyEntityTree(rootEntity)
+
+    /**
+     * @description Case 2:  rootEntity (with) -> child_1 (with) -> child_2 (empty) - get farthest
+     */
+    rootEntity = createEntity()
+    child_1 = createEntity()
+    child_2 = createEntity()
+    results = [] as Entity[]
+
+    setComponent(rootEntity, EntityTreeComponent)
+    setComponent(rootEntity, NameComponent, 'rootEntity')
+
+    setComponent(child_1, EntityTreeComponent, { parentEntity: rootEntity })
+    setComponent(child_1, NameComponent, 'child_1')
+    setComponent(child_1, component)
+    setComponent(child_1, component2)
+
+    setComponent(child_2, EntityTreeComponent, { parentEntity: child_1 })
+    setComponent(child_2, NameComponent, 'child_2')
+
+    results = getChildrenWithComponents(rootEntity, [component, component2])
+
+    // Case2: Validate
+    assertEntityHierarchy('rootEntity', rootEntity)
+    assertEntityHierarchy('child_1', child_1, rootEntity)
+    assertEntityHierarchy('child_2', child_2, child_1)
+    assert.equal(
+      true,
+      hasComponents(child_1, [component, component2]),
+      'Case2: The child_1 entity did not get its test component set correctly'
+    )
+    assert.equal(
+      false,
+      hasComponents(child_2, [component, component2]),
+      'Case2: The child_2 entity did not get its test component set correctly'
+    )
+    // Case2: Check
+    assert.equal(true, results.includes(child_1), 'Case1: The child1 entity was not found correctly')
+    assert.equal(false, results.includes(child_2), 'Case1: The child2 entity was not found correctly')
+    // Case2: Terminate
+    destroyEntityTree(rootEntity)
   })
 })

--- a/packages/spatial/src/transform/components/EntityTree.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.tsx
@@ -39,8 +39,8 @@ import {
 } from '@ir-engine/ecs/src/ComponentFunctions'
 import { Entity, UndefinedEntity } from '@ir-engine/ecs/src/Entity'
 import { entityExists, removeEntity, useEntityContext } from '@ir-engine/ecs/src/EntityFunctions'
-import { none, startReactor, useHookstate, useImmediateEffect } from '@ir-engine/hyperflux'
-import React, { useLayoutEffect } from 'react'
+import { none, startReactor, useForceUpdate, useHookstate, useImmediateEffect } from '@ir-engine/hyperflux'
+import React, { useEffect, useLayoutEffect } from 'react'
 
 import { TransformComponent } from './TransformComponent'
 
@@ -256,14 +256,15 @@ export function iterateEntityNode<R>(
 /**
  * Traverse parent nodes for given Entity Tree Node
  * @param node Node for which traversal will occur
- * @param cb Callback function which will be called for every traverse
+ * @param cb Callback function which will be called for every traverse; return true to stop traversal
  * @param tree Entity Tree
  */
-export function traverseEntityNodeParent(entity: Entity, cb: (parent: Entity) => void): void {
+export function traverseEntityNodeParent(entity: Entity, cb: (parent: Entity) => true|void): void {
   const entityTreeNode = getOptionalComponent(entity, EntityTreeComponent)
   if (entityTreeNode?.parentEntity) {
     const parent = entityTreeNode.parentEntity
-    cb(parent)
+    const earlyReturn = cb(parent)
+    if (earlyReturn === true) return 
     traverseEntityNodeParent(parent, cb)
   }
 }
@@ -283,11 +284,11 @@ export function getAncestorWithComponents(
   includeSelf = true
 ): Entity {
   let result = UndefinedEntity
-  if (includeSelf && closest && hasComponents(entity, components)) return entity
-  traverseEntityNodeParent(entity, (parent) => {
-    if (closest && result) return
-    if (hasComponents(parent, components)) {
-      result = parent
+  const startEntity = includeSelf ? entity : getComponent(entity, EntityTreeComponent).parentEntity
+  traverseEntityNodeParent(startEntity, (entity: Entity) => {
+    if (hasComponents(entity, components)) {
+      result = entity
+      if (closest) return true // stop traversal
     }
   })
   return result
@@ -378,49 +379,51 @@ export function useTreeQuery(entity: Entity) {
 
 /**
  * Returns the closest ancestor of an entity that has a component
- * @todo maybe extend this or write an alternative to get the furthest ancestor with component?
  * @param entity
  * @param components
  * @param closest
+ * @param includeSelf
  * @returns
  */
-export function useAncestorWithComponents(entity: Entity, components: ComponentType<any>[]) {
-  const result = useHookstate(() => getAncestorWithComponents(entity, components))
+export function useAncestorWithComponents(
+  entity: Entity, 
+  components: ComponentType<any>[],
+  closest: boolean = true,
+  includeSelf: boolean = true
+) {
+  const result = getAncestorWithComponents(entity, components, closest, includeSelf)
+  const forceUpdate = useForceUpdate()
 
+  const parentEntity = useOptionalComponent(entity, EntityTreeComponent)?.parentEntity
   const componentsString = components.map((component) => component.name).join()
 
-  useImmediateEffect(() => {
+  // hook into reactive changes up the tree to trigger a re-render of the parent when necessary
+  useEffect(() => {
     let unmounted = false
-    const ParentSubReactor = (props: { entity: Entity }) => {
+    const ParentSubReactor = React.memo((props: { entity: Entity }) => {
       const tree = useOptionalComponent(props.entity, EntityTreeComponent)
-
       const matchesQuery = components.every((component) => !!useOptionalComponent(props.entity, component))
-
-      useLayoutEffect(() => {
-        if (!matchesQuery) return
-        result.set(props.entity)
-        return () => {
-          if (!unmounted) result.set(UndefinedEntity)
-        }
+      useEffect(() => {
+        if (!unmounted) forceUpdate()
       }, [tree?.parentEntity?.value, matchesQuery])
-
-      if (matchesQuery) return null
-
+      if (matchesQuery && closest) return null
       if (!tree?.parentEntity?.value) return null
-
       return <ParentSubReactor key={tree.parentEntity.value} entity={tree.parentEntity.value} />
-    }
-
-    const root = startReactor(function useQueryReactor() {
-      return <ParentSubReactor entity={entity} key={entity} />
     })
+
+    const startEntity = includeSelf ? entity : parentEntity?.value ?? UndefinedEntity
+
+    const root = startEntity ? startReactor(function useQueryReactor() {
+      return <ParentSubReactor entity={startEntity} key={startEntity} />
+    }) : null
+
     return () => {
       unmounted = true
-      root.stop()
+      root?.stop()
     }
-  }, [entity, componentsString])
+  }, [entity, componentsString, includeSelf, parentEntity])
 
-  return result.value
+  return result
 }
 
 /**

--- a/packages/spatial/src/transform/components/EntityTree.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.tsx
@@ -532,32 +532,6 @@ export function getChildrenWithComponents(rootEntity: Entity, components: Compon
   }
 
   return children
-  // useLayoutEffect(() => {
-  //   let unmounted = false
-  //   const ChildSubReactor = (props: { entity: Entity }) => {
-  //     const tree = getOptionalComponent(props.entity, EntityTreeComponent)
-  //
-  //
-  //     if (!tree?.children) return null
-  //     return (
-  //       <>
-  //         {tree.children.map((e) => (
-  //           <ChildSubReactor key={e} entity={e} />
-  //         ))}
-  //       </>
-  //     )
-  //   }
-  //
-  //   const root = startReactor(function useQueryReactor() {
-  //     return <ChildSubReactor entity={rootEntity} key={rootEntity} />
-  //   })
-  //   return () => {
-  //     unmounted = true
-  //     root.stop()
-  //   }
-  // }, [rootEntity, componentsString])
-  //
-  // return children.value as Entity[]
 }
 
 /** @todo make a query component for useTreeQuery */

--- a/packages/spatial/src/transform/components/EntityTree.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.tsx
@@ -283,9 +283,9 @@ export function getAncestorWithComponents(
   closest = true,
   includeSelf = true
 ): Entity {
-  let result = UndefinedEntity
-  const startEntity = includeSelf ? entity : getComponent(entity, EntityTreeComponent).parentEntity
-  traverseEntityNodeParent(startEntity, (entity: Entity) => {
+  let result = hasComponents(entity, components) ? entity : UndefinedEntity
+  if (includeSelf && closest && result) return result
+  traverseEntityNodeParent(entity, (entity: Entity) => {
     if (hasComponents(entity, components)) {
       result = entity
       if (closest) return true // stop traversal

--- a/packages/spatial/src/transform/components/EntityTree.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.tsx
@@ -518,6 +518,48 @@ export function useChildrenWithComponents(rootEntity: Entity, components: Compon
   return children.value as Entity[]
 }
 
+export function getChildrenWithComponents(rootEntity: Entity, components: ComponentType<any>[]): Entity[] {
+  const children = [] as Entity[]
+
+  const tree = getOptionalComponent(rootEntity, EntityTreeComponent)
+  if (!tree?.children) return [] as Entity[]
+
+  const results = tree.children.filter((childEntity) => hasComponents(childEntity, components))
+  children.push(...results)
+
+  for (const childEntity of tree.children) {
+    children.push(...getChildrenWithComponents(childEntity, components))
+  }
+
+  return children
+  // useLayoutEffect(() => {
+  //   let unmounted = false
+  //   const ChildSubReactor = (props: { entity: Entity }) => {
+  //     const tree = getOptionalComponent(props.entity, EntityTreeComponent)
+  //
+  //
+  //     if (!tree?.children) return null
+  //     return (
+  //       <>
+  //         {tree.children.map((e) => (
+  //           <ChildSubReactor key={e} entity={e} />
+  //         ))}
+  //       </>
+  //     )
+  //   }
+  //
+  //   const root = startReactor(function useQueryReactor() {
+  //     return <ChildSubReactor entity={rootEntity} key={rootEntity} />
+  //   })
+  //   return () => {
+  //     unmounted = true
+  //     root.stop()
+  //   }
+  // }, [rootEntity, componentsString])
+  //
+  // return children.value as Entity[]
+}
+
 /** @todo make a query component for useTreeQuery */
 // export function TreeQueryReactor (props: { Components: QueryComponents; ChildEntityReactor: FC; props?: any }) {
 

--- a/packages/spatial/src/transform/components/EntityTree.tsx
+++ b/packages/spatial/src/transform/components/EntityTree.tsx
@@ -259,12 +259,12 @@ export function iterateEntityNode<R>(
  * @param cb Callback function which will be called for every traverse; return true to stop traversal
  * @param tree Entity Tree
  */
-export function traverseEntityNodeParent(entity: Entity, cb: (parent: Entity) => true|void): void {
+export function traverseEntityNodeParent(entity: Entity, cb: (parent: Entity) => true | void): void {
   const entityTreeNode = getOptionalComponent(entity, EntityTreeComponent)
   if (entityTreeNode?.parentEntity) {
     const parent = entityTreeNode.parentEntity
     const earlyReturn = cb(parent)
-    if (earlyReturn === true) return 
+    if (earlyReturn === true) return
     traverseEntityNodeParent(parent, cb)
   }
 }
@@ -386,7 +386,7 @@ export function useTreeQuery(entity: Entity) {
  * @returns
  */
 export function useAncestorWithComponents(
-  entity: Entity, 
+  entity: Entity,
   components: ComponentType<any>[],
   closest: boolean = true,
   includeSelf: boolean = true
@@ -413,9 +413,11 @@ export function useAncestorWithComponents(
 
     const startEntity = includeSelf ? entity : parentEntity?.value ?? UndefinedEntity
 
-    const root = startEntity ? startReactor(function useQueryReactor() {
-      return <ParentSubReactor entity={startEntity} key={startEntity} />
-    }) : null
+    const root = startEntity
+      ? startReactor(function useQueryReactor() {
+          return <ParentSubReactor entity={startEntity} key={startEntity} />
+        })
+      : null
 
     return () => {
       unmounted = true

--- a/packages/spatial/src/transform/functions/BoundingBoxFunctions.ts
+++ b/packages/spatial/src/transform/functions/BoundingBoxFunctions.ts
@@ -1,0 +1,21 @@
+import { Box3, Vector3 } from 'three'
+
+/**
+ * Returns all vertices of the bounding box, useful for including all vertices in the camera's view rather than hoping min and max are aligned with the camera
+ * @param boundingBox
+ */
+export function getBoundingBoxVertices(boundingBox: Box3): Vector3[] {
+  const min = boundingBox.min
+  const max = boundingBox.max
+
+  return [
+    new Vector3(min.x, min.y, min.z),
+    new Vector3(min.x, min.y, max.z),
+    new Vector3(min.x, max.y, min.z),
+    new Vector3(min.x, max.y, max.z),
+    new Vector3(max.x, min.y, min.z),
+    new Vector3(max.x, min.y, max.z),
+    new Vector3(max.x, max.y, min.z),
+    new Vector3(max.x, max.y, max.z)
+  ]
+}

--- a/packages/spatial/src/transform/functions/BoundingBoxFunctions.ts
+++ b/packages/spatial/src/transform/functions/BoundingBoxFunctions.ts
@@ -1,3 +1,28 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
 import { Box3, Vector3 } from 'three'
 
 /**


### PR DESCRIPTION
## Summary
adding missing tests for getAncestorWithComponents and getChildrenWithComponents, adding getChildrenWithComponents.

adding CameraFunctions for getting distance and center point of a PerspectiveCamera such that all Vector3[] are in the camera FOV, and another that does so with a bounding box box3

adding BoundingBox functions, with helper function to get all vertices of a box3 (useful for the above case, where a min and max point will not necessarily be aligned properly)

