### PR TITLE
Set NODE_ENV to production when running dev-api-server

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,7 +34,7 @@
     "check-errors": "tsc --noemit",
     "dev": "cross-env APP_ENV=development concurrently -n server,instanceserver,mediaserver,files -c '#FF9800,#A2789C,#00908F,#F93822' \"vite-node src/index.ts\" \"cd ../instanceserver && npm run dev\" \"cd ../instanceserver && npm run dev-channel\"",
     "start": "cross-env APP_ENV=production vite-node src/index.ts",
-    "dev-api-server": "vite-node src/index.ts",
+    "dev-api-server": "NODE_ENV=production vite-node src/index.ts",
     "dev-api-server-nossl": "cross-env NOSSL=true vite-node src/index.ts",
     "dev-nossl": "concurrently \"cross-env NOSSL=true vite-node src/index.ts\" \"cd ../instanceserver && cross-env NOSSL=true vite-node src/index.ts\"",
     "dev-reinit-db": "cross-env FORCE_DB_REFRESH=true vite-node src/index.ts",


### PR DESCRIPTION
## Summary

If NODE_ENV is `development`, authentication-oauth will force the redirect_uri to http, and will
add the port on again.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
