### PR TITLE
Fixed bug in static-resource patching

### DIFF
--- a/packages/editor/src/panels/files/modals/FilePropertiesModal.tsx
+++ b/packages/editor/src/panels/files/modals/FilePropertiesModal.tsx
@@ -111,7 +111,7 @@ export default function FilePropertiesModal() {
           licensing: resourceDigest.licensing.value,
           attribution: resourceDigest.attribution.value,
           description: resourceDigest.description.value,
-          project: projectName
+          project: resource.project
         })
       }
       modifiedFields.set([])


### PR DESCRIPTION
## Summary

FilePropertiesModal was patching static-resources with the project currently loaded in the studio, which may not be the project of the file being changed. e.g. if a user is on the project projectA, but they edit an asset in projectB, it was patching that projectB asset to belong to projectA. Then, when updating the resources.json file, it was updating the resources.json of the project of that asset, which would now be projectA's resources.json. projectB's resources.json would be left untouched, and projectA's would now have an entry for an asset that it didn't own.

Resolves IR-5208

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
