### PR TITLE
Nudge color picker away from horizontal scroll cutoff

### DIFF
--- a/packages/ui/src/primitives/tailwind/Color/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Color/index.tsx
@@ -72,7 +72,7 @@ export function ColorInput({
       >
         <SketchPicker
           className={twMerge(
-            'absolute z-10 mt-5 scale-0 bg-theme-surface-main focus-within:scale-100 group-focus:scale-100',
+            'absolute right-4 z-10 mt-5 scale-0 bg-theme-surface-main focus-within:scale-100 group-focus:scale-100',
             sketchPickerClassName
           )}
           color={hexColor}


### PR DESCRIPTION
Credit to @MbfloydIR , this added tailwind class will nudge color pickers a safe distance away from the righthand side of properties panels

Closes [IR-4720](https://tsu.atlassian.net/browse/IR-4720).

[IR-4720]: https://tsu.atlassian.net/browse/IR-4720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ