### PR TITLE
Added support for using non-root client subdomain in invite redirect

### DIFF
--- a/packages/server-core/src/user/accept-invite/accept-invite.ts
+++ b/packages/server-core/src/user/accept-invite/accept-invite.ts
@@ -26,50 +26,9 @@ Infinite Reality Engine. All Rights Reserved.
 import { acceptInviteMethods, acceptInvitePath } from '@ir-engine/common/src/schemas/user/accept-invite.schema'
 
 import { Application } from '../../../declarations'
-import config from '../../appconfig'
-import logger from '../../ServerLogger'
 import { AcceptInviteService } from './accept-invite.class'
 import acceptInviteDocs from './accept-invite.docs'
 import hooks from './accept-invite.hooks'
-
-/**
- * A function which returns url to the client
- *
- * @param req
- * @param res response to the client
- * @param next
- * @returns redirect url to the client
- */
-async function redirect(ctx, next) {
-  try {
-    const data = ctx.body
-    if (data.error) {
-      ctx.redirect(`${config.client.url}/?error=${data.error as string}`)
-    } else {
-      let link = `${config.client.url}/auth/magiclink?type=login&token=${data.token as string}`
-      if (data.locationName) {
-        let path = `/location/${data.locationName}`
-        if (data.inviteCode) {
-          path += path.indexOf('?') > -1 ? `&inviteCode=${data.inviteCode}` : `?inviteCode=${data.inviteCode}`
-        }
-        if (data.spawnPoint) {
-          path += path.indexOf('?') > -1 ? `&spawnPoint=${data.spawnPoint}` : `?spawnPoint=${data.spawnPoint}`
-        }
-        if (data.spectate) {
-          path += path.indexOf('?') > -1 ? `&spectate=${data.spectate}` : `?spectate=${data.spectate}`
-        }
-        if (data.instanceId) {
-          path += `&instanceId=${data.instanceId}`
-        }
-        link += `&path=${path}`
-      }
-      ctx.redirect(link)
-    }
-  } catch (err) {
-    logger.error(err)
-    throw err
-  }
-}
 
 declare module '@ir-engine/common/declarations' {
   interface ServiceTypes {
@@ -83,8 +42,7 @@ export default (app: Application): void => {
     methods: acceptInviteMethods,
     // You can add additional custom events to be sent to clients here
     events: [],
-    docs: acceptInviteDocs,
-    koa: { after: [redirect] }
+    docs: acceptInviteDocs
   })
 
   const service = app.service(acceptInvitePath)


### PR DESCRIPTION
## Summary

accept-invite was always redirecting to the root client subdomain. With multitenancy setups, however, some invites, like to an instance, need to redirect to a different domain, as scenes will only load on the domain associated with the account that they were created by.

Moved the accept-invite redirect hook into accept-invite.hooks.ts and tweaked it to match feathers context vs. koa context. Also made it use context.params.domain as the domain as top priority, falling back to config.client.url if that's not present. Other projects can make hooks to set context.params.domain before this hook.

Resolves IR-4884

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
