### PR TITLE
Fixes for importing project files

### DIFF
--- a/packages/server-core/src/seeder-config.ts
+++ b/packages/server-core/src/seeder-config.ts
@@ -6,8 +6,8 @@ Version 1.0. (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
 The License is based on the Mozilla Public License Version 1.1, but Sections 14
-and 15 have been added to cover use of software over a computer network and 
-provide for limited attribution for the Original Developer. In addition, 
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
 Exhibit A has been modified to be consistent with Exhibit B.
 
 Software distributed under the License is distributed on an "AS IS" basis,
@@ -19,7 +19,7 @@ The Original Code is Infinite Reality Engine.
 The Original Developer is the Initial Developer. The Initial Developer of the
 Original Code is the Infinite Reality Engine team.
 
-All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023
 Infinite Reality Engine. All Rights Reserved.
 */
 
@@ -41,41 +41,53 @@ import { socialSeeds } from './social/seeder-config'
 import { userSeeds } from './user/seeder-config'
 
 const installedProjects = fs.existsSync(path.resolve(__dirname, '../../projects/projects'))
-  ? fs
-      .readdirSync(path.resolve(__dirname, '../../projects/projects'), { withFileTypes: true })
-      .filter((orgDir) => orgDir.isDirectory())
-      .map((orgDir) => {
-        return fs
-          .readdirSync(path.resolve(__dirname, '../../projects/projects', orgDir.name), { withFileTypes: true })
-          .filter((projectDir) => projectDir.isDirectory())
-          .map((projectDir) => `${orgDir.name}/${projectDir.name}`)
-      })
-      .flat()
-      .map((projectName) => {
-        try {
-          const configPath = `../../projects/projects/${projectName}/xrengine.config.ts`
-          const config: ProjectConfigInterface = require(configPath).default
-          if (!config.databaseSeed) return null
-          return path.join(projectName, config.databaseSeed)
-        } catch (e) {
-          // console.log(e)
-        }
-      })
-      .filter((hasServices) => !!hasServices)
-      .map((seedDir) => require(`../../projects/projects/${seedDir}`).default)
-      .flat()
-  : []
+  ? async () => {
+      const projects = fs
+        .readdirSync(path.resolve(__dirname, '../../projects/projects'), { withFileTypes: true })
+        .filter((orgDir) => orgDir.isDirectory())
+        .map((orgDir) => {
+          return fs
+            .readdirSync(path.resolve(__dirname, '../../projects/projects', orgDir.name), { withFileTypes: true })
+            .filter((projectDir) => projectDir.isDirectory())
+            .map((projectDir) => `${orgDir.name}/${projectDir.name}`)
+        })
+        .flat()
+      const seederDirs = (
+        await Promise.all(
+          projects.map(async (projectName) => {
+            try {
+              const configPath = `../../projects/projects/${projectName}/xrengine.config.ts`
+              const config: ProjectConfigInterface = (await import(configPath)).default
+              if (!config.databaseSeed) return null
+              return path.join(projectName, config.databaseSeed)
+            } catch (e) {
+              // console.log(e)
+            }
+          })
+        )
+      ).filter((hasServices) => !!hasServices)
+      return (
+        await Promise.all(
+          seederDirs.map(async (seedDir) => (await import(`../../projects/projects/${seedDir}`)).default)
+        )
+      ).flat()
+    }
+  : async () => []
 
-export const knexSeeds: Array<KnexSeed> = [
-  ...routeSeeds,
-  ...analyticsSeeds,
-  ...settingSeeds,
-  ...scopeSeeds,
-  ...userSeeds,
-  ...socialSeeds,
-  ...projectSeeds,
-  ...mediaSeeds,
-  ...networkingSeeds,
-  ...integrationsSeeds,
-  ...installedProjects
-]
+export const knexSeeds = (): Promise<Array<KnexSeed>> => {
+  return installedProjects().then((installedProjectSeeds: KnexSeed[]) => {
+    return [
+      ...routeSeeds,
+      ...analyticsSeeds,
+      ...settingSeeds,
+      ...scopeSeeds,
+      ...userSeeds,
+      ...socialSeeds,
+      ...projectSeeds,
+      ...mediaSeeds,
+      ...networkingSeeds,
+      ...integrationsSeeds,
+      ...installedProjectSeeds
+    ]
+  })
+}

--- a/packages/server-core/src/seeder.ts
+++ b/packages/server-core/src/seeder.ts
@@ -41,8 +41,9 @@ export async function seeder(app: Application, forceRefresh: boolean, prepareDb:
   if (forceRefresh || prepareDb) {
     logger.info('Seeding or preparing database')
 
+    const seeds = await knexSeeds()
     const knexClient = app.get('knexClient')
-    for (const seedFile of knexSeeds) {
+    for (const seedFile of seeds) {
       logger.info('Seeding', seedFile)
       await seedFile.seed(knexClient)
       logger.info('Finished seeding', seedFile)

--- a/packages/server-core/src/services.ts
+++ b/packages/server-core/src/services.ts
@@ -47,32 +47,42 @@ import UserServices from './user/services'
 import WorldServices from './world/services'
 
 const installedProjects = fs.existsSync(path.resolve(__dirname, '../../projects/projects'))
-  ? fs
-      .readdirSync(path.resolve(__dirname, '../../projects/projects'), { withFileTypes: true })
-      .filter((orgDir) => orgDir.isDirectory())
-      .map((orgDir) => {
-        return fs
-          .readdirSync(path.resolve(__dirname, '../../projects/projects', orgDir.name), { withFileTypes: true })
-          .filter((projectDir) => projectDir.isDirectory())
-          .map((projectDir) => `${orgDir.name}/${projectDir.name}`)
-      })
-      .flat()
-      .map((projectName) => {
-        try {
-          const configPath = `../../projects/projects/${projectName}/xrengine.config.ts`
-          const config: ProjectConfigInterface = require(configPath).default
-          if (!config.services) return null
-          return path.join(projectName, config.services)
-        } catch (e) {
-          // console.log(e)
-        }
-      })
-      .filter((hasServices) => !!hasServices)
-      .map((servicesDir) => {
-        return require(`../../projects/projects/${servicesDir}`).default as (app: Application) => void
-      })
-      .flat()
-  : []
+  ? async () => {
+      const projects = fs
+        .readdirSync(path.resolve(__dirname, '../../projects/projects'), { withFileTypes: true })
+        .filter((orgDir) => orgDir.isDirectory())
+        .map((orgDir) => {
+          return fs
+            .readdirSync(path.resolve(__dirname, '../../projects/projects', orgDir.name), { withFileTypes: true })
+            .filter((projectDir) => projectDir.isDirectory())
+            .map((projectDir) => `${orgDir.name}/${projectDir.name}`)
+        })
+        .flat()
+      const servicesDirs = (
+        await Promise.all(
+          projects.map(async (projectName) => {
+            try {
+              const configPath = `../../projects/projects/${projectName}/xrengine.config.ts`
+              let config: ProjectConfigInterface = (await import(configPath)).default
+              if (!config.services) return null
+              return path.join(projectName, config.services as string)
+            } catch (e) {
+              console.log(e)
+            }
+          })
+        )
+      ).filter((hasServices) => !!hasServices)
+
+      return (
+        await Promise.all(
+          servicesDirs.map(
+            async (servicesDir) =>
+              (await import(`../../projects/projects/${servicesDir}`)).default as (app: Application) => void
+          )
+        )
+      ).flat()
+    }
+  : async () => []
 
 const services = [
   ...ClusterServices,
@@ -94,5 +104,6 @@ const services = [
 ]
 
 export default (app: Application) => {
-  services.concat(installedProjects).forEach((service) => app.configure(service))
+  services.forEach((service) => app.configure(service))
+  installedProjects().then((projects) => projects.forEach((service) => app.configure(service)))
 }


### PR DESCRIPTION
## Summary

Imports of project config, seeder, and service files were using require, and failing because of new ESM spec. Reworked those use use import, which required making the functions that imported and returned those files async.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
