### PR TITLE
Fix: storage permission query

### DIFF
--- a/packages/client/public/root-cookie-accessor-template.html
+++ b/packages/client/public/root-cookie-accessor-template.html
@@ -58,7 +58,7 @@
               const hasAccess = await document.hasStorageAccess()
               let storageAccessPermission
               try {
-                await navigator.permissions.query({
+                storageAccessPermission = await navigator.permissions.query({
                   name: 'storage-access'
                 })
               } catch (error) {

--- a/packages/client/public/root-cookie-accessor-template.html
+++ b/packages/client/public/root-cookie-accessor-template.html
@@ -56,9 +56,14 @@
               break
             } else {
               const hasAccess = await document.hasStorageAccess()
-              const storageAccessPermission = await navigator.permissions.query({
-                name: 'storage-access'
-              })
+              let storageAccessPermission = { state: 'denied' } 
+              try {
+                await navigator.permissions.query({
+                  name: 'storage-access'
+                })
+              } catch (error) {
+                console.error('Failed to query storage permission', error)
+              }
               if (hasAccess && storageAccessPermission.state === 'granted') {
                 message.data.hasStorageAccess = hasAccess
                 message.data.cookieSet = cookieSet

--- a/packages/client/public/root-cookie-accessor-template.html
+++ b/packages/client/public/root-cookie-accessor-template.html
@@ -56,12 +56,13 @@
               break
             } else {
               const hasAccess = await document.hasStorageAccess()
-              let storageAccessPermission = { state: 'denied' } 
+              let storageAccessPermission
               try {
                 await navigator.permissions.query({
                   name: 'storage-access'
                 })
               } catch (error) {
+                storageAccessPermission = { state: 'denied' } 
                 console.error('Failed to query storage permission', error)
               }
               if (hasAccess && storageAccessPermission.state === 'granted') {


### PR DESCRIPTION
## Summary
The `navigator.permissions.query()` method throws an error when a browser does not support the requested permission. This behavior is observed in Safari 17.5, causing the app to hang at the loading screen.

This update introduces error handling for unsupported permission queries, ensuring the app continues functioning smoothly without getting stuck.

**See [TypeError](https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query#exceptions)**

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
