### PR TITLE
IR-5112 Fix material export crash in image routing extension

### DIFF
--- a/packages/editor/src/panels/materials/helpers.tsx
+++ b/packages/editor/src/panels/materials/helpers.tsx
@@ -90,7 +90,8 @@ export async function saveMaterial(sourcePath: string) {
   const relativePath = pathJoin('assets', sourcePath)
   const gltf = (await exportMaterialsGLTF([UUIDComponent.getEntityByUUID(materialUUID)], {
     binary: false,
-    relativePath
+    relativePath,
+    projectName: projectName
   })!) as { [key: string]: any }
   const blob = [JSON.stringify(gltf)]
   const file = new File(blob, sourcePath)


### PR DESCRIPTION
## Summary
Material saving is broken after CJS to ESM migration due to project name never being passed into the options, which the image routing extension now depends on

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-5112

## QA Steps
