### PR TITLE
Fix loading spinner not going away when switching variants

### DIFF
--- a/packages/editor/src/systems/ModelLoadingSpinnerSystem.tsx
+++ b/packages/editor/src/systems/ModelLoadingSpinnerSystem.tsx
@@ -75,7 +75,7 @@ const LoadingSpinnerReactor = (props: { entity: Entity }) => {
   useEffect(() => {
     if (!modelComponent.scene.value) return
     removeLoadingGeo()
-  }, [modelComponent.scene.value])
+  }, [modelComponent.scene])
 
   return null
 }


### PR DESCRIPTION
Fixes bug where variants would have an infinite loading spinner when switching
To test, add the variant trigger prefab from ir-starter-assets to a scene and test switching between the two variants on dev + this branch. Observe that the spinner never goes away on dev but does go away on this branch