### PR TITLE
IR-4672 fixing control/command click selection in files tab

### DIFF
--- a/packages/editor/src/panels/files/fileitem.tsx
+++ b/packages/editor/src/panels/files/fileitem.tsx
@@ -25,6 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { useFind } from '@ir-engine/common'
 import { staticResourcePath } from '@ir-engine/common/src/schema.type.module'
+import { usesCtrlKey } from '@ir-engine/common/src/utils/OperatingSystemFunctions.ts'
 import {
   FilesState,
   FilesViewModeSettings,
@@ -248,9 +249,9 @@ export default function FileItem({ file }: { file: FileDataType }) {
     event.stopPropagation()
     if (!files) return
 
-    if (event.ctrlKey || event.metaKey) {
+    if (usesCtrlKey() ? event.ctrlKey : event.metaKey) {
       selectedFiles.set((prevSelectedFiles) =>
-        prevSelectedFiles.some((file) => file.key === file.key)
+        prevSelectedFiles.includes(file)
           ? prevSelectedFiles.filter((prevFile) => prevFile.key !== file.key)
           : [...prevSelectedFiles, file]
       )

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -248,7 +248,7 @@ export default function HierarchyTreeNode(props: ListChildComponentProps<undefin
       getMutableState(EditorHelperState).placementMode.set(PlacementMode.DRAG)
       // Deselect material entity since we've just clicked on a hierarchy node
       getMutableState(MaterialSelectionState).selectedMaterial.set(null)
-      if ((event.ctrlKey && usesCtrlKey()) || (event.metaKey && !usesCtrlKey())) {
+      if (usesCtrlKey() ? event.ctrlKey : event.metaKey) {
         if (entity === rootEntity) return
         EditorControlFunctions.toggleSelection([getComponent(entity, UUIDComponent)])
       } else if (event.shiftKey && firstSelectedEntity.value) {


### PR DESCRIPTION
## Summary
fixing control/command click selection in files tab. simplifying logic a bit in hierarchynode as well

## References
[https://tsu.atlassian.net/browse/IR-4672](https://tsu.atlassian.net/browse/IR-4672)

## QA Steps
open the files tab
make a selection or multi-selection (shift click etc)
hold <command on mac, or ctrl on windows > and click a file
   - a previously selected file will de-select
   - a previously unselected file will now be selected in addition to your prior file selection(s)