### PR TITLE
Updated .dockerignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,8 +7,10 @@ kubectl
 lib/
 packages/client/dist
 readme/
-tests/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json

--- a/dockerfiles/api/Dockerfile-api-client.dockerignore
+++ b/dockerfiles/api/Dockerfile-api-client.dockerignore
@@ -6,20 +6,17 @@ node_modules
 kubectl
 lib/
 readme/
-tests/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json
 packages/instanceserver
 packages/taskserver
-packages/projects/projects/*/public
-packages/projects/projects/*/assets
-packages/projects/projects/*/*.png
-packages/projects/projects/*/*.jpg
-packages/projects/projects/*/*.jpeg
-packages/projects/projects/*/*.ktx2
-packages/projects/projects/*/*.scene.json
+packages/projects/projects/*/*/public
+packages/projects/projects/*/*/assets
 
 
 kubernetes/**

--- a/dockerfiles/api/Dockerfile-api.dockerignore
+++ b/dockerfiles/api/Dockerfile-api.dockerignore
@@ -7,8 +7,10 @@ kubectl
 lib/
 packages/client/dist
 readme/
-tests/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json
@@ -18,13 +20,8 @@ packages/editor
 packages/instanceserver
 packages/taskserver
 packages/ui
-packages/projects/projects/*/public
-packages/projects/projects/*/assets
-packages/projects/projects/*/*.png
-packages/projects/projects/*/*.jpg
-packages/projects/projects/*/*.jpeg
-packages/projects/projects/*/*.ktx2
-packages/projects/projects/*/*.scene.json
+packages/projects/projects/*/*/public
+packages/projects/projects/*/*/assets
 
 kubernetes/**
 .vscode

--- a/dockerfiles/builder/Dockerfile-builder.dockerignore
+++ b/dockerfiles/builder/Dockerfile-builder.dockerignore
@@ -7,7 +7,10 @@ kubectl
 lib/
 packages/client/dist
 readme/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json

--- a/dockerfiles/client/Dockerfile-client-serve-static.dockerignore
+++ b/dockerfiles/client/Dockerfile-client-serve-static.dockerignore
@@ -7,21 +7,18 @@ kubectl
 lib/
 packages/client/dist
 readme/
-tests/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json
 packages/instanceserver
 packages/server
 packages/taskserver
-packages/projects/projects/*/public
-packages/projects/projects/*/assets
-packages/projects/projects/*/*.png
-packages/projects/projects/*/*.jpg
-packages/projects/projects/*/*.jpeg
-packages/projects/projects/*/*.ktx2
-packages/projects/projects/*/*.scene.json
+packages/projects/projects/*/*/public
+packages/projects/projects/*/*/assets
 
 
 kubernetes/**

--- a/dockerfiles/client/Dockerfile-client.dockerignore
+++ b/dockerfiles/client/Dockerfile-client.dockerignore
@@ -7,21 +7,18 @@ kubectl
 lib/
 packages/client/dist
 readme/
-tests/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json
 packages/instanceserver
 packages/server
 packages/taskserver
-packages/projects/projects/*/public
-packages/projects/projects/*/assets
-packages/projects/projects/*/*.png
-packages/projects/projects/*/*.jpg
-packages/projects/projects/*/*.jpeg
-packages/projects/projects/*/*.ktx2
-packages/projects/projects/*/*.scene.json
+packages/projects/projects/*/*/public
+packages/projects/projects/*/*/assets
 
 
 kubernetes/**

--- a/dockerfiles/instanceserver/Dockerfile-instanceserver.dockerignore
+++ b/dockerfiles/instanceserver/Dockerfile-instanceserver.dockerignore
@@ -7,8 +7,10 @@ kubectl
 lib/
 packages/client/dist
 readme/
-tests/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json
@@ -18,13 +20,8 @@ packages/editor
 packages/server
 packages/taskserver
 packages/ui
-packages/projects/projects/*/public
-packages/projects/projects/*/assets
-packages/projects/projects/*/*.png
-packages/projects/projects/*/*.jpg
-packages/projects/projects/*/*.jpeg
-packages/projects/projects/*/*.ktx2
-packages/projects/projects/*/*.scene.json
+packages/projects/projects/*/*/public
+packages/projects/projects/*/*/assets
 
 
 kubernetes/**

--- a/dockerfiles/taskserver/Dockerfile-taskserver.dockerignore
+++ b/dockerfiles/taskserver/Dockerfile-taskserver.dockerignore
@@ -7,8 +7,10 @@ kubectl
 lib/
 packages/client/dist
 readme/
-tests/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json
@@ -18,13 +20,8 @@ packages/editor
 packages/instanceserver
 packages/server
 packages/ui
-packages/projects/projects/*/public
-packages/projects/projects/*/assets
-packages/projects/projects/*/*.png
-packages/projects/projects/*/*.jpg
-packages/projects/projects/*/*.jpeg
-packages/projects/projects/*/*.ktx2
-packages/projects/projects/*/*.scene.json
+packages/projects/projects/*/*/public
+packages/projects/projects/*/*/assets
 
 
 kubernetes/**

--- a/dockerfiles/testbot/Dockerfile-testbot.dockerignore
+++ b/dockerfiles/testbot/Dockerfile-testbot.dockerignore
@@ -6,18 +6,15 @@ node_modules
 kubectl
 lib/
 packages/client/dist
-readme/
-vendor/
+**/*.test.ts
+**/*.test.tsx
+**/tests/
+**/vendor/
 packages/**/node_modules
 package-lock.json
 packages/**/package-lock.json
-packages/projects/projects/*/public
-packages/projects/projects/*/assets
-packages/projects/projects/*/*.png
-packages/projects/projects/*/*.jpg
-packages/projects/projects/*/*.jpeg
-packages/projects/projects/*/*.ktx2
-packages/projects/projects/*/*.scene.json
+packages/projects/projects/*/*/public
+packages/projects/projects/*/*/assets
 
 
 kubernetes/**


### PR DESCRIPTION
## Summary

`tests` and `vendor` folders now match those anywhere in the hierarchy

projects' `public` and `assets` folders updated to match the fact that projects are now namespaced, so those folders will be two levels deep.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
