### PR TITLE
IR-5078  Mount Point dismount offset

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1073,8 +1073,11 @@
     "mountPoint": {
       "name": "Mount point",
       "description": "An object with a pose to define interactable behaviors.",
+      "interact-message-seat": "Press E to Sit",
       "lbl-type": "Type",
-      "lbl-dismount": "Dismount point, offsets this transform"
+      "lbl-dismount": "Dismount point, offsets this transform",
+      "lbl-force-dismount" : "Force Dismount Position",
+      "lbl-force-dismount-info" : "If true, the dismount position will be forced to the specified position (mid-air OK), regardless of raycast result returning a hit within 2m below dismount offset point"
     },
     "text": {
       "name": "3D Text",

--- a/packages/engine/src/scene/components/MountPointComponent.ts
+++ b/packages/engine/src/scene/components/MountPointComponent.ts
@@ -62,11 +62,9 @@ export type MountPointTypes = (typeof MountPoint)[keyof typeof MountPoint]
 
 const MountPointTypesSchema = S.LiteralUnion(Object.values(MountPoint), 'seat')
 
-/**
- * @todo refactor this into i18n and configurable
- */
+/** Mapping of mount point types to interact messages using translation keys from i18n. */
 const mountPointInteractMessages = {
-  [MountPoint.seat]: 'Press E to Sit'
+  [MountPoint.seat]: 'editor:properties.mountPoint.interact-message-seat'
 }
 
 const mountCallbackName = 'mountEntity'
@@ -133,7 +131,7 @@ const unmountEntity = (entity: Entity) => {
   const mountComponent = getComponent(sittingComponent.mountPointEntity, MountPointComponent)
   //we use teleport avatar only when rigidbody is not enabled, otherwise translation is called on rigidbody
   const dismountPoint = new Vector3().copy(mountComponent.dismountOffset).applyMatrix4(mountTransform.matrixWorld)
-  teleportAvatar(entity, dismountPoint)
+  teleportAvatar(entity, dismountPoint, mountComponent.forceDismountPosition)
   removeComponent(entity, SittingComponent)
 }
 
@@ -143,7 +141,8 @@ export const MountPointComponent = defineComponent({
 
   schema: S.Object({
     type: MountPointTypesSchema,
-    dismountOffset: S.Vec3({ x: 0, y: 0, z: 0.75 })
+    dismountOffset: S.Vec3({ x: 0, y: 0, z: 0.75 }),
+    forceDismountPosition: S.Bool(false)
   }),
 
   mountEntity,

--- a/packages/spatial/src/physics/enums/CollisionGroups.ts
+++ b/packages/spatial/src/physics/enums/CollisionGroups.ts
@@ -31,9 +31,12 @@ export enum CollisionGroups {
   Trigger = 1 << 3
 }
 
+/** Default | Avatars | Ground */
 export const DefaultCollisionMask = CollisionGroups.Default | CollisionGroups.Avatars | CollisionGroups.Ground
 
+/** Default | Ground | Trigger */
 export const AvatarCollisionMask = CollisionGroups.Default | CollisionGroups.Ground | CollisionGroups.Trigger
 
+/** Default | Avatars | Ground | Trigger */
 export const AllCollisionMask =
   CollisionGroups.Default | CollisionGroups.Avatars | CollisionGroups.Ground | CollisionGroups.Trigger

--- a/packages/ui/src/components/editor/properties/mountPoint/index.tsx
+++ b/packages/ui/src/components/editor/properties/mountPoint/index.tsx
@@ -35,6 +35,7 @@ import { MountPoint, MountPointComponent } from '@ir-engine/engine/src/scene/com
 import { NO_PROXY } from '@ir-engine/hyperflux'
 import { LuUsers2 } from 'react-icons/lu'
 import { Vector3 } from 'three'
+import BooleanInput from '../../input/Boolean'
 import InputGroup from '../../input/Group'
 import SelectInput from '../../input/Select'
 import Vector3Input from '../../input/Vector3'
@@ -55,7 +56,7 @@ export const MountPointNodeEditor: EditorComponentType = (props) => {
     if (!hasComponent(props.entity, InteractableComponent)) {
       const mountPoint = getComponent(props.entity, MountPointComponent)
       EditorControlFunctions.addOrRemoveComponent([props.entity], InteractableComponent, true, {
-        label: MountPointComponent.mountPointInteractMessages[mountPoint.type],
+        label: t(MountPointComponent.mountPointInteractMessages[mountPoint.type]),
         callbacks: [
           {
             callbackID: MountPointComponent.mountCallbackName,
@@ -85,6 +86,17 @@ export const MountPointNodeEditor: EditorComponentType = (props) => {
           value={mountComponent.dismountOffset.get(NO_PROXY)}
           onChange={updateProperty(MountPointComponent, 'dismountOffset')}
           onRelease={commitProperty(MountPointComponent, 'dismountOffset')}
+        />
+      </InputGroup>
+      <InputGroup
+        name="Force Dismount Offset"
+        label={t('editor:properties.mountPoint.lbl-force-dismount')}
+        info={t('editor:properties.mountPoint.lbl-force-dismount-info')}
+      >
+        <BooleanInput
+          value={mountComponent.forceDismountPosition.value}
+          onChange={updateProperty(MountPointComponent, 'forceDismountPosition')}
+          onRelease={commitProperty(MountPointComponent, 'forceDismountPosition')}
         />
       </InputGroup>
     </NodeEditor>


### PR DESCRIPTION
## Summary
adding i18n and better descriptions to mount point, plus an override option on dismount to allow for dropping the avatar in midair (and explaining how dismount offset works)


## References
[https://tsu.atlassian.net/browse/IR-5078](https://tsu.atlassian.net/browse/IR-5078)

## QA Steps
choose a mount point dismount offset
enter play mode or spawn into a location
interact with the mount point to sit
move avatar to unmount

observe that you will either:
- dismount at the offset position if it within 2m above a valid collider and "force dismount position" is false (otherwise dismount in-place)
- dismount at offset position regardless of raycast results if "force dismount position" is true