### PR TITLE
Validate iframe message is coming from root-cookie-accessor

### DIFF
--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -162,7 +162,8 @@ const waitForToken = async (win, clientUrl): Promise<string> => {
 
 const getToken = async (): Promise<string> => {
   let gotResponse = false
-  const iframe = document.getElementById('root-cookie-accessor') as HTMLFrameElement
+  const iframe = document.getElementById('root-cookie-accessor') as HTMLIFrameElement
+  const iframeUrl = new URL(iframe.src).origin
   let win
   try {
     win = iframe!.contentWindow
@@ -171,7 +172,7 @@ const getToken = async (): Promise<string> => {
   }
 
   window.addEventListener('message', (e) => {
-    if (e?.data) {
+    if (e.origin === iframeUrl && e?.data) {
       try {
         const value = JSON.parse(e.data)
         if (value?.invalidDomain != null) {

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -203,7 +203,6 @@ const getToken = async (): Promise<string> => {
       } else clearInterval(checkAccessInterval)
     }, 100)
     const hasAccessListener = async function (e) {
-      console.log('hasAccessListener', e)
       if (isRootCookieAncestorMessage(e)) {
         gotResponse = true
         window.removeEventListener('message', hasAccessListener)


### PR DESCRIPTION
## Summary

Some integrations create iframe elements in the client and those generate messages 
that might cause the auth process to break, for that we validate we the message origin is actually coming 
from root-cookie-accessor otherwise we ignore those message to prevent errors while parsing. 

Current implementation causes the app to break on a GTM scan by sending a message, the origin is not validated, and then the app  gets stuck at loading:

![image](https://github.com/user-attachments/assets/25d3ae33-dd8d-489c-9fb7-0e3c29d8a52d)
![image](https://github.com/user-attachments/assets/69d6dff5-b061-4642-9a19-92fff792eca5)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
