### PR TITLE
IR-4358 particle system type

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -618,6 +618,7 @@
       "emitter-shape": "Emitter Shape",
       "emission-bursts": "Emission Bursts",
       "shape-mesh": "Emitter Shape Mesh",
+      "shape-mesh-info": "Drag Gltf or Glb file here (or paste it's file asset url) to set the mesh to use as the emitter shape",
       "start-life": "Start Life",
       "start-size": "Start Size",
       "start-speed": "Start Speed",

--- a/packages/engine/src/scene/components/ParticleSystemComponent.ts
+++ b/packages/engine/src/scene/components/ParticleSystemComponent.ts
@@ -77,13 +77,12 @@ import { VisibleComponent } from '@ir-engine/spatial/src/renderer/components/Vis
 import { useDisposable } from '@ir-engine/spatial/src/resources/resourceHooks'
 import { EntityTreeComponent } from '@ir-engine/spatial/src/transform/components/EntityTree'
 import { TransformComponent } from '@ir-engine/spatial/src/transform/components/TransformComponent'
-import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils'
 import { AssetLoader } from '../../assets/classes/AssetLoader'
 import { useGLTF, useTexture } from '../../assets/functions/resourceLoaderHooks'
 import { GLTFComponent } from '../../gltf/GLTFComponent'
 import { GLTFSnapshotAction } from '../../gltf/GLTFDocumentState'
 import { GLTFSnapshotState, GLTFSourceState } from '../../gltf/GLTFState'
-import getFirstMesh, { getMeshes } from '../util/meshUtils'
+import getFirstMesh, { getMeshes, mergeGeometries } from '../util/meshUtils'
 import { SourceComponent } from './SourceComponent'
 
 export type ParticleSystemRendererInstance = {
@@ -947,8 +946,10 @@ export const ParticleSystemComponent = defineComponent({
         })
         const mergedGeometry = mergeGeometries(geometries)
 
-        componentState.systemParameters.shape.geometry.set(componentState.value.systemParameters.shape.mesh!)
-        metadata.geometries.nested(componentState.value.systemParameters.shape.mesh!).set(mergedGeometry)
+        if (mergedGeometry) {
+          componentState.systemParameters.shape.geometry.set(componentState.value.systemParameters.shape.mesh!)
+          metadata.geometries.nested(componentState.value.systemParameters.shape.mesh!).set(mergedGeometry)
+        }
       }
     }, [shapeMesh])
 

--- a/packages/engine/src/scene/util/meshUtils.ts
+++ b/packages/engine/src/scene/util/meshUtils.ts
@@ -2,7 +2,7 @@
 CPAL-1.0 License
 
 The contents of this file are subject to the Common Public Attribution License
-Version 1.0. (the "License"); you may not use this file except in compliance
+Version 1.0. (the "License") you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
 The License is based on the Mozilla Public License Version 1.1, but Sections 14
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { Mesh, Object3D } from 'three'
+import { AttributeGPUType, BufferAttribute, BufferGeometry, Mesh, Object3D } from 'three'
 
 import iterateObject3D from '@ir-engine/spatial/src/common/functions/iterateObject3D'
 
@@ -46,4 +46,254 @@ export function getMeshes(obj3d: Object3D): Mesh[] {
     false,
     false
   )
+}
+
+/** Merge geometries, (copied from three/examples/jsm/utils/BufferGeometryUtils.js to avoid importing examples file)
+ * @param  {Array<BufferGeometry>} geometries
+ * @param  {Boolean} useGroups
+ * @return {BufferGeometry}
+ */
+export function mergeGeometries(geometries, useGroups = false) {
+  const isIndexed = geometries[0].index !== null
+
+  const attributesUsed = new Set(Object.keys(geometries[0].attributes))
+  const morphAttributesUsed = new Set(Object.keys(geometries[0].morphAttributes))
+
+  const attributes = {}
+  const morphAttributes = {}
+
+  const morphTargetsRelative = geometries[0].morphTargetsRelative
+
+  const mergedGeometry = new BufferGeometry()
+
+  let offset = 0
+
+  for (let i = 0; i < geometries.length; ++i) {
+    const geometry = geometries[i]
+    let attributesCount = 0
+
+    // ensure that all geometries are indexed, or none
+    if (isIndexed !== (geometry.index !== null)) {
+      console.error(
+        'THREE.BufferGeometryUtils: .mergeGeometries() failed with geometry at index ' +
+          i +
+          '. All geometries must have compatible attributes; make sure index attribute exists among all geometries, or in none of them.'
+      )
+      return null
+    }
+
+    // gather attributes, exit early if they're different
+    for (const name in geometry.attributes) {
+      if (!attributesUsed.has(name)) {
+        console.error(
+          'THREE.BufferGeometryUtils: .mergeGeometries() failed with geometry at index ' +
+            i +
+            '. All geometries must have compatible attributes; make sure "' +
+            name +
+            '" attribute exists among all geometries, or in none of them.'
+        )
+        return null
+      }
+
+      if (attributes[name] === undefined) attributes[name] = []
+
+      attributes[name].push(geometry.attributes[name])
+      attributesCount++
+    }
+
+    // ensure geometries have the same number of attributes
+    if (attributesCount !== attributesUsed.size) {
+      console.error(
+        'THREE.BufferGeometryUtils: .mergeGeometries() failed with geometry at index ' +
+          i +
+          '. Make sure all geometries have the same number of attributes.'
+      )
+      return null
+    }
+
+    // gather morph attributes, exit early if they're different
+    if (morphTargetsRelative !== geometry.morphTargetsRelative) {
+      console.error(
+        'THREE.BufferGeometryUtils: .mergeGeometries() failed with geometry at index ' +
+          i +
+          '. .morphTargetsRelative must be consistent throughout all geometries.'
+      )
+      return null
+    }
+
+    for (const name in geometry.morphAttributes) {
+      if (!morphAttributesUsed.has(name)) {
+        console.error(
+          'THREE.BufferGeometryUtils: .mergeGeometries() failed with geometry at index ' +
+            i +
+            '.  .morphAttributes must be consistent throughout all geometries.'
+        )
+        return null
+      }
+
+      if (morphAttributes[name] === undefined) morphAttributes[name] = []
+
+      morphAttributes[name].push(geometry.morphAttributes[name])
+    }
+
+    if (useGroups) {
+      let count
+
+      if (isIndexed) {
+        count = geometry.index.count
+      } else if (geometry.attributes.position !== undefined) {
+        count = geometry.attributes.position.count
+      } else {
+        console.error(
+          'THREE.BufferGeometryUtils: .mergeGeometries() failed with geometry at index ' +
+            i +
+            '. The geometry must have either an index or a position attribute'
+        )
+        return null
+      }
+      mergedGeometry.addGroup(offset, count, i)
+      offset += count
+    }
+  }
+
+  // merge indices
+
+  if (isIndexed) {
+    let indexOffset = 0
+    const mergedIndex = [] as number[]
+
+    for (let i = 0; i < geometries.length; ++i) {
+      const index = geometries[i].index
+
+      for (let j = 0; j < index.count; ++j) {
+        mergedIndex.push(index.getX(j) + indexOffset)
+      }
+      indexOffset += geometries[i].attributes.position.count
+    }
+    mergedGeometry.setIndex(mergedIndex)
+  }
+
+  // merge attributes
+
+  for (const name in attributes) {
+    const mergedAttribute = mergeAttributes(attributes[name])
+
+    if (!mergedAttribute) {
+      console.error(
+        'THREE.BufferGeometryUtils: .mergeGeometries() failed while trying to merge the ' + name + ' attribute.'
+      )
+      return null
+    }
+    mergedGeometry.setAttribute(name, mergedAttribute)
+  }
+
+  // merge morph attributes
+
+  for (const name in morphAttributes) {
+    const numMorphTargets = morphAttributes[name][0].length
+
+    if (numMorphTargets === 0) break
+
+    mergedGeometry.morphAttributes = mergedGeometry.morphAttributes || {}
+    mergedGeometry.morphAttributes[name] = []
+
+    for (let i = 0; i < numMorphTargets; ++i) {
+      const morphAttributesToMerge = [] as BufferAttribute[]
+
+      for (let j = 0; j < morphAttributes[name].length; ++j) {
+        morphAttributesToMerge.push(morphAttributes[name][j][i])
+      }
+
+      const mergedMorphAttribute = mergeAttributes(morphAttributesToMerge)
+
+      if (!mergedMorphAttribute) {
+        console.error(
+          'THREE.BufferGeometryUtils: .mergeGeometries() failed while trying to merge the ' + name + ' morphAttribute.'
+        )
+        return null
+      }
+      mergedGeometry.morphAttributes[name].push(mergedMorphAttribute)
+    }
+  }
+  return mergedGeometry
+}
+
+/**
+ * @param {Array<BufferAttribute>} attributes
+ * @return {BufferAttribute}
+ */
+function mergeAttributes(attributes) {
+  let TypedArray
+  let itemSize
+  let normalized
+  let gpuType = -1
+  let arrayLength = 0
+
+  for (let i = 0; i < attributes.length; ++i) {
+    const attribute = attributes[i]
+
+    if (TypedArray === undefined) TypedArray = attribute.array.constructor
+
+    if (TypedArray !== attribute.array.constructor) {
+      console.error(
+        'THREE.BufferGeometryUtils: .mergeAttributes() failed. BufferAttribute.array must be of consistent array types across matching attributes.'
+      )
+      return null
+    }
+
+    if (itemSize === undefined) itemSize = attribute.itemSize
+
+    if (itemSize !== attribute.itemSize) {
+      console.error(
+        'THREE.BufferGeometryUtils: .mergeAttributes() failed. BufferAttribute.itemSize must be consistent across matching attributes.'
+      )
+      return null
+    }
+
+    if (normalized === undefined) normalized = attribute.normalized
+
+    if (normalized !== attribute.normalized) {
+      console.error(
+        'THREE.BufferGeometryUtils: .mergeAttributes() failed. BufferAttribute.normalized must be consistent across matching attributes.'
+      )
+      return null
+    }
+
+    if (gpuType === -1) gpuType = attribute.gpuType
+
+    if (gpuType !== attribute.gpuType) {
+      console.error(
+        'THREE.BufferGeometryUtils: .mergeAttributes() failed. BufferAttribute.gpuType must be consistent across matching attributes.'
+      )
+      return null
+    }
+    arrayLength += attribute.count * itemSize
+  }
+
+  const array = new TypedArray(arrayLength)
+  const result = new BufferAttribute(array, itemSize, normalized)
+  let offset = 0
+
+  for (let i = 0; i < attributes.length; ++i) {
+    const attribute = attributes[i]
+
+    if (attribute.isInterleavedBufferAttribute) {
+      const tupleOffset = offset / itemSize
+
+      for (let j = 0, l = attribute.count; j < l; j++) {
+        for (let c = 0; c < itemSize; c++) {
+          const value = attribute.getComponent(j, c)
+          result.setComponent(j + tupleOffset, c, value)
+        }
+      }
+    } else {
+      array.set(attribute.array, offset)
+    }
+    offset += attribute.count * itemSize
+  }
+
+  if (gpuType !== undefined) {
+    result.gpuType = gpuType as AttributeGPUType
+  }
+  return result
 }

--- a/packages/spatial/src/renderer/materials/constants/DefaultArgs.ts
+++ b/packages/spatial/src/renderer/materials/constants/DefaultArgs.ts
@@ -53,12 +53,12 @@ export function getDefaultType(value) {
     case 'number':
       return FloatArg.type
     case 'object':
-      if ((value as Texture).isTexture) return TextureArg.type
-      if ((value as Color).isColor) return ColorArg.type
-      if ((value as Vector2).isVector2) return Vec2Arg.type
-      if ((value as Vector3).isVector3) return Vec3Arg.type
-      if ((value as Quaternion).isQuaternion || (value as Vector4).isVector4) return Vec4Arg.type
-      if ((value as Euler).isEuler) return EulerArg.type
+      if ((value as Texture)?.isTexture) return TextureArg.type
+      if ((value as Color)?.isColor) return ColorArg.type
+      if ((value as Vector2)?.isVector2) return Vec2Arg.type
+      if ((value as Vector3)?.isVector3) return Vec3Arg.type
+      if ((value as Quaternion)?.isQuaternion || (value as Vector4)?.isVector4) return Vec4Arg.type
+      if ((value as Euler)?.isEuler) return EulerArg.type
       return ''
     //todo: selects, objects
     default:

--- a/packages/ui/src/components/editor/properties/particle/index.tsx
+++ b/packages/ui/src/components/editor/properties/particle/index.tsx
@@ -68,7 +68,6 @@ import NumericInput from '../../input/Numeric'
 import SelectInput from '../../input/Select'
 import TexturePreviewInput from '../../input/Texture'
 import NodeEditor from '../nodeEditor'
-import ParameterInput from '../parameter'
 
 const ParticleSystemNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
@@ -248,15 +247,11 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
       />
       {particleSystem.systemParameters.shape.type === 'mesh_surface' && (
         <InputGroup name="Shape Mesh" label={t('editor:properties.particle-system.shape-mesh')}>
-          <ModelInput value={particleSystem.systemParameters.shape.mesh!} onChange={onChangeShapeParm('mesh')} />
+          <ModelInput
+            value={particleSystem.systemParameters.shape.mesh!}
+            onRelease={onSetState(particleSystemState.systemParameters.shape.mesh as any)}
+          />
         </InputGroup>
-      )}
-      {particleSystem.systemParameters.shape.type !== 'mesh_surface' && (
-        <ParameterInput
-          entity={`${entity}-shape`}
-          values={particleSystem.systemParameters.shape}
-          onChange={onChangeShapeParm}
-        />
       )}
 
       <InputGroup name="Start Life" label={t('editor:properties.particle-system.start-life')}>

--- a/packages/ui/src/components/editor/properties/particle/index.tsx
+++ b/packages/ui/src/components/editor/properties/particle/index.tsx
@@ -207,7 +207,14 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
           ]}
         />
       </InputGroup>
-
+      {particleSystem.systemParameters.shape.type === 'mesh_surface' && (
+        <InputGroup name="Shape Mesh" label={t('editor:properties.particle-system.shape-mesh')}>
+          <ModelInput
+            value={particleSystem.systemParameters.shape.mesh!}
+            onRelease={onSetState(particleSystemState.systemParameters.shape.mesh as any)}
+          />
+        </InputGroup>
+      )}
       <InputGroup name="Emission Bursts" label={t('editor:properties.particle-system.emission-bursts')}>
         <Button onClick={onAddBurst}>Add Burst</Button>
       </InputGroup>
@@ -245,14 +252,6 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
           )
         }}
       />
-      {particleSystem.systemParameters.shape.type === 'mesh_surface' && (
-        <InputGroup name="Shape Mesh" label={t('editor:properties.particle-system.shape-mesh')}>
-          <ModelInput
-            value={particleSystem.systemParameters.shape.mesh!}
-            onRelease={onSetState(particleSystemState.systemParameters.shape.mesh as any)}
-          />
-        </InputGroup>
-      )}
 
       <InputGroup name="Start Life" label={t('editor:properties.particle-system.start-life')}>
         <ValueGenerator

--- a/packages/ui/src/components/editor/properties/particle/index.tsx
+++ b/packages/ui/src/components/editor/properties/particle/index.tsx
@@ -208,7 +208,11 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
         />
       </InputGroup>
       {particleSystem.systemParameters.shape.type === 'mesh_surface' && (
-        <InputGroup name="Shape Mesh" label={t('editor:properties.particle-system.shape-mesh')}>
+        <InputGroup
+          name="Shape Mesh"
+          label={t('editor:properties.particle-system.shape-mesh')}
+          info={t('editor:properties.particle-system.shape-mesh-info')}
+        >
           <ModelInput
             value={particleSystem.systemParameters.shape.mesh!}
             onRelease={onSetState(particleSystemState.systemParameters.shape.mesh as any)}


### PR DESCRIPTION
## Summary
fix to rename incorrectly displayed and used field "type", this was only used for emitter shape mesh
fix for emitter shape of "geometry"
fix for drag/drop support of geometry into "emitter shape mesh"

## References
[https://tsu.atlassian.net/browse/IR-4358](https://tsu.atlassian.net/browse/IR-4358)

## QA Steps
change particle system emitter shape to type "mesh"
drag a gltf or glb file into the new field below for "emitter mesh shape"
observe particle distribution is now in the shape of your mesh, at proper scale