### PR TITLE
Updated cleanFileName length restrictions

### DIFF
--- a/packages/common/src/utils/cleanFileName.ts
+++ b/packages/common/src/utils/cleanFileName.ts
@@ -27,8 +27,9 @@ Infinite Reality Engine. All Rights Reserved.
  * This method takes a filename (with or without included path) and returns a cleaned version of it.
  * ensures toLower file extension, truncates a file name if too long
  * @param fullFileName
+ * @param useStorageProviderLengthRestrictions
  */
-export const cleanFileNameString = (fullFileName: string): string => {
+export const cleanFileNameString = (fullFileName: string, useStorageProviderLengthRestrictions = false): string => {
   try {
     //extract the path and file name separately
     const lastSlashIndex = fullFileName.lastIndexOf('/')
@@ -42,12 +43,17 @@ export const cleanFileNameString = (fullFileName: string): string => {
     let nameWithoutExtension = fileName.substring(0, lastDotIndex)
     const extension = fileName.substring(lastDotIndex + 1).toLowerCase()
 
-    // Truncate or concat the name if it is too long or too short
-    if (nameWithoutExtension.length > 64) {
-      nameWithoutExtension = nameWithoutExtension.slice(0, 64)
-    } else if (nameWithoutExtension.length < 4) {
-      //file names need to be longer than 3 characters to be valid for s3 - https://docs.weka.io/additional-protocols/s3/s3-limitations
-      nameWithoutExtension = nameWithoutExtension + '0000'
+    //Used by backend uploads to storage provider, which has different length restrictions than other uses
+    if (useStorageProviderLengthRestrictions) {
+      if (nameWithoutExtension.length > 1024) nameWithoutExtension = nameWithoutExtension.slice(0, 1024)
+    } else {
+      // Truncate or concat the name if it is too long or too short
+      if (nameWithoutExtension.length > 1024) {
+        nameWithoutExtension = nameWithoutExtension.slice(0, 64)
+      } else if (nameWithoutExtension.length < 4) {
+        //file names need to be longer than 3 characters to be valid for s3 - https://docs.weka.io/additional-protocols/s3/s3-limitations
+        nameWithoutExtension = nameWithoutExtension + '0000'
+      }
     }
 
     // Combine the name with the lowercase extension

--- a/packages/server-core/src/media/file-browser/file-browser.hooks.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.hooks.ts
@@ -39,7 +39,7 @@ import { FileBrowserService } from './file-browser.class'
 
 const cleanFileName = () => {
   return async (context: HookContext<FileBrowserService>) => {
-    context.data.path = cleanFileNameString(context.data.path)
+    context.data.path = cleanFileNameString(context.data.path, true)
     return context
   }
 }

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1726,7 +1726,7 @@ export const uploadLocalProjectToProvider = async (
   for (const file of filteredFilesInProjectFolder) {
     try {
       const fileResult = fs.readFileSync(file)
-      const filePathRelative = cleanFileNameString(file.slice(projectRootPath.length + 1))
+      const filePathRelative = cleanFileNameString(file.slice(projectRootPath.length + 1), true)
       const key = `projects/${projectName}/${filePathRelative}`
 
       const contentType = getContentType(key)

--- a/scripts/push-client-to-s3.ts
+++ b/scripts/push-client-to-s3.ts
@@ -54,7 +54,7 @@ cli.main(async () => {
         return new Promise(async (resolve) => {
           try {
             const fileResult = fs.readFileSync(file)
-            let filePathRelative = cleanFileNameString(file.slice(clientPath.length))
+            let filePathRelative = cleanFileNameString(file.slice(clientPath.length), true)
             let contentType = getContentType(file)
             const putData: any = {
               Body: fileResult,


### PR DESCRIPTION
## Summary

Object names in S3-compliant stores only have a maximum of 1024 characters, and no minimum. Added a boolean param to cleanFileName that will use that restriction if true, rather than the default of min 4/max 64 characters, which is needed in other places.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
