### PR TITLE
Fix asset search

### DIFF
--- a/packages/editor/src/panels/assets/hooks.tsx
+++ b/packages/editor/src/panels/assets/hooks.tsx
@@ -25,7 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { API } from '@ir-engine/common'
 import { StaticResourceQuery, StaticResourceType, staticResourcePath } from '@ir-engine/common/src/schema.type.module'
-import { State, useHookstate } from '@ir-engine/hyperflux'
+import { State, useHookstate, usePrevious } from '@ir-engine/hyperflux'
 import React, { ReactNode, createContext, useContext, useEffect } from 'react'
 import { ASSETS_PAGE_LIMIT, Category, calculateItemsToFetch, iterativelyListTags, mapCategoriesHelper } from './helpers'
 
@@ -54,6 +54,7 @@ export const AssetsQueryProvider = ({ children }: { children: ReactNode }) => {
   const categories = useHookstate<Category[]>([])
   const expandedCategories = useHookstate({} as { [key: string]: boolean })
   const categorySidbarWidth = useHookstate(300)
+  const previousSearchQuery = usePrevious(search.query)
 
   const staticResourcesFindApi = () => {
     const abortController = new AbortController()
@@ -98,12 +99,12 @@ export const AssetsQueryProvider = ({ children }: { children: ReactNode }) => {
         .then((fetchedResources) => {
           if (abortController.signal.aborted) return
 
-          if (staticResourcesPagination.skip.value > 0) {
+          if (staticResourcesPagination.skip.value > 0 && previousSearchQuery === search.query.value) {
             resources.merge(fetchedResources.data)
           } else {
             resources.set(fetchedResources.data)
           }
-          staticResourcesPagination.merge({ total: fetchedResources.total })
+          staticResourcesPagination.merge({ total: resources.length })
           resourcesLoading.set(false)
         })
     }

--- a/packages/editor/src/panels/assets/topbar.tsx
+++ b/packages/editor/src/panels/assets/topbar.tsx
@@ -135,7 +135,7 @@ export default function Topbar() {
   const { t } = useTranslation()
   const { search } = useAssetsQuery()
   const { currentCategoryPath, expandedCategories } = useAssetsCategory()
-  const { refetchResources } = useAssetsQuery()
+  const { refetchResources, staticResourcesPagination } = useAssetsQuery()
 
   const handleBack = () => {
     currentCategoryPath.set((path) => path.slice(0, -1))
@@ -147,7 +147,10 @@ export default function Topbar() {
     refetchResources()
   }
 
-  useEffect(() => refetchResources(), [search.query])
+  useEffect(() => {
+    staticResourcesPagination.skip.set(0)
+    refetchResources()
+  }, [search.query])
 
   return (
     <div className="mb-1 flex h-8 items-center gap-2 bg-[#212226] py-1" data-testid="assets-panel-top-bar">


### PR DESCRIPTION
## Summary
- Reset the `skip` parameter when search string is changed.
- Merge search results only on scroll events, and not when search string is changed.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-5150

## QA Steps
