### PR TITLE
Fixed issues with invites

### DIFF
--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -125,7 +125,11 @@
     "share": {
       "lbl-share": "Share",
       "ph-phoneEmail": "Invite by email or phone number",
+      "ph-email": "Invite by email",
+      "ph-phone": "Invite by phone number",
       "lbl-phoneEmail": "Send to email or phone number",
+      "lbl-email": "Send to email",
+      "lbl-phone": "Send to phone number",
       "lbl-copy": "Copy",
       "lbl-send-invite": "Send Invite",
       "lbl-spectator-mode": "Spectator Mode",

--- a/packages/client-core/src/user/UserUISystem.tsx
+++ b/packages/client-core/src/user/UserUISystem.tsx
@@ -30,8 +30,10 @@ import { defineSystem } from '@ir-engine/ecs/src/SystemFunctions'
 import { PresentationSystemGroup } from '@ir-engine/ecs/src/SystemGroups'
 import { getMutableState, none } from '@ir-engine/hyperflux'
 
+import { useHookstate } from '@hookstate/core'
 import useFeatureFlags from '@ir-engine/client-core/src/hooks/useFeatureFlags'
 import { FeatureFlags } from '@ir-engine/common/src/constants/FeatureFlags'
+import { NetworkState } from '@ir-engine/network'
 import { InviteService } from '../social/services/InviteService'
 import { PopupMenuState } from './components/UserMenu/PopupMenuService'
 import AvatarCreatorMenu, { SupportedSdks } from './components/UserMenu/menus/AvatarCreatorMenu'
@@ -78,6 +80,8 @@ const reactor = () => {
     FeatureFlags.Client.Menu.ReadyPlayerMe
   ])
 
+  const worldHostId = useHookstate(getMutableState(NetworkState).hostIds.world).value
+
   useEffect(() => {
     const FaceRetouchingNatural = lazy(() => import('@mui/icons-material/FaceRetouchingNatural'))
     const Send = lazy(() => import('@mui/icons-material/Send'))
@@ -94,7 +98,7 @@ const reactor = () => {
 
     popupMenuState.hotbar.merge({
       [UserMenus.Profile]: { icon: <FaceRetouchingNatural />, tooltip: t('user:menu.settings') },
-      [UserMenus.Share]: { icon: <Send />, tooltip: t('user:menu.sendLocation') }
+      [UserMenus.Share]: { icon: <Send />, tooltip: t('user:menu.sendLocation'), disabled: true }
     })
 
     return () => {
@@ -167,6 +171,12 @@ const reactor = () => {
       })
     }
   }, [rpmEnabled])
+
+  useEffect(() => {
+    const popupMenuState = getMutableState(PopupMenuState)
+
+    if (worldHostId) popupMenuState.hotbar[UserMenus.Share].disabled.set(false)
+  }, [worldHostId])
 
   return null
 }

--- a/packages/client-core/src/user/components/UserMenu/PopupMenuService.ts
+++ b/packages/client-core/src/user/components/UserMenu/PopupMenuService.ts
@@ -31,7 +31,7 @@ export const PopupMenuState = defineState({
     openMenu: null as string | null,
     params: null as object | null,
     menus: {} as { [id: string]: UserMenuPanelType },
-    hotbar: {} as { [id: string]: { icon: React.ReactNode; tooltip: string } }
+    hotbar: {} as { [id: string]: { icon: React.ReactNode; tooltip: string; disabled?: boolean } }
   })
 })
 
@@ -47,7 +47,8 @@ export const PopupMenuServices = {
     menu?: UserMenuPanelType,
     tooltip?: string,
     icon?: React.ReactNode,
-    unregister?: boolean
+    unregister?: boolean,
+    disabled = false
   ) => {
     const s = getMutableState(PopupMenuState)
     if (unregister) {
@@ -55,7 +56,7 @@ export const PopupMenuServices = {
       s.hotbar.merge({ [id]: none })
     } else {
       if (menu) s.menus.merge({ [id]: menu })
-      if (icon) s.hotbar.merge({ [id]: { icon: icon!, tooltip: tooltip! } })
+      if (icon) s.hotbar.merge({ [id]: { icon: icon!, tooltip: tooltip!, disabled: disabled } })
     }
   }
 }

--- a/packages/client-core/src/user/components/UserMenu/index.tsx
+++ b/packages/client-core/src/user/components/UserMenu/index.tsx
@@ -62,6 +62,7 @@ export const UserMenu = () => {
                     title={hotbarItem.tooltip}
                     icon={hotbarItem.icon}
                     sizePx={50}
+                    disabled={hotbarItem.disabled}
                     onClick={() => {
                       if (getState(AppState).showBottomShelf) PopupMenuServices.showPopupMenu(id)
                     }}

--- a/packages/client-core/src/user/components/UserMenu/menus/ShareMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ShareMenu.tsx
@@ -37,7 +37,7 @@ import Menu from '@ir-engine/client-core/src/common/components/Menu'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
 import multiLogger from '@ir-engine/common/src/logger'
 import { EMAIL_REGEX, PHONE_REGEX } from '@ir-engine/common/src/regex'
-import { InviteCode, InviteData } from '@ir-engine/common/src/schema.type.module'
+import { authenticationSettingPath, InviteCode, InviteData } from '@ir-engine/common/src/schema.type.module'
 import { useMutableState } from '@ir-engine/hyperflux'
 import { isShareAvailable } from '@ir-engine/spatial/src/common/functions/DetectFeatures'
 import { EngineState } from '@ir-engine/spatial/src/EngineState'
@@ -46,6 +46,7 @@ import Icon from '@ir-engine/ui/src/primitives/mui/Icon'
 import IconButton from '@ir-engine/ui/src/primitives/mui/IconButton'
 import OutlinedInput from '@ir-engine/ui/src/primitives/mui/OutlinedInput'
 
+import { useFind } from '@ir-engine/common'
 import { InviteService } from '../../../../social/services/InviteService'
 import { AuthState } from '../../../services/AuthService'
 import styles from '../index.module.scss'
@@ -188,6 +189,29 @@ const ShareMenu = (): JSX.Element => {
     navigator.clipboard.writeText(text)
     NotificationService.dispatchNotify(t('user:usermenu.share.linkCopied'), { variant: 'success' })
   }
+  const authSetting = useFind(authenticationSettingPath).data.at(0)
+
+  const getConnectPlaceholder = () => {
+    let smsMagicLink,
+      emailMagicLink = false
+
+    if (authSetting?.authStrategies) {
+      for (let item of authSetting.authStrategies) {
+        if (item.smsMagicLink) smsMagicLink = true
+        if (item.emailMagicLink) emailMagicLink = true
+      }
+
+      if (emailMagicLink && smsMagicLink) {
+        return t('user:usermenu.share.ph-phoneEmail')
+      } else if (emailMagicLink && !smsMagicLink) {
+        return t('user:usermenu.share.ph-email')
+      } else if (!emailMagicLink && smsMagicLink) {
+        return t('user:usermenu.share.ph-phone')
+      } else {
+        return ''
+      }
+    } else return ''
+  }
 
   return (
     <Menu open title={t('user:usermenu.share.title')} onClose={() => PopupMenuServices.showPopupMenu()}>
@@ -259,7 +283,7 @@ const ShareMenu = (): JSX.Element => {
         <InputText
           endIcon={<Icon type="Send" />}
           label={t('user:usermenu.share.shareInvite')}
-          placeholder={t('user:usermenu.share.ph-phoneEmail')}
+          placeholder={getConnectPlaceholder()}
           value={token}
           onChange={(e) => handleChangeToken(e)}
           onEndIconClick={packageInvite}

--- a/packages/server-core/src/user/accept-invite/accept-invite.class.ts
+++ b/packages/server-core/src/user/accept-invite/accept-invite.class.ts
@@ -44,6 +44,7 @@ import logger from '../../ServerLogger'
 
 export interface AcceptInviteParams extends KnexAdapterParams {
   preventUserRelationshipRemoval?: boolean
+  passcode?: string
 }
 
 /**
@@ -89,12 +90,14 @@ export class AcceptInviteService implements ServiceInterface<AcceptInviteParams>
         }
       }
 
-      if (params.query!.passcode !== invite.passcode) {
+      if (params.query?.passcode !== invite.passcode) {
         logger.info('INVALID INVITE PASSCODE')
         return {
           error: 'Invalid Invite Passcode'
         }
       }
+
+      if (params.query?.passcode) delete params.query.passcode
 
       const dateNow = new Date()
 


### PR DESCRIPTION
## Summary

Instance invite menu would throw errors if one tried to send an invite before connected to an instance. Button to open menu is now disabled until one has connected to an instance.

accept-invite would error out when creating a new identity-provider because of better enforcement of validators. params.query.passcode was being used by identity-provider.create but was not a valid query param for that process. Deleting params.query.passcode after it is no longer needed.

Added alternative placeholder text to invite menu's email/phone input based on which magiclink services are enabled.

Resolves IR-4321 and IR-4846

(Opening this against dev, it was previously opened directly onto stg)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
