### PR TITLE
fix world chat input width to be specified

### DIFF
--- a/packages/client-core/src/components/InstanceChat/index.module.scss
+++ b/packages/client-core/src/components/InstanceChat/index.module.scss
@@ -40,9 +40,6 @@
     align-items: center;
     justify-content: flex-end;
     transition: all 0.2s;
-    width: 300px;
-    margin-left: auto;
-    margin-right: 25px;
 
     .chat-input {
       margin-left: 10px;
@@ -92,6 +89,7 @@
           .messageFieldContainer {
             margin: 0;
             padding: 0 5px 0 20px;
+            width: 300px;
 
             label {
               padding-left: 20px;
@@ -343,6 +341,7 @@
   font-size: 0.7rem;
   white-space: pre-wrap;
   font-family: var(--lato);
+  width: 300px;
 }
 
 .animateTop {

--- a/packages/client-core/src/components/InstanceChat/index.module.scss
+++ b/packages/client-core/src/components/InstanceChat/index.module.scss
@@ -89,7 +89,6 @@
           .messageFieldContainer {
             margin: 0;
             padding: 0 5px 0 20px;
-            width: 300px;
 
             label {
               padding-left: 20px;

--- a/packages/client-core/src/components/InstanceChat/index.module.scss
+++ b/packages/client-core/src/components/InstanceChat/index.module.scss
@@ -40,6 +40,9 @@
     align-items: center;
     justify-content: flex-end;
     transition: all 0.2s;
+    width: 300px;
+    margin-left: auto;
+    margin-right: 25px;
 
     .chat-input {
       margin-left: 10px;


### PR DESCRIPTION
## Summary

wrap long user name to specified width to avoid chat input expanding

## References
closes https://tsu.atlassian.net/browse/IR-4938

## QA Steps

![image](https://github.com/user-attachments/assets/5163c647-5b78-4847-9c0e-b37961691ebf)

![image](https://github.com/user-attachments/assets/2b2f17c5-946c-4cc8-aa15-0a4961dcaee3)

