### PR TITLE
Force display precision on UI

### DIFF
--- a/packages/ui/src/components/editor/input/Numeric/index.tsx
+++ b/packages/ui/src/components/editor/input/Numeric/index.tsx
@@ -34,6 +34,7 @@ import { twMerge } from 'tailwind-merge'
 import Text from '../../../../primitives/tailwind/Text'
 
 function toPrecisionString(value: number, precision?: number) {
+  if (value === 0) return '0.00'
   if (precision && precision <= 1) {
     const numDigits = Math.abs(Math.log10(precision))
     const minimumFractionDigits = Math.min(numDigits, 2)
@@ -98,15 +99,7 @@ const NumericInput = ({
       onChange(roundedValue)
     }
 
-    tempValue.set(
-      Number(
-        roundedValue.toLocaleString('fullwide', {
-          useGrouping: false,
-          minimumFractionDigits: 0,
-          maximumFractionDigits: Math.abs(Math.log10(precision || 0)) + 1
-        })
-      )
-    )
+    tempValue.set(Number(toPrecisionString(roundedValue, precision)))
     focused.set(focus)
   }
 
@@ -140,15 +133,7 @@ const NumericInput = ({
   }
 
   const handleFocus = () => {
-    tempValue.set(
-      Number(
-        value.toLocaleString('fullwide', {
-          useGrouping: false,
-          minimumFractionDigits: 0,
-          maximumFractionDigits: Math.abs(Math.log10(precision || 0)) + 1
-        })
-      )
-    )
+    tempValue.set(Number(toPrecisionString(value, displayPrecision)))
     focused.set(true)
   }
 


### PR DESCRIPTION
This pull request includes a commit that forces the display precision on the UI. The commit modifies the `NumericInput` component to ensure that the displayed value has the specified precision. It introduces a new function `toPrecisionString` that handles the precision formatting. The commit also updates the `onChange` and `handleFocus` functions to use the `toPrecisionString` function for setting the temporary value and focused state respectively.