### PR TITLE
IR-4707 hierarchy duplication and reordering bugs

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.test.tsx
+++ b/packages/editor/src/functions/EditorControlFunctions.test.tsx
@@ -637,14 +637,14 @@ describe('EditorControlFunctions', () => {
       const childEntity = UUIDComponent.getEntityByUUID(childUUID)
       const sourceID = getComponent(nodeEntity, SourceComponent)
 
-      EditorControlFunctions.reparentObject([childEntity], null, rootEntity)
+      EditorControlFunctions.reparentObject([childEntity], null, null, rootEntity)
 
       applyIncomingActions()
 
       const newSnapshot = getState(GLTFSnapshotState)[sourceID].snapshots[1]
       assert.equal(newSnapshot.scenes![0].nodes![0], 0)
       assert.equal(newSnapshot.scenes![0].nodes![1], 1)
-      assert(!newSnapshot.nodes![0].children)
+      assert.equal(newSnapshot.nodes![0].children?.length!, 0)
     })
 
     it('should reparent an object to another object', () => {
@@ -682,7 +682,7 @@ describe('EditorControlFunctions', () => {
       const node2Entity = UUIDComponent.getEntityByUUID(node2UUID)
       const sourceID = getComponent(nodeEntity, SourceComponent)
 
-      EditorControlFunctions.reparentObject([node2Entity], null, nodeEntity)
+      EditorControlFunctions.reparentObject([node2Entity], null, null, nodeEntity)
 
       applyIncomingActions()
 
@@ -728,13 +728,13 @@ describe('EditorControlFunctions', () => {
       const childEntity = UUIDComponent.getEntityByUUID(childUUID)
       const sourceID = getComponent(nodeEntity, SourceComponent)
 
-      EditorControlFunctions.reparentObject([childEntity], nodeEntity, rootEntity)
+      EditorControlFunctions.reparentObject([childEntity], nodeEntity, null, rootEntity)
 
       applyIncomingActions()
 
       const newSnapshot = getState(GLTFSnapshotState)[sourceID].snapshots[1]
-      assert.equal(newSnapshot.scenes![0].nodes![0], 1)
-      assert.equal(newSnapshot.scenes![0].nodes![1], 0)
+      assert.equal(newSnapshot.nodes![0].name, 'child')
+      assert.equal(newSnapshot.nodes![1].name, 'node')
       assert(!newSnapshot.nodes![0].children)
     })
 
@@ -782,7 +782,7 @@ describe('EditorControlFunctions', () => {
       const childEntity = UUIDComponent.getEntityByUUID(childUUID)
       const sourceID = getComponent(nodeEntity, SourceComponent)
 
-      EditorControlFunctions.reparentObject([node2Entity], childEntity, nodeEntity)
+      EditorControlFunctions.reparentObject([node2Entity], childEntity, null, nodeEntity)
 
       applyIncomingActions()
 

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import { GLTF } from '@gltf-transform/core'
 import { Euler, Matrix4, Quaternion, Vector3 } from 'three'
 
-import { EntityUUID, generateEntityUUID, SetComponentType, UUIDComponent } from '@ir-engine/ecs'
+import { EntityUUID, generateEntityUUID, getMutableComponent, SetComponentType, UUIDComponent } from '@ir-engine/ecs'
 import {
   Component,
   componentJsonDefaults,
@@ -524,13 +524,13 @@ const scaleObject = (entities: Entity[], scales: Vector3[], overrideScale = fals
   }
 }
 
-const reparentObject = (entities: Entity[], before?: Entity | null, parent = getState(EditorState).rootEntity) => {
+const reparentObject = (
+  entities: Entity[],
+  before?: Entity | null,
+  after?: Entity | null,
+  parent = getState(EditorState).rootEntity
+) => {
   const scenes = getSourcesForEntities(entities)
-
-  const targetSceneID = getComponent(parent, SourceComponent)
-  const nodeData = [] as GLTF.INode[]
-
-  const newParentUUID = getComponent(parent, UUIDComponent)
 
   for (const [sceneID, entities] of Object.entries(scenes)) {
     const gltf = GLTFSnapshotState.cloneCurrentSnapshot(sceneID)
@@ -540,18 +540,6 @@ const reparentObject = (entities: Entity[], before?: Entity | null, parent = get
 
       const entityUUID = getComponent(entity, UUIDComponent)
       const nodeIndex = gltf.data.nodes!.findIndex((n) => n.extensions?.[UUIDComponent.jsonID] === entityUUID)
-
-      const isCurrentlyChildOfRoot = gltf.data.scenes![0].nodes.includes(nodeIndex)
-
-      if (isCurrentlyChildOfRoot) {
-        gltf.data.scenes![0].nodes.splice(gltf.data.scenes![0].nodes.indexOf(nodeIndex), 1)
-      } else {
-        const currentParentNode = getParentNodeByUUID(gltf.data, entityUUID)
-        if (!currentParentNode) continue
-        const currentParentNodeIndex = currentParentNode.children!.indexOf(nodeIndex)
-        currentParentNode.children!.splice(currentParentNodeIndex, 1)
-        if (!currentParentNode.children?.length) delete currentParentNode.children
-      }
 
       // Ensure the entity Transform remains unmodified when reparented
       const node = getGLTFNodeByUUID(gltf.data, entityUUID) // Get the GLTF Node for the entity
@@ -566,71 +554,243 @@ const reparentObject = (entities: Entity[], before?: Entity | null, parent = get
           .toArray()
       }
 
-      if (targetSceneID === sceneID) {
-        const isParentRoot = parent === getState(EditorState).rootEntity
+      const newParentUUID = getComponent(parent, UUIDComponent)
+      const isNewParentRoot = parent === getState(EditorState).rootEntity
 
-        // Add to new parent
-        if (isParentRoot) {
-          if (before) {
-            const beforeIndex = gltf.data.nodes!.findIndex(
-              (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent)
-            )
-            gltf.data.scenes![0].nodes.splice(beforeIndex, 0, nodeIndex)
-            const replacingNode = structuredClone(gltf.data.nodes?.[nodeIndex])!
-            gltf.data.nodes?.splice(nodeIndex, 1)
-            gltf.data.nodes?.splice(beforeIndex, 0, replacingNode)
-          } else {
-            gltf.data.scenes![0].nodes.push(nodeIndex)
-            gltf.data.nodes?.push(gltf.data.nodes[nodeIndex])
-          }
+      const entityTreeComponent = getMutableComponent(entity, EntityTreeComponent)
+      const oldParent = entityTreeComponent.parentEntity.value
+      const isOldParentRoot = oldParent === getState(EditorState).rootEntity
+      const oldParentUUID = getComponent(oldParent, UUIDComponent)
+
+      if (entityTreeComponent.parentEntity.value != parent) {
+        entityTreeComponent.parentEntity.set(parent)
+      }
+
+      // gltf.data.scenes![0].nodes is the child array of the root parent
+      // newParentNode.children is the child array of a non root parent
+      // gltf.data.nodes is the node data used for reference, its index should not change, unless it is a child on the root parent, then it is used to order the root parent's children
+
+      //build a index ref table for the lookup table to be used to correct child index value and maintain data integrity
+      let indexConvertArray: number[] = []
+      gltf.data.nodes?.forEach((value, index) => {
+        indexConvertArray.push(index)
+      })
+
+      //if the new parent is the root parent, update the look up table since it is used for root parent child order
+      //update the index conver array to match so it can be used later to correct child index value and maintain data integrity
+      if (isNewParentRoot && gltf.data.nodes) {
+        if (before) {
+          const nodeData = gltf.data.nodes.splice(nodeIndex, 1)
+          indexConvertArray.splice(nodeIndex, 1)
+          const beforeNodeIndex = gltf.data.nodes.findIndex((n) => {
+            return n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent)
+          })
+          gltf.data.nodes.splice(beforeNodeIndex, 0, nodeData![0])
+          indexConvertArray.splice(beforeNodeIndex, 0, nodeIndex)
         } else {
-          const newParentNode = getGLTFNodeByUUID(gltf.data, newParentUUID)
-          if (newParentNode) {
-            if (!newParentNode.children) newParentNode.children = []
-            if (before) {
-              const beforeIndex = newParentNode.children.findIndex(
-                (n) =>
-                  n ===
-                  gltf.data.nodes!.find(
-                    (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent)
-                  )
-              )
-              newParentNode.children.splice(beforeIndex, 0, nodeIndex)
-            } else {
-              newParentNode.children.push(nodeIndex)
+          if (after) {
+            const afterNodeIndex = gltf.data.nodes.findIndex((n) => {
+              return n.extensions?.[UUIDComponent.jsonID] === getComponent(after, UUIDComponent)
+            })
+            const afterIndex = gltf.data.scenes![0].nodes.findIndex((n) => {
+              return n === afterNodeIndex
+            })
+            let spliceIndex = gltf.data.scenes![0].nodes[afterIndex + 1]
+            if (nodeIndex < spliceIndex) {
+              spliceIndex -= 1
             }
+
+            const nodeData = gltf.data.nodes.splice(nodeIndex, 1)
+            indexConvertArray.splice(nodeIndex, 1)
+
+            gltf.data.nodes.splice(spliceIndex, 0, nodeData![0])
+            indexConvertArray.splice(spliceIndex, 0, nodeIndex)
+          } else {
+            const nodeData = gltf.data.nodes.splice(nodeIndex, 1)
+            indexConvertArray.splice(nodeIndex, 1)
+            gltf.data.nodes?.push(nodeData![0])
+            indexConvertArray.push(nodeIndex)
           }
         }
-      } else {
-        node && nodeData.push(node)
       }
-    }
 
-    dispatchAction(GLTFSnapshotAction.createSnapshot(gltf))
-  }
+      // make the old parent children array into a homoginize ref
+      let oldParentChildArray = gltf.data.scenes![0].nodes
+      if (!isOldParentRoot) {
+        const oldParentNode = getGLTFNodeByUUID(gltf.data, oldParentUUID)
+        if (oldParentNode) {
+          if (!oldParentNode.children) oldParentNode.children = []
+          oldParentChildArray = oldParentNode.children
+        }
+      }
 
-  if (!Object.keys(scenes).includes(targetSceneID)) {
-    const gltf = GLTFSnapshotState.cloneCurrentSnapshot(targetSceneID)
-    for (const node of nodeData) {
-      const nodeIndex = gltf.data.nodes!.push(node) - 1
-      gltf.data.scenes![0].nodes.push(nodeIndex)
+      // make the new parent children array into a homoginize ref
+      let newParentChildArray = gltf.data.scenes![0].nodes
+      if (!isNewParentRoot) {
+        const newParentNode = getGLTFNodeByUUID(gltf.data, newParentUUID)
+        if (newParentNode) {
+          if (!newParentNode.children) newParentNode.children = []
+          newParentChildArray = newParentNode.children
+        }
+      }
 
-      const newParentNode = getGLTFNodeByUUID(gltf.data, newParentUUID)!
-      if (!newParentNode.children) newParentNode.children = []
+      //remove from old parent's child array
+      const oldParentChildIndex = oldParentChildArray.findIndex((i) => {
+        return i === nodeIndex
+      })
+      if (oldParentChildIndex >= 0) {
+        oldParentChildArray.splice(oldParentChildIndex, 1)
+      }
+
+      //add to new parent's child array
       if (before) {
-        const beforeIndex = newParentNode.children.findIndex(
-          (n) =>
-            n ===
-            gltf.data.nodes!.find((n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent))
-        )
-        newParentNode.children.splice(beforeIndex, 0, nodeIndex)
+        const beforeUuid = getComponent(before, UUIDComponent)
+        const beforeNodeIndex = gltf.data.nodes!.findIndex((n) => {
+          const nUuid = n.extensions?.[UUIDComponent.jsonID]
+          return nUuid === beforeUuid
+        })
+        const beforeIndex = newParentChildArray.findIndex((n) => {
+          return n === beforeNodeIndex
+        })
+        newParentChildArray.splice(beforeIndex, 0, nodeIndex)
       } else {
-        newParentNode.children.push(nodeIndex)
+        newParentChildArray.push(nodeIndex)
       }
+
+      //loop through the root parent children and update the child index values
+      gltf.data.scenes![0].nodes.forEach((value, index) => {
+        gltf.data.scenes![0].nodes[index] = indexConvertArray.indexOf(value)
+      })
+
+      //loop through the children of the parent nodes and update the child index values
+      gltf.data.nodes?.forEach((value, index) => {
+        const loopParentUuid: string = String(value.extensions?.[UUIDComponent.jsonID])
+        const loopParentNode = getGLTFNodeByUUID(gltf.data, loopParentUuid)
+        if (loopParentNode) {
+          if (loopParentNode.children) {
+            loopParentNode.children?.forEach((value, index) => {
+              if (loopParentNode.children) {
+                loopParentNode.children[index] = indexConvertArray.indexOf(value)
+              }
+            })
+          }
+        }
+      })
     }
+
     dispatchAction(GLTFSnapshotAction.createSnapshot(gltf))
   }
 }
+
+// const reparentObject = (entities: Entity[], before?: Entity | null, parent = getState(EditorState).rootEntity) => {
+//   const scenes = getSourcesForEntities(entities)
+//
+//   const targetSceneID = getComponent(parent, SourceComponent)
+//   const nodeData = [] as GLTF.INode[]
+//
+//   const newParentUUID = getComponent(parent, UUIDComponent)
+//
+//   for (const [sceneID, entities] of Object.entries(scenes)) {
+//     const gltf = GLTFSnapshotState.cloneCurrentSnapshot(sceneID)
+//
+//     for (const entity of entities) {
+//       if (entity === parent) continue
+//
+//       const entityUUID = getComponent(entity, UUIDComponent)
+//       const nodeIndex = gltf.data.nodes!.findIndex((n) => n.extensions?.[UUIDComponent.jsonID] === entityUUID)
+//
+//       const isCurrentlyChildOfRoot = gltf.data.scenes![0].nodes.includes(nodeIndex)
+//
+//       if (isCurrentlyChildOfRoot) {
+//         gltf.data.scenes![0].nodes.splice(gltf.data.scenes![0].nodes.indexOf(nodeIndex), 1)
+//       } else {
+//         const currentParentNode = getParentNodeByUUID(gltf.data, entityUUID)
+//         if (!currentParentNode) continue
+//         const currentParentNodeIndex = currentParentNode.children!.indexOf(nodeIndex)
+//         currentParentNode.children!.splice(currentParentNodeIndex, 1)
+//         if (!currentParentNode.children?.length) delete currentParentNode.children
+//       }
+//
+//       // Ensure the entity Transform remains unmodified when reparented
+//       const node = getGLTFNodeByUUID(gltf.data, entityUUID) // Get the GLTF Node for the entity
+//       if (node) {
+//         // Get the transforms for both entitites
+//         const parentTransform = getComponent(parent, TransformComponent)
+//         const entityTransform = getComponent(entity, TransformComponent)
+//         // Calculate the new matrix relative to the new parent entity, and apply the matrix to its GLTF node.matrix
+//         node.matrix = tempMatrix4
+//           .copy(entityTransform.matrixWorld)
+//           .premultiply(parentTransform.matrixWorld.clone().invert())
+//           .toArray()
+//       }
+//
+//       if (targetSceneID === sceneID) {
+//         const isParentRoot = parent === getState(EditorState).rootEntity
+//
+//         // Add to new parent
+//         if (isParentRoot) {
+//           if (before) {
+//             const beforeIndex = gltf.data.nodes!.findIndex(
+//               (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent)
+//             )
+//             gltf.data.scenes![0].nodes.splice(beforeIndex, 0, nodeIndex)
+//             const replacingNode = structuredClone(gltf.data.nodes?.[nodeIndex])!
+//             gltf.data.nodes?.splice(nodeIndex, 1)
+//             gltf.data.nodes?.splice(beforeIndex, 0, replacingNode)
+//           } else {
+//             gltf.data.scenes![0].nodes.push(nodeIndex)
+//             const replacingNode = structuredClone(gltf.data.nodes?.[nodeIndex])!
+//             gltf.data.nodes?.push(replacingNode)
+//             gltf.data.nodes?.splice(nodeIndex, 1)
+//           }
+//         } else {
+//           const newParentNode = getGLTFNodeByUUID(gltf.data, newParentUUID)
+//           if (newParentNode) {
+//             if (!newParentNode.children) newParentNode.children = []
+//             if (before) {
+//               const beforeIndex = newParentNode.children.findIndex(
+//                 (n) =>
+//                   n ===
+//                   gltf.data.nodes!.find(
+//                     (n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent)
+//                   )
+//               )
+//               newParentNode.children.splice(beforeIndex, 0, nodeIndex)
+//             } else {
+//               newParentNode.children.push(nodeIndex)
+//             }
+//           }
+//         }
+//       } else {
+//         node && nodeData.push(node)
+//       }
+//     }
+//
+//     dispatchAction(GLTFSnapshotAction.createSnapshot(gltf))
+//   }
+//
+//   if (!Object.keys(scenes).includes(targetSceneID)) {
+//     const gltf = GLTFSnapshotState.cloneCurrentSnapshot(targetSceneID)
+//     for (const node of nodeData) {
+//       const nodeIndex = gltf.data.nodes!.push(node) - 1
+//       gltf.data.scenes![0].nodes.push(nodeIndex)
+//
+//       const newParentNode = getGLTFNodeByUUID(gltf.data, newParentUUID)!
+//       if (!newParentNode.children) newParentNode.children = []
+//       if (before) {
+//         const beforeIndex = newParentNode.children.findIndex(
+//           (n) =>
+//             n ===
+//             gltf.data.nodes!.find((n) => n.extensions?.[UUIDComponent.jsonID] === getComponent(before, UUIDComponent))
+//         )
+//         newParentNode.children.splice(beforeIndex, 0, nodeIndex)
+//       } else {
+//         newParentNode.children.push(nodeIndex)
+//       }
+//     }
+//     dispatchAction(GLTFSnapshotAction.createSnapshot(gltf))
+//   }
+// }
 
 /** @todo - grouping currently doesnt take into account parentEntity or beforeEntity */
 const groupObjects = (entities: Entity[]) => {

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -244,13 +244,16 @@ export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' 
 
     if (node) {
       if (place === 'Before') {
+        console.log('before!!')
         const entityTreeComponent = getOptionalComponent(node.entity, EntityTreeComponent)
         parentNode = entityTreeComponent?.parentEntity
-        beforeNode = node.entity
+        const parentTreeComponent = getOptionalComponent(entityTreeComponent?.parentEntity!, EntityTreeComponent)
+        beforeNode = parentTreeComponent ? parentTreeComponent.children[node.childIndex] : node.entity
       } else if (place === 'After') {
         const entityTreeComponent = getOptionalComponent(node.entity, EntityTreeComponent)
         parentNode = entityTreeComponent?.parentEntity
         const parentTreeComponent = getOptionalComponent(entityTreeComponent?.parentEntity!, EntityTreeComponent)
+        console.log('after!!')
         if (
           parentTreeComponent &&
           !node.lastChild &&

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -239,38 +239,44 @@ export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' 
   }
 
   const dropItem = (item: FileDataType | DnDFileType | DragItemType, monitor: DropTargetMonitor): void => {
-    let parentNode: Entity | undefined = undefined
-    let beforeNode: Entity | undefined = undefined
+    let parentNode: Entity | undefined
+    let beforeNode: Entity = UndefinedEntity
+    let afterNode: Entity = UndefinedEntity
 
     if (node) {
-      if (place === 'Before') {
-        console.log('before!!')
-        const entityTreeComponent = getOptionalComponent(node.entity, EntityTreeComponent)
-        parentNode = entityTreeComponent?.parentEntity
-        const parentTreeComponent = getOptionalComponent(entityTreeComponent?.parentEntity!, EntityTreeComponent)
-        beforeNode = parentTreeComponent ? parentTreeComponent.children[node.childIndex] : node.entity
-      } else if (place === 'After') {
-        const entityTreeComponent = getOptionalComponent(node.entity, EntityTreeComponent)
-        parentNode = entityTreeComponent?.parentEntity
-        const parentTreeComponent = getOptionalComponent(entityTreeComponent?.parentEntity!, EntityTreeComponent)
-        console.log('after!!')
-        if (
-          parentTreeComponent &&
-          !node.lastChild &&
-          parentNode &&
-          parentTreeComponent?.children.length > node.childIndex + 1
-        ) {
-          beforeNode = parentTreeComponent.children[node.childIndex + 1]
-        }
-      } else {
-        parentNode = node.entity
+      const entityTreeComponent = getOptionalComponent(node.entity, EntityTreeComponent)
+      parentNode = entityTreeComponent?.parentEntity
+      const parentTreeComponent = getOptionalComponent(entityTreeComponent?.parentEntity!, EntityTreeComponent)
+
+      switch (place) {
+        case 'Before': // we want to place before this node
+          beforeNode = node.entity
+          if (!parentTreeComponent || !parentNode) break
+          if (0 > node.childIndex - 1) break // nothing to place after it, as node index is the first child
+          afterNode = UndefinedEntity
+          break
+        case 'After': // we want to place after this node
+          afterNode = node.entity
+          if (!parentTreeComponent || !parentNode) break
+          if (node.lastChild) break // if it is last child, nothing to place before it
+          if (parentTreeComponent?.children.length < node.childIndex + 1) break //node index is last child
+          beforeNode = UndefinedEntity
+          break
+        default: //case 'on'
+          parentNode = node.entity
       }
+    }
+
+    if (!parentNode) {
+      console.warn('parent is not defined')
+      return
     }
 
     if ('files' in item) {
       const dndItem: any = monitor.getItem()
       const entries = Array.from(dndItem.items).map((item: any) => item.webkitGetAsEntry())
 
+      //uploading files then adding as media to the editor
       onUpload(entries).then((assets) => {
         if (!assets) return
         for (const asset of assets) {
@@ -299,7 +305,8 @@ export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' 
         ? ((item as DragItemType).value as Entity[])
         : [(item as DragItemType).value as Entity],
       beforeNode,
-      parentNode
+      afterNode,
+      parentNode === null ? undefined : parentNode
     )
   }
 


### PR DESCRIPTION
## Summary
hierarchy duplication and reordering bugs fixed, migrated fixes from @MbfloydIR that were done on previous code before a major refactor into new systems and fixed conversion issues

## References
[https://tsu.atlassian.net/browse/IR-4707](https://tsu.atlassian.net/browse/IR-4707)

## QA Steps
drag one or multiple selected objects in the hierarchy to a new location, reordering or reparenting. you should no longer see the order desync from what you were trying for, and no longer see duplication in the hierarchy when dropping into the end of the hierarchy