### PR TITLE
Move contextmenu to file browser

### DIFF
--- a/packages/editor/src/panels/files/contextmenu.tsx
+++ b/packages/editor/src/panels/files/contextmenu.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { useMutation } from '@ir-engine/common'
 import { fileBrowserPath } from '@ir-engine/common/src/schema.type.module'
-import { NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
+import { ImmutableObject, NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
 import { TransformComponent } from '@ir-engine/spatial'
 import { ContextMenu } from '@ir-engine/ui/src/components/tailwind/ContextMenu'
 import Button from '@ir-engine/ui/src/primitives/tailwind/Button'
@@ -57,7 +57,7 @@ function PasteFileButton({
   const isFilesLoading = filesQuery?.status === 'pending'
   const filesState = useMutableState(FilesState)
   const fileService = useMutation(fileBrowserPath)
-  const file = filesState.clipboardFile.value?.file
+  const clipboardFile = filesState.clipboardFile.value?.file
   const currentDirectory = filesState.selectedDirectory.value.startsWith('/')
     ? filesState.selectedDirectory.value.substring(1)
     : filesState.selectedDirectory.value
@@ -68,17 +68,17 @@ function PasteFileButton({
       size="small"
       fullWidth
       data-testid="files-panel-context-menu-paste-asset-button"
-      disabled={!file}
+      disabled={!clipboardFile}
       onClick={() => {
-        if (!file || isFilesLoading) return
+        if (!clipboardFile || isFilesLoading) return
         setAnchorEvent(undefined)
         fileService.update(null, {
           oldProject: filesState.projectName.value,
           newProject: filesState.projectName.value,
-          oldName: file.fullName,
-          newName: file.fullName,
-          oldPath: file.path,
-          newPath: (newPath ?? currentDirectory) + file.fullName,
+          oldName: clipboardFile.fullName,
+          newName: clipboardFile.fullName,
+          oldPath: clipboardFile.path,
+          newPath: (newPath ?? currentDirectory) + clipboardFile.fullName,
           isCopy: filesState.clipboardFile.value?.isCopy
         })
       }}
@@ -95,7 +95,7 @@ export function FileContextMenu({
 }: {
   anchorEvent: React.MouseEvent | undefined
   setAnchorEvent: (event: React.MouseEvent | undefined) => void
-  file: FileDataType
+  file: ImmutableObject<FileDataType>
 }) {
   const { t } = useTranslation()
   const { createNewFolder, refreshDirectory } = useCurrentFiles()

--- a/packages/editor/src/panels/files/contextmenu.tsx
+++ b/packages/editor/src/panels/files/contextmenu.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { useMutation } from '@ir-engine/common'
 import { fileBrowserPath } from '@ir-engine/common/src/schema.type.module'
-import { ImmutableObject, NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
+import { NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
 import { TransformComponent } from '@ir-engine/spatial'
 import { ContextMenu } from '@ir-engine/ui/src/components/tailwind/ContextMenu'
 import Button from '@ir-engine/ui/src/primitives/tailwind/Button'
@@ -35,7 +35,6 @@ import { useTranslation } from 'react-i18next'
 import { Vector3 } from 'three'
 import ImageCompressionPanel from '../../components/assets/ImageCompressionPanel'
 import ModelCompressionPanel from '../../components/assets/ModelCompressionPanel'
-import { FileDataType } from '../../constants/AssetTypes'
 import { addMediaNode } from '../../functions/addMediaNode'
 import { getSpawnPositionAtCenter } from '../../functions/screenSpaceFunctions'
 import { FilesState, SelectedFilesState } from '../../services/FilesState'
@@ -55,9 +54,11 @@ function PasteFileButton({
   const { t } = useTranslation()
   const { filesQuery } = useCurrentFiles()
   const isFilesLoading = filesQuery?.status === 'pending'
-  const filesState = useMutableState(FilesState)
   const fileService = useMutation(fileBrowserPath)
-  const clipboardFile = filesState.clipboardFile.value?.file
+
+  const filesState = useMutableState(FilesState)
+  const clipboardFiles = filesState.clipboardFiles.files
+  const hasClipboardFiles = clipboardFiles.length > 0
   const currentDirectory = filesState.selectedDirectory.value.startsWith('/')
     ? filesState.selectedDirectory.value.substring(1)
     : filesState.selectedDirectory.value
@@ -68,19 +69,21 @@ function PasteFileButton({
       size="small"
       fullWidth
       data-testid="files-panel-context-menu-paste-asset-button"
-      disabled={!clipboardFile}
-      onClick={() => {
-        if (!clipboardFile || isFilesLoading) return
+      disabled={!hasClipboardFiles}
+      onClick={async () => {
+        if (!hasClipboardFiles || isFilesLoading) return
         setAnchorEvent(undefined)
-        fileService.update(null, {
-          oldProject: filesState.projectName.value,
-          newProject: filesState.projectName.value,
-          oldName: clipboardFile.fullName,
-          newName: clipboardFile.fullName,
-          oldPath: clipboardFile.path,
-          newPath: (newPath ?? currentDirectory) + clipboardFile.fullName,
-          isCopy: filesState.clipboardFile.value?.isCopy
-        })
+        for (const clipboardFile of clipboardFiles.get(NO_PROXY)) {
+          await fileService.update(null, {
+            oldProject: filesState.projectName.value,
+            newProject: filesState.projectName.value,
+            oldName: clipboardFile.fullName,
+            newName: clipboardFile.fullName,
+            oldPath: clipboardFile.path,
+            newPath: (newPath ?? currentDirectory) + clipboardFile.fullName,
+            isCopy: filesState.clipboardFiles.isCopy.value
+          })
+        }
       }}
     >
       {t('editor:layout.filebrowser.pasteAsset')}
@@ -90,17 +93,18 @@ function PasteFileButton({
 
 export function FileContextMenu({
   anchorEvent,
-  setAnchorEvent,
-  file
+  setAnchorEvent
 }: {
   anchorEvent: React.MouseEvent | undefined
   setAnchorEvent: (event: React.MouseEvent | undefined) => void
-  file: ImmutableObject<FileDataType>
 }) {
   const { t } = useTranslation()
   const { createNewFolder, refreshDirectory } = useCurrentFiles()
   const selectedFiles = useMutableState(SelectedFilesState)
   const filesState = useMutableState(FilesState)
+
+  const hasSelection = selectedFiles.length > 0
+  const hasFiles = selectedFiles.some((file) => !file.isFolder)
 
   return (
     <ContextMenu anchorEvent={anchorEvent} onClose={() => setAnchorEvent(undefined)}>
@@ -108,6 +112,80 @@ export function FileContextMenu({
         className="flex w-fit min-w-44 flex-col gap-1 truncate rounded-lg bg-neutral-900 shadow-lg"
         data-testid="files-panel-file-item-context-menu"
       >
+        {/* Place Object, Place Object At Origin */}
+        {hasFiles && (
+          <>
+            <Button
+              variant="outline"
+              size="small"
+              fullWidth
+              data-testid="files-panel-file-item-context-menu-place-object-button"
+              onClick={() => {
+                const vec3 = new Vector3()
+                getSpawnPositionAtCenter(vec3)
+                selectedFiles
+                  .filter((file) => !file.isFolder)
+                  .map((file) => {
+                    addMediaNode(file.url.value, undefined, undefined, [
+                      { name: TransformComponent.jsonID, props: { position: vec3 } }
+                    ])
+                  })
+                setAnchorEvent(undefined)
+              }}
+            >
+              {t('editor:layout.assetGrid.placeObject')}
+            </Button>
+            <Button
+              variant="outline"
+              size="small"
+              fullWidth
+              data-testid="files-panel-file-item-context-menu-place-object-at-origin-button"
+              onClick={() => {
+                selectedFiles
+                  .filter((file) => !file.isFolder)
+                  .map((file) => {
+                    addMediaNode(file.url.value)
+                  })
+                setAnchorEvent(undefined)
+              }}
+            >
+              {t('editor:layout.assetGrid.placeObjectAtOrigin')}
+            </Button>
+          </>
+        )}
+        {/* Copy URL */}
+        {hasSelection && (
+          <Button
+            variant="outline"
+            size="small"
+            fullWidth
+            data-testid="files-panel-file-item-context-menu-copy-url-button"
+            onClick={() => {
+              if (navigator.clipboard) {
+                navigator.clipboard.writeText(selectedFiles.map((file) => file.url.value).join(' '))
+              }
+              setAnchorEvent(undefined)
+            }}
+          >
+            {t('editor:layout.assetGrid.copyURL')}
+          </Button>
+        )}
+        {/* Open In New Tab */}
+        {hasFiles && (
+          <Button
+            variant="outline"
+            size="small"
+            fullWidth
+            data-testid="files-panel-file-item-context-menu-open-in-new-tab-button"
+            onClick={() => {
+              selectedFiles.filter((file) => !file.isFolder).forEach((file) => window.open(file.url.value))
+              setAnchorEvent(undefined)
+            }}
+          >
+            {t('editor:layout.assetGrid.openInNewTab')}
+          </Button>
+        )}
+        {/* Add New Folder */}
         <Button
           variant="outline"
           size="small"
@@ -117,177 +195,89 @@ export function FileContextMenu({
         >
           {t('editor:layout.filebrowser.addNewFolder')}
         </Button>
-        {!file.isFolder && (
+        {hasSelection && (
+          <>
+            {/* Cut Asset */}
+            <Button
+              variant="outline"
+              size="small"
+              fullWidth
+              data-testid="files-panel-file-item-context-menu-cut-asset-button"
+              onClick={() => {
+                filesState.clipboardFiles.set({
+                  files: selectedFiles.get(NO_PROXY)
+                })
+                setAnchorEvent(undefined)
+              }}
+            >
+              {t('editor:layout.filebrowser.cutAsset')}
+            </Button>
+            {/* Copy Asset */}
+            <Button
+              variant="outline"
+              size="small"
+              fullWidth
+              data-testid="files-panel-file-item-context-menu-copy-asset-button"
+              onClick={() => {
+                filesState.clipboardFiles.set({
+                  files: selectedFiles.get(NO_PROXY),
+                  isCopy: true
+                })
+                setAnchorEvent(undefined)
+              }}
+            >
+              {t('editor:layout.filebrowser.copyAsset')}
+            </Button>
+          </>
+        )}
+        {/* Paste Asset */}
+        <PasteFileButton setAnchorEvent={setAnchorEvent} />
+        {/* Rename Asset */}
+        {selectedFiles.length === 1 && (
           <Button
             variant="outline"
             size="small"
+            data-testid="files-panel-file-item-context-menu-rename-asset-button"
             fullWidth
-            data-testid="files-panel-file-item-context-menu-place-object-button"
             onClick={() => {
-              const vec3 = new Vector3()
-              getSpawnPositionAtCenter(vec3)
-              addMediaNode(file.url, undefined, undefined, [
-                { name: TransformComponent.jsonID, props: { position: vec3 } }
-              ])
+              PopoverState.showPopupover(
+                <RenameFileModal projectName={filesState.projectName.value} file={selectedFiles.value[0]} />
+              )
               setAnchorEvent(undefined)
             }}
           >
-            {t('editor:layout.assetGrid.placeObject')}
+            {t('editor:layout.filebrowser.renameAsset')}
           </Button>
         )}
-        {!file.isFolder && (
+        {/* Delete Asset */}
+        {hasSelection && (
           <Button
             variant="outline"
             size="small"
             fullWidth
-            data-testid="files-panel-file-item-context-menu-place-object-at-origin-button"
+            data-testid="files-panel-file-item-context-menu-delete-asset-button"
             onClick={() => {
-              addMediaNode(file.url)
+              PopoverState.showPopupover(
+                <DeleteFileModal
+                  files={selectedFiles.value}
+                  onComplete={(err) => {
+                    selectedFiles.set([])
+                    ClickPlacementState.resetSelectedAsset()
+                  }}
+                />
+              )
               setAnchorEvent(undefined)
             }}
           >
-            {t('editor:layout.assetGrid.placeObjectAtOrigin')}
+            {t('editor:layout.assetGrid.deleteAsset')}
           </Button>
         )}
-        {!file.isFolder && (
+        {/* Compress */}
+        {hasFiles && fileConsistsOfContentType(selectedFiles.value, 'model') && (
           <Button
             variant="outline"
             size="small"
             fullWidth
-            data-testid="files-panel-file-item-context-menu-open-in-new-tab-button"
-            onClick={() => {
-              window.open(file.url)
-              setAnchorEvent(undefined)
-            }}
-          >
-            {t('editor:layout.assetGrid.openInNewTab')}
-          </Button>
-        )}
-        <Button
-          variant="outline"
-          size="small"
-          fullWidth
-          data-testid="files-panel-file-item-context-menu-copy-url-button"
-          onClick={() => {
-            if (navigator.clipboard) {
-              navigator.clipboard.writeText(file.url)
-            }
-            setAnchorEvent(undefined)
-          }}
-        >
-          {t('editor:layout.assetGrid.copyURL')}
-        </Button>
-        <Button
-          variant="outline"
-          size="small"
-          fullWidth
-          data-testid="files-panel-file-item-context-menu-cut-asset-button"
-          onClick={() => {
-            filesState.clipboardFile.set({
-              file
-            })
-            setAnchorEvent(undefined)
-          }}
-        >
-          {t('editor:layout.filebrowser.cutAsset')}
-        </Button>
-        <Button
-          variant="outline"
-          size="small"
-          fullWidth
-          data-testid="files-panel-file-item-context-menu-copy-asset-button"
-          onClick={() => {
-            filesState.clipboardFile.set({
-              file,
-              isCopy: true
-            })
-            setAnchorEvent(undefined)
-          }}
-        >
-          {t('editor:layout.filebrowser.copyAsset')}
-        </Button>
-        <PasteFileButton newPath={file.isFolder ? file.key : undefined} setAnchorEvent={setAnchorEvent} />
-        <Button
-          variant="outline"
-          size="small"
-          data-testid="files-panel-file-item-context-menu-rename-asset-button"
-          fullWidth
-          onClick={() => {
-            PopoverState.showPopupover(<RenameFileModal projectName={filesState.projectName.value} file={file} />)
-            setAnchorEvent(undefined)
-          }}
-        >
-          {t('editor:layout.filebrowser.renameAsset')}
-        </Button>
-        <Button
-          variant="outline"
-          size="small"
-          fullWidth
-          data-testid="files-panel-file-item-context-menu-delete-asset-button"
-          onClick={() => {
-            PopoverState.showPopupover(
-              <DeleteFileModal
-                files={selectedFiles.value}
-                onComplete={(err) => {
-                  selectedFiles.set([])
-                  ClickPlacementState.resetSelectedAsset()
-                }}
-              />
-            )
-            setAnchorEvent(undefined)
-          }}
-        >
-          {t('editor:layout.assetGrid.deleteAsset')}
-        </Button>
-        <Button
-          variant="outline"
-          size="small"
-          data-testid="files-panel-file-item-context-menu-view-asset-properties-button"
-          fullWidth
-          onClick={() => {
-            if (!selectedFiles.get(NO_PROXY).some((selectedFile) => selectedFile.key === file.key)) {
-              if (selectedFiles.value.length > 1) {
-                selectedFiles.merge([file])
-              } else {
-                selectedFiles.set([file])
-              }
-            }
-            PopoverState.showPopupover(<FilePropertiesModal />)
-            setAnchorEvent(undefined)
-          }}
-        >
-          {t('editor:layout.filebrowser.viewAssetProperties')}
-        </Button>
-
-        {/*
-          <Button
-            variant="outline"
-            size="small"
-            fullWidth
-            disabled={!fileConsistsOfContentType(item, 'model') && !fileConsistsOfContentType(item, 'image')}
-            onClick={() => {
-              if (fileConsistsOfContentType(item, 'model')) {
-                PopoverState.showPopupover(
-                  <ModelCompressionPanel selectedFile={item as FileType} refreshDirectory={refreshDirectory} />
-                )
-              } else if (fileConsistsOfContentType(item, 'image')) {
-                PopoverState.showPopupover(
-                  <ImageCompressionPanel selectedFile={item as FileType} refreshDirectory={refreshDirectory} />
-                )
-              }
-              handleClose()
-            }}
-          >
-            {t('editor:layout.filebrowser.compress')}
-          </Button>
-          */}
-
-        {fileConsistsOfContentType(selectedFiles.value, 'model') && (
-          <Button
-            variant="outline"
-            size="small"
-            fullWidth
-            disabled={!fileConsistsOfContentType(selectedFiles.value, 'model')}
             onClick={() => {
               if (fileConsistsOfContentType(selectedFiles.value, 'model')) {
                 PopoverState.showPopupover(
@@ -300,12 +290,11 @@ export function FileContextMenu({
             {t('editor:layout.filebrowser.compress')}
           </Button>
         )}
-        {fileConsistsOfContentType(selectedFiles.value, 'image') && (
+        {hasFiles && fileConsistsOfContentType(selectedFiles.value, 'image') && (
           <Button
             variant="outline"
             size="small"
             fullWidth
-            disabled={!fileConsistsOfContentType(selectedFiles.value, 'image')}
             onClick={() => {
               if (fileConsistsOfContentType(selectedFiles.value, 'image')) {
                 PopoverState.showPopupover(
@@ -318,33 +307,23 @@ export function FileContextMenu({
             {t('editor:layout.filebrowser.compress')}
           </Button>
         )}
+
+        {/* View Asset Properties */}
+        {hasSelection && (
+          <Button
+            variant="outline"
+            size="small"
+            data-testid="files-panel-file-item-context-menu-view-asset-properties-button"
+            fullWidth
+            onClick={() => {
+              PopoverState.showPopupover(<FilePropertiesModal />)
+              setAnchorEvent(undefined)
+            }}
+          >
+            {t('editor:layout.filebrowser.viewAssetProperties')}
+          </Button>
+        )}
       </div>
-    </ContextMenu>
-  )
-}
-
-export function BrowserContextMenu({
-  anchorEvent,
-  setAnchorEvent
-}: {
-  anchorEvent: React.MouseEvent | undefined
-  setAnchorEvent: (event: React.MouseEvent | undefined) => void
-}) {
-  const { t } = useTranslation()
-  const { createNewFolder } = useCurrentFiles()
-
-  return (
-    <ContextMenu anchorEvent={anchorEvent} onClose={() => setAnchorEvent(undefined)}>
-      <Button
-        variant="outline"
-        size="small"
-        fullWidth
-        onClick={createNewFolder}
-        data-testid="files-panel-file-browser-context-menu-add-new-folder-button"
-      >
-        {t('editor:layout.filebrowser.addNewFolder')}
-      </Button>
-      <PasteFileButton setAnchorEvent={setAnchorEvent} />
     </ContextMenu>
   )
 }

--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -23,15 +23,15 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { useHookstate, useMutableState } from '@ir-engine/hyperflux'
+import { useMutableState } from '@ir-engine/hyperflux'
 import React, { useEffect, useState } from 'react'
 import { useDrop } from 'react-dnd'
 import { twMerge } from 'tailwind-merge'
-import { FileDataType, SupportedFileTypes } from '../../constants/AssetTypes'
+import { SupportedFileTypes } from '../../constants/AssetTypes'
 import { EditorState } from '../../services/EditorServices'
 import { FilesState, FilesViewModeState, SelectedFilesState } from '../../services/FilesState'
 import { ClickPlacementState } from '../../systems/ClickPlacementSystem'
-import { BrowserContextMenu, FileContextMenu } from './contextmenu'
+import { FileContextMenu } from './contextmenu'
 import FileItem, { TableWrapper } from './fileitem'
 import { CurrentFilesQueryProvider, canDropOnFileBrowser, useCurrentFiles, useFileBrowserDrop } from './helpers'
 import FilesLoaders from './loaders'
@@ -51,8 +51,6 @@ function Browser() {
   const selectedFiles = useMutableState(SelectedFilesState)
   const { files } = useCurrentFiles()
 
-  const contextMenuFile = useHookstate<FileDataType | null>(null)
-
   const FileItems = () => (
     <>
       {files.map((file) => (
@@ -61,16 +59,15 @@ function Browser() {
           onContextMenu={(event) => {
             event.preventDefault()
             event.stopPropagation()
-            contextMenuFile.set(file)
+            if (!selectedFiles.value.find((selectedFile) => selectedFile.key === file.key)) {
+              selectedFiles.set([file])
+            }
             setAnchorEvent(event)
           }}
           key={file.key}
           data-testid="files-panel-file-item"
         />
       ))}
-      {contextMenuFile.value && (
-        <FileContextMenu anchorEvent={anchorEvent} setAnchorEvent={setAnchorEvent} file={contextMenuFile.value!} />
-      )}
     </>
   )
 
@@ -81,6 +78,7 @@ function Browser() {
       onContextMenu={(event) => {
         event.preventDefault()
         event.stopPropagation()
+        selectedFiles.set([])
         setAnchorEvent(event)
       }}
     >
@@ -102,7 +100,7 @@ function Browser() {
           )}
         </div>
       </div>
-      {!contextMenuFile.value && <BrowserContextMenu anchorEvent={anchorEvent} setAnchorEvent={setAnchorEvent} />}
+      <FileContextMenu anchorEvent={anchorEvent} setAnchorEvent={setAnchorEvent} />
     </div>
   )
 }

--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -23,15 +23,15 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { useMutableState } from '@ir-engine/hyperflux'
+import { useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import React, { useEffect, useState } from 'react'
 import { useDrop } from 'react-dnd'
 import { twMerge } from 'tailwind-merge'
-import { SupportedFileTypes } from '../../constants/AssetTypes'
+import { FileDataType, SupportedFileTypes } from '../../constants/AssetTypes'
 import { EditorState } from '../../services/EditorServices'
 import { FilesState, FilesViewModeState, SelectedFilesState } from '../../services/FilesState'
 import { ClickPlacementState } from '../../systems/ClickPlacementSystem'
-import { BrowserContextMenu } from './contextmenu'
+import { BrowserContextMenu, FileContextMenu } from './contextmenu'
 import FileItem, { TableWrapper } from './fileitem'
 import { CurrentFilesQueryProvider, canDropOnFileBrowser, useCurrentFiles, useFileBrowserDrop } from './helpers'
 import FilesLoaders from './loaders'
@@ -51,11 +51,26 @@ function Browser() {
   const selectedFiles = useMutableState(SelectedFilesState)
   const { files } = useCurrentFiles()
 
+  const contextMenuFile = useHookstate<FileDataType | null>(null)
+
   const FileItems = () => (
     <>
       {files.map((file) => (
-        <FileItem file={file} key={file.key} data-testid="files-panel-file-item" />
+        <FileItem
+          file={file}
+          onContextMenu={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            contextMenuFile.set(file)
+            setAnchorEvent(event)
+          }}
+          key={file.key}
+          data-testid="files-panel-file-item"
+        />
       ))}
+      {contextMenuFile.value && (
+        <FileContextMenu anchorEvent={anchorEvent} setAnchorEvent={setAnchorEvent} file={contextMenuFile.value!} />
+      )}
     </>
   )
 
@@ -87,7 +102,7 @@ function Browser() {
           )}
         </div>
       </div>
-      <BrowserContextMenu anchorEvent={anchorEvent} setAnchorEvent={setAnchorEvent} />
+      {!contextMenuFile.value && <BrowserContextMenu anchorEvent={anchorEvent} setAnchorEvent={setAnchorEvent} />}
     </div>
   )
 }

--- a/packages/editor/src/panels/files/fileitem.tsx
+++ b/packages/editor/src/panels/files/fileitem.tsx
@@ -43,7 +43,6 @@ import { VscBlank } from 'react-icons/vsc'
 import { twMerge } from 'tailwind-merge'
 import { FileDataType, SupportedFileTypes } from '../../constants/AssetTypes'
 import { ClickPlacementState } from '../../systems/ClickPlacementSystem'
-import { FileContextMenu } from './contextmenu'
 import { FileIcon } from './fileicon'
 import {
   FILES_PAGE_LIMIT,
@@ -201,10 +200,15 @@ function GridView({ file, onDoubleClick, onClick, isSelected, drag, drop, isOver
   )
 }
 
-export default function FileItem({ file }: { file: FileDataType }) {
+export default function FileItem({
+  file,
+  onContextMenu
+}: {
+  file: FileDataType
+  onContextMenu: React.MouseEventHandler
+}) {
   const filesViewMode = useMutableState(FilesViewModeState).viewMode
   const isListView = filesViewMode.value === 'list'
-  const [anchorEvent, setAnchorEvent] = React.useState<undefined | React.MouseEvent>(undefined)
   const filesState = useMutableState(FilesState)
   const { changeDirectoryByPath, files } = useCurrentFiles()
   const dropOnFileBrowser = useFileBrowserDrop()
@@ -236,13 +240,6 @@ export default function FileItem({ file }: { file: FileDataType }) {
       isOver: monitor.canDrop() && monitor.isOver()
     })
   })
-
-  const handleContextMenu = (event: React.MouseEvent) => {
-    event.preventDefault()
-    event.stopPropagation()
-    setAnchorEvent(event)
-    if (selectedFiles.length <= 1) selectedFiles.set([file])
-  }
 
   const handleSelectedFiles = (event: React.MouseEvent) => {
     event.stopPropagation()
@@ -293,13 +290,8 @@ export default function FileItem({ file }: { file: FileDataType }) {
     drag,
     drop,
     isOver,
-    onContextMenu: handleContextMenu
+    onContextMenu
   }
 
-  return (
-    <>
-      {isListView ? <TableView {...commonProps} /> : <GridView {...commonProps} />}
-      <FileContextMenu anchorEvent={anchorEvent} setAnchorEvent={setAnchorEvent} file={file} />
-    </>
-  )
+  return isListView ? <TableView {...commonProps} /> : <GridView {...commonProps} />
 }

--- a/packages/editor/src/panels/files/helpers.tsx
+++ b/packages/editor/src/panels/files/helpers.tsx
@@ -279,14 +279,17 @@ export const createStaticResourceDigest = (staticResources: ImmutableArray<Stati
 }
 
 export function fileConsistsOfContentType(files: readonly FileDataType[], contentType: string): boolean {
-  return files.every((file) => {
-    if (file.isFolder) {
-      return contentType.startsWith('image')
-    } else {
-      const guessedType: string = CommonKnownContentTypes[file.type]
-      return guessedType?.startsWith(contentType)
-    }
-  })
+  return (
+    files.length > 0 &&
+    files.every((file) => {
+      if (file.isFolder) {
+        return contentType.startsWith('image')
+      } else {
+        const guessedType: string = CommonKnownContentTypes[file.type]
+        return guessedType?.startsWith(contentType)
+      }
+    })
+  )
 }
 
 export const canDropOnFileBrowser = (folderName: string) =>

--- a/packages/editor/src/services/FilesState.ts
+++ b/packages/editor/src/services/FilesState.ts
@@ -58,7 +58,7 @@ export const FilesState = defineState({
   initial: () => ({
     selectedDirectory: '',
     projectName: '',
-    clipboardFile: null as { isCopy?: boolean; file: FileDataType } | null,
+    clipboardFiles: { files: [] } as { isCopy?: boolean; files: FileDataType[] },
     searchText: ''
   })
 })


### PR DESCRIPTION
## Summary
The file context menu shouldn't be inside the file item component— it must persist when the file items are re-rendered. I've moved it back into the file browser component, combined it with the browser context menu, and modified it so that buttons only appear in the proper context and can handle multiple selected files.

Closes https://tsu.atlassian.net/browse/IR-2857 .