### PR TITLE
fix(ir-engine): fixed location find queries when using $or operator

### DIFF
--- a/packages/server-core/src/social/location/location.hooks.ts
+++ b/packages/server-core/src/social/location/location.hooks.ts
@@ -246,6 +246,7 @@ const restrictProtectedQuery = async (context: HookContext<LocationService>) => 
     'id',
     'name',
     'slugifiedName',
+    '$or',
     '$like',
     '$limit',
     '$sort',


### PR DESCRIPTION
## Summary
Hotfixed broken location find query when using the $or operator
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
