### PR TITLE
fix list view options to accomodate in one line

### DIFF
--- a/packages/editor/src/panels/files/toolbar.tsx
+++ b/packages/editor/src/panels/files/toolbar.tsx
@@ -142,7 +142,7 @@ const ViewModeSettings = () => {
           />
         </InputGroup>
       ) : (
-        <>
+        <div className="flex flex-col items-center">
           <InputGroup
             label={t('editor:layout.filebrowser.view-mode.settings.fontSize')}
             dataTestId="files-panel-view-options-list-font-size-value-input-group"
@@ -151,17 +151,18 @@ const ViewModeSettings = () => {
               min={10}
               max={100}
               step={0.5}
+              width={100}
               value={viewModeSettings.list.fontSize.value}
               onChange={viewModeSettings.list.fontSize.set}
               onRelease={viewModeSettings.list.fontSize.set}
             />
           </InputGroup>
 
-          <div>
+          <div className="w-full">
             <div className="mt-1 flex flex-auto text-white">
               <label>{t('editor:layout.filebrowser.view-mode.settings.select-listColumns')}</label>
             </div>
-            <div className="flex-col">
+            <div>
               {availableTableColumns.map((column) => (
                 <InputGroup
                   label={t(`editor:layout.filebrowser.table-list.headers.${column}`)}
@@ -175,7 +176,7 @@ const ViewModeSettings = () => {
               ))}
             </div>
           </div>
-        </>
+        </div>
       )}
     </Popup>
   )


### PR DESCRIPTION
## Summary

made the layout of list view options to columnar instead of row. this makes the checkboxes inputs in one line

## References
closes https://tsu.atlassian.net/browse/IR-4870

## QA Steps

![image](https://github.com/user-attachments/assets/90129351-4381-42c9-ab49-f3bb96698fad)
