### PR TITLE
refresh filebrowser on assets upload

### DIFF
--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -140,6 +140,7 @@ export const inputFileWithAddToScene = ({
           await handleUploadFiles(projectName, directoryPath, newFiles)
         }
         resolve(null)
+        API.instance.service(fileBrowserPath).emit('created')
       } catch (err) {
         reject(err)
       } finally {


### PR DESCRIPTION
## Summary

emit a `created` event to which the [file browser listens to](https://github.com/ir-engine/ir-engine/blob/3ef8804449eb79c1302b0cf719091bbe20d7db60/packages/editor/src/panels/files/helpers.tsx/#L120) and refreshes the directory automatically

## References
closes https://tsu.atlassian.net/browse/IR-4499

## QA Steps


https://github.com/user-attachments/assets/dfc720af-22e0-447f-a3ea-75af83379434



