### PR TITLE
The file browser now always shows the scroll bar if its contents vertically overflow.

### DIFF
--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -61,7 +61,7 @@ function Browser() {
 
   return (
     <div
-      className={twMerge('h-full', isFileDropOver ? 'border-2 border-gray-300' : '')}
+      className={twMerge('h-full overflow-y-scroll', isFileDropOver ? 'border-2 border-gray-300' : '')}
       ref={fileDropRef}
       onContextMenu={(event) => {
         event.preventDefault()


### PR DESCRIPTION
closes https://tsu.atlassian.net/browse/IR-4697 .