### PR TITLE
IR-5157 bugfix - uniform scaling issue with Z resetting to zero

### DIFF
--- a/packages/ui/src/components/editor/input/Vector3/index.tsx
+++ b/packages/ui/src/components/editor/input/Vector3/index.tsx
@@ -103,7 +103,7 @@ export const Vector3Input = ({
 
   const toVec3 = (field: string, fieldValue: number): Vector3 => {
     if (uniformEnabled.value) {
-      return new Vector3(fieldValue, fieldValue)
+      return new Vector3(fieldValue, fieldValue, fieldValue)
     } else {
       const vec = new Vector3()
       vec.copy(value)


### PR DESCRIPTION
## Summary
adding in Z value for uniform scaling that was defaulting to 0 without being specified

## References
[https://tsu.atlassian.net/browse/IR-5157](https://tsu.atlassian.net/browse/IR-5157)

## QA Steps
1. set a transform's scale uniform lock to locked.
2. drag any of the x/y/z values, all should scale properly (z should not immediately and independently be set to 0)