### PR TITLE
Physics worlds wait for a scene to load before

### DIFF
--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -45,6 +45,8 @@ import { parseStorageProviderURLs } from '@ir-engine/engine/src/assets/functions
 import { dispatchAction, getState, useHookstate } from '@ir-engine/hyperflux'
 
 import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
+import { SceneComponent } from '@ir-engine/spatial/src/renderer/components/SceneComponents'
+import { getAncestorWithComponents } from '@ir-engine/spatial/src/transform/components/EntityTree'
 import { FileLoader } from '../assets/loaders/base/FileLoader'
 import { BINARY_EXTENSION_HEADER_MAGIC, EXTENSIONS, GLTFBinaryExtension } from '../assets/loaders/gltf/GLTFExtensions'
 import { ErrorComponent } from '../scene/components/ErrorComponent'
@@ -237,6 +239,14 @@ const DependencyEntryReactor = (props: { gltfComponentEntity: Entity; uuid: stri
 const DependencyReactor = (props: { gltfComponentEntity: Entity; dependencies: ComponentDependencies }) => {
   const { gltfComponentEntity, dependencies } = props
   const entries = Object.entries(dependencies)
+
+  useEffect(() => {
+    return () => {
+      const ancestor = getAncestorWithComponents(gltfComponentEntity, [SceneComponent])
+      const scene = getMutableComponent(ancestor, SceneComponent)
+      scene.active.set(true)
+    }
+  }, [])
 
   return (
     <>

--- a/packages/engine/src/gltf/GLTFState.tsx
+++ b/packages/engine/src/gltf/GLTFState.tsx
@@ -64,7 +64,6 @@ import { EntityTreeComponent } from '@ir-engine/spatial/src/transform/components
 import { TransformComponent } from '@ir-engine/spatial/src/transform/components/TransformComponent'
 
 import { EngineState } from '@ir-engine/spatial/src/EngineState'
-import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics'
 import { SceneComponent } from '@ir-engine/spatial/src/renderer/components/SceneComponents'
 import { SourceComponent } from '../scene/components/SourceComponent'
 import { proxifyParentChildRelationships } from '../scene/functions/loadGLTFModel'
@@ -382,7 +381,7 @@ export const DocumentReactor = (props: { documentID: string; parentUUID: EntityU
   return (
     <>
       {Object.entries(nodeState.get(NO_PROXY)).map(([uuid, { nodeIndex, childIndex, parentUUID }]) => (
-        <ParentNodeReactor
+        <NodeReactor
           key={uuid}
           childIndex={childIndex}
           nodeIndex={nodeIndex}
@@ -392,19 +391,6 @@ export const DocumentReactor = (props: { documentID: string; parentUUID: EntityU
       ))}
     </>
   )
-}
-
-const ParentNodeReactor = (props: {
-  nodeIndex: number
-  childIndex: number
-  parentUUID: EntityUUID
-  documentID: string
-}) => {
-  const parentEntity = UUIDComponent.useEntityByUUID(props.parentUUID)
-  const physicsWorld = Physics.useWorld(parentEntity)
-  if (!parentEntity || !physicsWorld) return null
-
-  return <NodeReactor {...props} />
 }
 
 const NodeReactor = (props: { nodeIndex: number; childIndex: number; parentUUID: EntityUUID; documentID: string }) => {

--- a/packages/spatial/src/initializeEngine.ts
+++ b/packages/spatial/src/initializeEngine.ts
@@ -97,7 +97,7 @@ export const initializeSpatialEngine = () => {
   setComponent(localFloorEntity, EntityTreeComponent, { parentEntity: UndefinedEntity })
   setComponent(localFloorEntity, TransformComponent)
   setComponent(localFloorEntity, VisibleComponent, true)
-  setComponent(localFloorEntity, SceneComponent)
+  setComponent(localFloorEntity, SceneComponent, { active: true })
   const origin = new Group()
   addObjectToGroup(localFloorEntity, origin)
   const floorHelperMesh = new Mesh(new BoxGeometry(0.1, 0.1, 0.1), new MeshNormalMaterial())

--- a/packages/spatial/src/physics/systems/PhysicsSystem.tsx
+++ b/packages/spatial/src/physics/systems/PhysicsSystem.tsx
@@ -112,7 +112,7 @@ const PhysicsSceneReactor = () => {
     return () => {
       Physics.destroyWorld(uuid)
     }
-  }, [uuid, scene.active])
+  }, [uuid, scene.active.value])
   return null
 }
 

--- a/packages/spatial/src/physics/systems/PhysicsSystem.tsx
+++ b/packages/spatial/src/physics/systems/PhysicsSystem.tsx
@@ -104,12 +104,15 @@ const execute = () => {
 const PhysicsSceneReactor = () => {
   const entity = useEntityContext()
   const uuid = useComponent(entity, UUIDComponent).value
+  const scene = useComponent(entity, SceneComponent)
+
   useEffect(() => {
+    if (!scene.active.value) return
     Physics.createWorld(uuid)
     return () => {
       Physics.destroyWorld(uuid)
     }
-  }, [uuid])
+  }, [uuid, scene.active])
   return null
 }
 

--- a/packages/spatial/src/renderer/components/SceneComponents.tsx
+++ b/packages/spatial/src/renderer/components/SceneComponents.tsx
@@ -29,7 +29,8 @@ import { defineComponent } from '@ir-engine/ecs'
 import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
 
 export const SceneComponent = defineComponent({
-  name: 'SceneComponent'
+  name: 'SceneComponent',
+  schema: S.Object({ active: S.Bool(false) })
 })
 
 export const BackgroundComponent = defineComponent({


### PR DESCRIPTION
## Summary
This is a basic implementation of the concept of Scene active. Where a physics world won't be created if the scene is not fully loaded. We have to finalize this but this is functional and doesn't seem risky as far as I can tell. 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
