### PR TITLE
Fix contextmenu file selection

### DIFF
--- a/packages/editor/src/panels/files/contextmenu.tsx
+++ b/packages/editor/src/panels/files/contextmenu.tsx
@@ -225,7 +225,7 @@ export function FileContextMenu({
           size="small"
           fullWidth
           onClick={() => {
-            if (!selectedFiles.get(NO_PROXY).includes(file)) {
+            if (!selectedFiles.get(NO_PROXY).some((selectedFile) => selectedFile.key === file.key)) {
               if (selectedFiles.value.length > 1) {
                 selectedFiles.merge([file])
               } else {

--- a/packages/ui/src/primitives/tailwind/Color/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Color/index.tsx
@@ -72,7 +72,7 @@ export function ColorInput({
       >
         <SketchPicker
           className={twMerge(
-            'absolute z-10 mt-5 scale-0 bg-theme-surface-main focus-within:scale-100 group-focus:scale-100',
+            'absolute right-4 z-10 mt-5 scale-0 bg-theme-surface-main focus-within:scale-100 group-focus:scale-100',
             sketchPickerClassName
           )}
           color={hexColor}


### PR DESCRIPTION
If the file browser's context menu is opened while files are already selected, it will add the current file to the selection if it isn't already included. This membership test needs to use `Array::some` for references to objects, not `Array::includes`.

Closes [IR-4216](https://tsu.atlassian.net/browse/IR-4216).

[IR-4216]: https://tsu.atlassian.net/browse/IR-4216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ