### PR TITLE
Fixed verification of GitHub JWT signing tokens.

### DIFF
--- a/packages/common/src/schemas/setting/authentication-setting.schema.ts
+++ b/packages/common/src/schemas/setting/authentication-setting.schema.ts
@@ -98,7 +98,8 @@ export const authAppCredentialsSchema = Type.Object(
     nonce: Type.Optional(Type.Boolean()),
     response: Type.Optional(Type.Array(Type.String())),
     scope: Type.Optional(Type.Array(Type.String())),
-    custom_params: Type.Optional(Type.Record(Type.String(), Type.String()))
+    custom_params: Type.Optional(Type.Record(Type.String(), Type.String())),
+    privateKey: Type.Optional(Type.String())
   },
   { $id: 'AuthAppCredentials', additionalProperties: false }
 )

--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -261,7 +261,7 @@ const authentication = {
   secret: process.env.AUTH_SECRET!.split(String.raw`\n`).join('\n'),
   authStrategies: ['jwt', 'apple', 'discord', 'facebook', 'github', 'google', 'linkedin', 'twitter', 'didWallet'],
   jwtAlgorithm: process.env.JWT_ALGORITHM,
-  jwtPublicKey: process.env.JWT_PUBLIC_KEY,
+  jwtPublicKey: process.env.JWT_PUBLIC_KEY?.split(String.raw`\n`).join('\n'),
   jwtOptions: {
     algorithm: process.env.JWT_ALGORITHM || 'HS256',
     expiresIn: '30 days'
@@ -329,7 +329,8 @@ const authentication = {
       appId: process.env.GITHUB_APP_ID!,
       key: process.env.GITHUB_CLIENT_ID!,
       secret: process.env.GITHUB_CLIENT_SECRET!,
-      scope: GITHUB_SCOPES
+      scope: GITHUB_SCOPES,
+      privateKey: process.env.GITHUB_PRIVATE_KEY?.split(String.raw`\n`).join('\n')
     },
     google: {
       key: process.env.GOOGLE_CLIENT_ID!,

--- a/packages/server-core/src/hooks/authenticate.ts
+++ b/packages/server-core/src/hooks/authenticate.ts
@@ -70,8 +70,10 @@ export default async (context: HookContext<Application>, next: NextFunction): Pr
   if (context.arguments[1]?.token && context.path === 'project' && context.method === 'update') {
     const appId = config.authentication.oauth.github.appId ? parseInt(config.authentication.oauth.github.appId) : null
     const token = context.arguments[1].token
-    const algorithms = process.env.APP_ENV === 'development' ? 'HS256' : 'RS256'
-    const jwtDecoded = verify(token, config.authentication.secret, { algorithms: [algorithms] })! as JwtPayload
+    if (!config.authentication.oauth.github.privateKey) throw new NotAuthenticated('No GitHub private key configured')
+    const jwtDecoded = verify(token, config.authentication.oauth.github.privateKey, {
+      algorithms: ['RS256']
+    })! as JwtPayload
     if (jwtDecoded.iss == null || parseInt(jwtDecoded.iss) !== appId)
       throw new NotAuthenticated('Invalid app credentials')
     const octoKit = new Octokit({ auth: token })

--- a/packages/server-core/src/projects/project/project.hooks.ts
+++ b/packages/server-core/src/projects/project/project.hooks.ts
@@ -259,14 +259,14 @@ const checkIfProjectExists = async (context: HookContext<ProjectService>) => {
   }
 
   const data: ProjectData[] = Array.isArray(context.data) ? context.data : [context.data]
-
   const projectName = data[0].name!
+  const slashIndex = projectName.indexOf('/')
 
-  const orgName = projectName.slice(0, projectName.indexOf('/'))
-
-  const cleanedProjectName = cleanString(projectName.slice(projectName.indexOf('/')))
-
-  context.projectName = `${orgName}/${cleanedProjectName}`.toLowerCase()
+  if (slashIndex > -1) {
+    const orgName = projectName.slice(0, projectName.indexOf('/'))
+    const cleanedProjectName = cleanString(projectName.slice(projectName.indexOf('/')))
+    context.projectName = `${orgName}/${cleanedProjectName}`.toLowerCase()
+  } else context.projectName = projectName.toLowerCase()
 
   const projectExists = (await context.service._find({
     query: { name: context.projectName, $limit: 1 }

--- a/packages/server-core/src/updateAppConfig.ts
+++ b/packages/server-core/src/updateAppConfig.ts
@@ -120,8 +120,16 @@ export const updateAppConfig = async (): Promise<void> => {
         appConfig.authentication = {
           ...appConfig.authentication,
           ...(dbAuthenticationConfig as any),
+          secret: appConfig.authentication.secret.split(String.raw`\n`).join('\n'),
           authStrategies: authStrategies
         }
+        if (dbAuthenticationConfig.oauth?.github?.privateKey)
+          appConfig.authentication.oauth.github.privateKey = dbAuthenticationConfig.oauth.github.privateKey
+            .split(String.raw`\n`)
+            .join('\n')
+        if (dbAuthenticationConfig.jwtPublicKey)
+          appConfig.authentication.jwtPublicKey = dbAuthenticationConfig.jwtPublicKey.split(String.raw`\n`).join('\n')
+        appConfig.authentication.jwtOptions.algorithm = dbAuthentication.jwtAlgorithm || 'HS256'
       }
     })
     .catch((e) => {


### PR DESCRIPTION
## Summary

Verification of GH JWTs was mistakenly using the apps' secret. A GitHub private key can now be stored in
authentication-settings.oauth.github.privateKey, and the GH JWT auth gets the key from there.

Fixed some bugs with populating JWT config in updateAppConfig.ts

Fixed a naming bug when downloading a project without an org in the name.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
