### PR TITLE
RC0.9 IR-5195 remove entity crash

### DIFF
--- a/packages/engine/src/interaction/components/InteractableComponent.ts
+++ b/packages/engine/src/interaction/components/InteractableComponent.ts
@@ -225,14 +225,6 @@ const addInteractableUI = (entity: Entity) => {
   return uiEntity
 }
 
-// const removeInteractableUI = (entity: Entity) => {
-//   const interactable = getOptionalComponent(entity, InteractableComponent)
-//   if (!interactable || interactable?.uiEntity == UndefinedEntity) return //null or empty label = no ui
-//
-//   removeEntity(interactable.uiEntity)
-//   getMutableComponent(entity, InteractableComponent).uiEntity.set(UndefinedEntity)
-// }
-
 export const InteractableComponent = defineComponent({
   name: 'InteractableComponent',
   jsonID: 'EE_interactable',

--- a/packages/engine/src/interaction/components/InteractableComponent.ts
+++ b/packages/engine/src/interaction/components/InteractableComponent.ts
@@ -222,29 +222,22 @@ const addInteractableUI = (entity: Entity) => {
   const transition = createTransitionState(0.25)
   transition.setState('OUT')
   InteractableTransitions.set(entity, transition)
+  return uiEntity
 }
 
-const removeInteractableUI = (entity: Entity) => {
-  const interactable = getComponent(entity, InteractableComponent)
-  if (interactable.uiEntity == UndefinedEntity) return //null or empty label = no ui
-
-  removeEntity(interactable.uiEntity)
-  getMutableComponent(entity, InteractableComponent).uiEntity.set(UndefinedEntity)
-}
+// const removeInteractableUI = (entity: Entity) => {
+//   const interactable = getOptionalComponent(entity, InteractableComponent)
+//   if (!interactable || interactable?.uiEntity == UndefinedEntity) return //null or empty label = no ui
+//
+//   removeEntity(interactable.uiEntity)
+//   getMutableComponent(entity, InteractableComponent).uiEntity.set(UndefinedEntity)
+// }
 
 export const InteractableComponent = defineComponent({
   name: 'InteractableComponent',
   jsonID: 'EE_interactable',
 
   schema: S.Object({
-    //TODO reimpliment the frustum culling for interactables
-
-    //TODO check if highlight works properly on init and with non clickInteract
-    //TODO simplify button logic in inputUpdate
-
-    //TODO after that is done, get rid of custom updates and add a state bool for "interactable" or "showUI"...think about best name
-
-    //TODO canInteract for grabbed state on grabbable?
     canInteract: S.Bool(false),
     uiInteractable: S.Bool(true),
     uiEntity: S.Entity(),
@@ -283,7 +276,6 @@ export const InteractableComponent = defineComponent({
         removeComponent(entity, DistanceFromCameraComponent)
         removeComponent(entity, DistanceFromLocalClientComponent)
         removeComponent(entity, BoundingBoxComponent)
-        removeInteractableUI(entity)
       }
     }, [])
 
@@ -309,15 +301,16 @@ export const InteractableComponent = defineComponent({
 
     useEffect(() => {
       if (!isEditing.value) {
-        addInteractableUI(entity)
-      }
-      return () => {
-        removeInteractableUI(entity)
+        const uiEntity = addInteractableUI(entity)
+        return () => {
+          if (uiEntity) {
+            removeEntity(uiEntity)
+          }
+        }
       }
     }, [isEditing.value])
 
     useEffect(() => {
-      //const xrUI = getMutableComponent(interactableComponent.uiEntity, XRUIComponent)
       const msg = interactableComponent.label?.value ?? ''
       modalState.interactMessage?.set(msg)
     }, [interactableComponent.label]) //TODO just nuke the whole XRUI and recreate....


### PR DESCRIPTION
## Summary
fixing cleanup of interactables that was causing issues with xrui entity

## References
[https://tsu.atlassian.net/browse/IR-5195](https://tsu.atlassian.net/browse/IR-5195)

## QA Steps
1 create an entity and add an interactable component and primitive geometry
2 delete said entity
3 check for errors

repeat in play mode with the xrui open
1 create an entity and add an interactable component and primitive geometry
2 enter preview/play mode and walk the avatar close to the interactable to open the "E" ui
3 delete said entity
4 check for errors
