### PR TITLE
Ensure archiver only downloads requested folder

### DIFF
--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -679,6 +679,7 @@ export class S3Provider implements StorageProviderInterface {
    * @param recursive If true it will list content from sub folders as well.
    */
   async listFolderContent(folderName: string, recursive = false): Promise<FileBrowserContentType[]> {
+    folderName = folderName.endsWith('/') ? folderName : folderName + '/'
     const folderContent = await this.listObjects(folderName, recursive)
 
     const promises: Promise<FileBrowserContentType>[] = []


### PR DESCRIPTION
## Summary

- ensure s3 storage provider forces slash at the end of folder
- exclude node modules folder
- gracefully fail zipping each file

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
