### PR TITLE
IR-5170 Add support for collider entity sourced trigger events

### DIFF
--- a/packages/spatial/src/physics/classes/Physics.ts
+++ b/packages/spatial/src/physics/classes/Physics.ts
@@ -98,6 +98,12 @@ export type PhysicsWorld = World & {
   drainContacts: ReturnType<typeof Physics.drainContactEventQueue>
 }
 
+declare module '@dimforge/rapier3d-compat' {
+  export interface Collider {
+    userData: { entity: Entity }
+  }
+}
+
 async function load() {
   return RAPIER.init()
 }
@@ -554,6 +560,7 @@ function attachCollider(
   const rigidBody = world.Rigidbodies.get(rigidBodyEntity) // guaranteed will exist
   if (!rigidBody) return console.error('Rigidbody not found for entity ' + rigidBodyEntity)
   const collider = world.createCollider(colliderDesc, rigidBody)
+  collider.userData = { entity: colliderEntity }
   world.Colliders.set(colliderEntity, collider)
   return collider
 }

--- a/packages/spatial/src/physics/systems/TriggerSystem.test.ts
+++ b/packages/spatial/src/physics/systems/TriggerSystem.test.ts
@@ -127,7 +127,7 @@ describe('TriggerSystem', () => {
   })
 
   describe('triggerEnter', () => {
-    const Hit = {} as ColliderHitEvent // @todo The hitEvent argument is currently ignored in the function body
+    const Hit = { type: CollisionEvents.TRIGGER_START } as ColliderHitEvent // @todo The hitEvent argument is currently ignored in the function body
     describe('for all entity.triggerComponent.triggers ...', () => {
       it('... should only run if trigger.target defines the UUID of a valid entity', () => {
         setComponent(triggerEntity, TriggerComponent, {
@@ -160,7 +160,7 @@ describe('TriggerSystem', () => {
   })
 
   describe('triggerExit', () => {
-    const Hit = {} as ColliderHitEvent // @todo The hitEvent argument is currently ignored in the function body
+    const Hit = { type: CollisionEvents.TRIGGER_END } as ColliderHitEvent // @todo The hitEvent argument is currently ignored in the function body
     describe('for all entity.triggerComponent.triggers ...', () => {
       it('... should only run if trigger.target defines the UUID of a valid entity', () => {
         setComponent(triggerEntity, TriggerComponent, {
@@ -215,6 +215,7 @@ describe('TriggerSystem', () => {
       const beforeExit = ExitStartValue + 1
       assert.equal(enterVal, beforeEnter)
       assert.equal(exitVal, beforeExit)
+      console.log(enterVal, exitVal)
       triggerSystemExecute()
       assert.equal(enterVal, beforeEnter)
       assert.equal(exitVal, beforeExit)

--- a/packages/spatial/src/physics/systems/TriggerSystem.test.ts
+++ b/packages/spatial/src/physics/systems/TriggerSystem.test.ts
@@ -51,7 +51,7 @@ import { CollisionComponent } from '../components/CollisionComponent'
 import { RigidBodyComponent } from '../components/RigidBodyComponent'
 import { TriggerComponent } from '../components/TriggerComponent'
 import { ColliderHitEvent, CollisionEvents } from '../types/PhysicsTypes'
-import { TriggerSystem, triggerEnter, triggerExit } from './TriggerSystem'
+import { TriggerSystem, triggerEnterOrExit } from './TriggerSystem'
 
 describe('TriggerSystem', () => {
   describe('IDs', () => {
@@ -134,7 +134,7 @@ describe('TriggerSystem', () => {
           triggers: [{ onEnter: TestOnEnterName, onExit: TestOnExitName, target: InvalidEntityUUID }]
         })
         assert.equal(enterVal, EnterStartValue)
-        triggerEnter(triggerEntity, targetEntity, Hit)
+        triggerEnterOrExit(triggerEntity, targetEntity, Hit)
         assert.equal(enterVal, EnterStartValue)
       })
 
@@ -147,13 +147,13 @@ describe('TriggerSystem', () => {
           triggers: [{ onEnter: null, onExit: TestOnExitName, target: noEnterEntityUUID }]
         })
         assert.equal(enterVal, EnterStartValue)
-        triggerEnter(triggerEntity, targetEntity, Hit)
+        triggerEnterOrExit(triggerEntity, targetEntity, Hit)
         assert.equal(enterVal, EnterStartValue)
       })
 
       it('... should run the target.CallbackComponent.callbacks[trigger.onEnter] function', () => {
         assert.equal(enterVal, EnterStartValue)
-        triggerEnter(triggerEntity, targetEntity, Hit)
+        triggerEnterOrExit(triggerEntity, targetEntity, Hit)
         assert.notEqual(enterVal, EnterStartValue)
       })
     })
@@ -167,7 +167,7 @@ describe('TriggerSystem', () => {
           triggers: [{ onEnter: TestOnEnterName, onExit: TestOnExitName, target: InvalidEntityUUID }]
         })
         assert.equal(exitVal, ExitStartValue)
-        triggerExit(triggerEntity, targetEntity, Hit)
+        triggerEnterOrExit(triggerEntity, targetEntity, Hit)
         assert.equal(exitVal, ExitStartValue)
       })
 
@@ -180,13 +180,13 @@ describe('TriggerSystem', () => {
           triggers: [{ onEnter: TestOnEnterName, onExit: null, target: noExitEntityUUID }]
         })
         assert.equal(exitVal, ExitStartValue)
-        triggerExit(triggerEntity, targetEntity, Hit)
+        triggerEnterOrExit(triggerEntity, targetEntity, Hit)
         assert.equal(exitVal, ExitStartValue)
       })
 
       it('... should run the target.CallbackComponent.callbacks[trigger.onExit] function', () => {
         assert.equal(exitVal, ExitStartValue)
-        triggerExit(triggerEntity, targetEntity, Hit)
+        triggerEnterOrExit(triggerEntity, targetEntity, Hit)
         assert.notEqual(exitVal, ExitStartValue)
       })
     })

--- a/packages/spatial/src/physics/systems/TriggerSystem.ts
+++ b/packages/spatial/src/physics/systems/TriggerSystem.ts
@@ -36,15 +36,15 @@ import { ColliderHitEvent, CollisionEvents } from '@ir-engine/spatial/src/physic
 import { TriggerComponent } from '../components/TriggerComponent'
 
 export const triggerEnterOrExit = (triggerEntity: Entity, otherEntity: Entity, hit: ColliderHitEvent) => {
-  const triggerComponent = getComponent(hit.shapeSelf.userData.entity, TriggerComponent)
+  const triggerComponent = getOptionalComponent(hit.shapeSelf?.userData.entity ?? triggerEntity, TriggerComponent)
   if (!triggerComponent) return
   for (const trigger of triggerComponent.triggers) {
     if (trigger.target && !UUIDComponent.getEntityByUUID(trigger.target)) continue
     const targetEntity = trigger.target ? UUIDComponent.getEntityByUUID(trigger.target) : triggerEntity
-    if (targetEntity && trigger.onEnter) {
+    if (targetEntity && (trigger.onEnter || trigger.onExit)) {
       const callbacks = getOptionalComponent(targetEntity, CallbackComponent)
       if (!callbacks) continue
-      callbacks.get(hit.type === CollisionEvents.TRIGGER_START ? trigger.onEnter : trigger.onExit!)?.(
+      callbacks.get(hit.type === CollisionEvents.TRIGGER_START ? trigger.onEnter! : trigger.onExit!)?.(
         triggerEntity,
         otherEntity
       )

--- a/packages/spatial/src/physics/systems/TriggerSystem.ts
+++ b/packages/spatial/src/physics/systems/TriggerSystem.ts
@@ -35,42 +35,30 @@ import { ColliderHitEvent, CollisionEvents } from '@ir-engine/spatial/src/physic
 
 import { TriggerComponent } from '../components/TriggerComponent'
 
-export const triggerEnter = (triggerEntity: Entity, otherEntity: Entity, hit: ColliderHitEvent) => {
-  const triggerComponent = getComponent(triggerEntity, TriggerComponent)
+export const triggerEnterOrExit = (triggerEntity: Entity, otherEntity: Entity, hit: ColliderHitEvent) => {
+  const triggerComponent = getComponent(hit.shapeSelf.userData.entity, TriggerComponent)
+  if (!triggerComponent) return
   for (const trigger of triggerComponent.triggers) {
     if (trigger.target && !UUIDComponent.getEntityByUUID(trigger.target)) continue
     const targetEntity = trigger.target ? UUIDComponent.getEntityByUUID(trigger.target) : triggerEntity
     if (targetEntity && trigger.onEnter) {
       const callbacks = getOptionalComponent(targetEntity, CallbackComponent)
       if (!callbacks) continue
-      callbacks.get(trigger.onEnter)?.(triggerEntity, otherEntity)
+      callbacks.get(hit.type === CollisionEvents.TRIGGER_START ? trigger.onEnter : trigger.onExit!)?.(
+        triggerEntity,
+        otherEntity
+      )
     }
   }
 }
 
-export const triggerExit = (triggerEntity: Entity, otherEntity: Entity, hit: ColliderHitEvent) => {
-  const triggerComponent = getComponent(triggerEntity, TriggerComponent)
-  for (const trigger of triggerComponent.triggers) {
-    if (trigger.target && !UUIDComponent.getEntityByUUID(trigger.target)) continue
-    const targetEntity = trigger.target ? UUIDComponent.getEntityByUUID(trigger.target) : triggerEntity
-    if (targetEntity && trigger.onExit) {
-      const callbacks = getOptionalComponent(targetEntity, CallbackComponent)
-      if (!callbacks) continue
-      callbacks.get(trigger.onExit)?.(triggerEntity, otherEntity)
-    }
-  }
-}
-
-const collisionQuery = defineQuery([TriggerComponent, CollisionComponent])
+const collisionQuery = defineQuery([CollisionComponent])
 
 const execute = () => {
   for (const entity of collisionQuery()) {
     for (const [e, hit] of getComponent(entity, CollisionComponent)) {
-      if (hit.type === CollisionEvents.TRIGGER_START) {
-        triggerEnter(entity, e, hit)
-      }
-      if (hit.type === CollisionEvents.TRIGGER_END) {
-        triggerExit(entity, e, hit)
+      if (hit.type === CollisionEvents.TRIGGER_START || hit.type === CollisionEvents.TRIGGER_END) {
+        triggerEnterOrExit(entity, e, hit)
       }
     }
   }


### PR DESCRIPTION
## Summary
A small proposed refactor of the trigger system to source trigger events from the collider rather than the rigidbody entity. This fixes triggers as children of rigidbodies not working.

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-5170](https://tsu.atlassian.net/browse/IR-5170)

## QA Steps


[IR-5170]: https://tsu.atlassian.net/browse/IR-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ