### PR TITLE
Fix: GTM integration

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -75,8 +75,20 @@
         rootIframe.style.left = `${left}px`
       })
     </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '<%- gtmEnvironent %>';f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%- gtmId %>');</script>
+    <!-- End Google Tag Manager -->
 </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=<%- gtmId %><%- gtmEnvironent %>" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"  style='z-index: 1; margin: 0; width: 100%; height: 100vh; position: absolute; pointer-events: none;'></div>
     <iframe style="display:block; visibility: hidden; height: 400px; width: 400px; pointer-events: auto; position: absolute; z-index: 100; max-width: 100%; max-height: 100%;" id="root-cookie-accessor" src="<%- rootCookieAccessor %>" sandbox="allow-storage-access-by-user-activation allow-scripts allow-same-origin"></iframe>
     <script type="module" src="/src/main.tsx"></script>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -42,7 +42,6 @@
     "@mui/icons-material": "5.15.15",
     "@mui/material": "5.11.13",
     "@originjs/vite-plugin-commonjs": "^1.0.3",
-    "@sooro-io/react-gtm-module": "^3.0.0",
     "app-root-path": "3.1.0",
     "classnames": "2.3.2",
     "cli": "1.0.1",

--- a/packages/client/src/store.tsx
+++ b/packages/client/src/store.tsx
@@ -40,7 +40,6 @@ import { clientSettingPath } from '@ir-engine/common/src/schema.type.module'
 import { DomainConfigState } from '@ir-engine/engine/src/assets/state/DomainConfigState'
 import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
-import TagManager from '@sooro-io/react-gtm-module'
 import { initializei18n } from './util'
 
 const authenticate = async () => {
@@ -60,14 +59,6 @@ const initializeGoogleServices = async () => {
   if (settings?.gaMeasurementId) {
     ReactGA.initialize(settings.gaMeasurementId)
     ReactGA.send({ hitType: 'pageview', page: window.location.pathname })
-  }
-
-  if (settings?.gtmContainerId) {
-    TagManager.initialize({
-      gtmId: settings.gtmContainerId,
-      auth: settings?.gtmAuth,
-      preview: settings?.gtmPreview
-    })
   }
 }
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -336,7 +336,12 @@ export default defineConfig(async () => {
               : 'service-worker.js'
             : '',
         paymentPointer: coilSetting?.find((item) => item.key === EngineSettings.Coil.PaymentPointer)?.value || '',
-        rootCookieAccessor: `${clientSetting.url}/root-cookie-accessor.html`
+        rootCookieAccessor: `${clientSetting.url}/root-cookie-accessor.html`,
+        gtmId: clientSetting.gtmContainerId,
+        gtmEnvironent:
+          clientSetting.gtmAuth && clientSetting.gtmPreview
+            ? `&gtm_auth=${clientSetting.gtmAuth}&gtm_preview=${clientSetting.gtmPreview}&gtm_cookies_win=x`
+            : ''
       }),
       viteCompression({
         filter: /\.(js|mjs|json|css)$/i,


### PR DESCRIPTION
## Summary
Initialize GTM using script snippets instead of using react library. Current integration has an initialization delay caused by the authentication and as a result some pages are not tagged (see alerts generated in GTM dashboard). This change builds add the GTM script at build time instead of initialization after authentication.

## Subtasks Checklist

## Breaking Changes

## References
closes  https://tsu.atlassian.net/browse/IR-4963

## QA Steps
