### PR TITLE
Fix for downloadProjects.ts

### DIFF
--- a/packages/server-core/src/projects/project/downloadProjects.ts
+++ b/packages/server-core/src/projects/project/downloadProjects.ts
@@ -66,7 +66,7 @@ export const download = async (projectName: string, storageProviderName?: string
         const fileResult = await storageProvider.getObject(filePath)
         if (fileResult.Body.length === 0) {
           logger.info(`[ProjectLoader]: WARNING file "${filePath}" is empty`)
-          return
+          if (filePath[filePath.length - 1] === '/') return
         }
         writeFileSyncRecursive(path.join(appRootPath.path, 'packages/projects', filePath), fileResult.Body)
       })


### PR DESCRIPTION
## Summary

Empty files were not being written, as the presence of a 'file' with a 0 body length was being conflated with it actually being a folder. Making a distinction based on the last character.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
