### PR TITLE
Only show alpha editor options for supported image types - dev

### DIFF
--- a/packages/engine/src/assets/constants/AssetType.ts
+++ b/packages/engine/src/assets/constants/AssetType.ts
@@ -131,10 +131,15 @@ export const FileExtToAssetExt = (fileExt: string): AssetExt | undefined => {
   return <AssetExt>fileExt
 }
 
+const dataURLStart = 'data:image'
 export const FileToAssetExt = (file: string): AssetExt | undefined => {
   if (isURL(file)) {
     const url = new URL(file)
     file = url.pathname.split('/').pop() as string
+  }
+  // Check if image data url
+  else if (file.startsWith(dataURLStart)) {
+    return file.startsWith('/png', dataURLStart.length) ? AssetExt.PNG : AssetExt.JPEG
   }
   const ext = file.split('.').pop()
   return ext ? FileExtToAssetExt(ext) : undefined

--- a/packages/ui/src/components/editor/properties/image/sourceProperties/index.tsx
+++ b/packages/ui/src/components/editor/properties/image/sourceProperties/index.tsx
@@ -33,6 +33,7 @@ import { ImageComponent } from '@ir-engine/engine/src/scene/components/ImageComp
 import InputSlider from '@ir-engine/client-core/src/common/components/InputSlider'
 import { useComponent } from '@ir-engine/ecs'
 import { EditorComponentType, commitProperty, updateProperty } from '@ir-engine/editor/src/components/properties/Util'
+import { AssetExt, FileToAssetExt } from '@ir-engine/engine/src/assets/constants/AssetType'
 import InputGroup from '../../../input/Group'
 import SelectInput from '../../../input/Select'
 
@@ -46,39 +47,49 @@ const ImageProjectionSideOptions = [
   { label: 'Both', value: DoubleSide }
 ]
 
+const supportsTransparency = (src: string) => {
+  const assetExt = FileToAssetExt(src)
+  return assetExt === AssetExt.PNG || assetExt === AssetExt.KTX2
+}
+
 export const ImageSourceProperties: EditorComponentType = (props) => {
   const { t } = useTranslation()
 
   const imageComponent = useComponent(props.entity, ImageComponent)
+  const showTransparencyOptions = supportsTransparency(imageComponent.source.value)
 
   return (
     <>
-      <InputGroup name="Transparency" label={t('editor:properties.image.lbl-transparency')}>
-        <SelectInput
-          key={props.entity}
-          options={imageTransparencyOptions}
-          value={imageComponent.alphaMode.value}
-          onChange={commitProperty(ImageComponent, 'alphaMode')}
-        />
-      </InputGroup>
+      {showTransparencyOptions && (
+        <>
+          <InputGroup name="Transparency" label={t('editor:properties.image.lbl-transparency')}>
+            <SelectInput
+              key={props.entity}
+              options={imageTransparencyOptions}
+              value={imageComponent.alphaMode.value}
+              onChange={commitProperty(ImageComponent, 'alphaMode')}
+            />
+          </InputGroup>
 
-      {imageComponent.alphaMode.value === ImageAlphaMode.Mask && (
-        <InputGroup
-          name="Alpha Cutoff"
-          label={t('editor:properties.image.lbl-alphaCutoff')}
-          info={t('editor:properties.image.info-alphaCutoff')}
-        >
-          <InputSlider
-            //icon={<Icon type={audioState.masterVolume.value == 0 ? 'VolumeOff' : 'VolumeUp'} />}
-            //label={t('user:usermenu.setting.lbl-volume')}
-            max={1}
-            min={0}
-            step={0.01}
-            value={imageComponent.alphaCutoff.value}
-            onChange={updateProperty(ImageComponent, 'alphaCutoff')}
-            onRelease={commitProperty(ImageComponent, 'alphaCutoff')}
-          />
-        </InputGroup>
+          {imageComponent.alphaMode.value === ImageAlphaMode.Mask && (
+            <InputGroup
+              name="Alpha Cutoff"
+              label={t('editor:properties.image.lbl-alphaCutoff')}
+              info={t('editor:properties.image.info-alphaCutoff')}
+            >
+              <InputSlider
+                //icon={<Icon type={audioState.masterVolume.value == 0 ? 'VolumeOff' : 'VolumeUp'} />}
+                //label={t('user:usermenu.setting.lbl-volume')}
+                max={1}
+                min={0}
+                step={0.01}
+                value={imageComponent.alphaCutoff.value}
+                onChange={updateProperty(ImageComponent, 'alphaCutoff')}
+                onRelease={commitProperty(ImageComponent, 'alphaCutoff')}
+              />
+            </InputGroup>
+          )}
+        </>
       )}
 
       <InputGroup name="Projection" label={t('editor:properties.image.lbl-projection')}>


### PR DESCRIPTION
## Summary
Only show transparency options in the ImageComponent editor if the asset type supports transparency

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
