### PR TITLE
Fixing a null check on a reactive proxy and a mixup with entities.

### DIFF
--- a/packages/engine/src/scene/components/ParticleSystemComponent.ts
+++ b/packages/engine/src/scene/components/ParticleSystemComponent.ts
@@ -913,7 +913,7 @@ export const ParticleSystemComponent = defineComponent({
     })
     //@todo: this is a hack to make trail rendering mode work correctly. We need to find out why an additional snapshot is needed
     useEffect(() => {
-      if (gltfComponent && !GLTFComponent.isSceneLoaded(entity)) return
+      if (gltfComponent?.value && !GLTFComponent.isSceneLoaded(rootEntity)) return
       if (refreshed.value) return
 
       //if (componentState.systemParameters.renderMode.value === RenderMode.Trail) {


### PR DESCRIPTION
Closes https://tsu.atlassian.net/browse/IR-5048 .