### PR TITLE
fix: fixed avatar upload for end-users with no scopes

### DIFF
--- a/packages/server-core/src/user/avatar/avatar-helper.ts
+++ b/packages/server-core/src/user/avatar/avatar-helper.ts
@@ -156,6 +156,8 @@ export const uploadAvatarStaticResource = async (
   const isFromDomain = !!data.path
   const folderName = isFromDomain ? data.path! : staticResourceKey
 
+  delete params?.provider
+
   const modelKey = path.join(folderName, `${name}.${data.avatarFileType ?? 'glb'}`)
   const thumbnailKey = path.join(folderName, `${name}.png`)
 


### PR DESCRIPTION
## Summary

This PR removes the `provider` property from params before invoking the static-resource service for model and thumbnail creation. Keeping the provider causes` isProvider('external')` to evaluate as true, which checks if users have the necessary scopes for the service call, leading to a permissions error. By removing the provider property, calls to the static-resource service are treated as internal, bypassing this issue.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

1.- Access any location with a user that doesn't have any scopes
2.- Create a new avatar
3.- Upload it. 
