### PR TITLE
Define min height for asset panel scrollbar

### DIFF
--- a/packages/editor/src/panels/assets/assetPanel.css
+++ b/packages/editor/src/panels/assets/assetPanel.css
@@ -1,3 +1,3 @@
 #asset-panel::-webkit-scrollbar-thumb {
-  min-height: 40px;
+  min-height: 20%;
 }

--- a/packages/editor/src/panels/assets/assetPanel.css
+++ b/packages/editor/src/panels/assets/assetPanel.css
@@ -1,0 +1,3 @@
+#asset-panel::-webkit-scrollbar-thumb {
+  min-height: 40px;
+}

--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -41,6 +41,7 @@ import { twMerge } from 'tailwind-merge'
 import { ClickPlacementState } from '../../systems/ClickPlacementSystem'
 import { FileIcon } from '../files/fileicon'
 import DeleteFileModal from '../files/modals/DeleteFileModal'
+import './assetPanel.css'
 import { ASSETS_PAGE_LIMIT, calculateItemsToFetch } from './helpers'
 import { useAssetsQuery } from './hooks'
 


### PR DESCRIPTION
This pull request adds a minimum height for the asset panel scrollbar. The `asset-panel` class now includes a `min-height` property of 40px.