### PR TITLE
Change default to Envmap to skybox

### DIFF
--- a/packages/engine/src/scene/components/EnvmapComponent.tsx
+++ b/packages/engine/src/scene/components/EnvmapComponent.tsx
@@ -82,7 +82,7 @@ export const EnvmapComponent = defineComponent({
   jsonID: 'EE_envmap',
 
   schema: S.Object({
-    type: S.LiteralUnion(Object.values(EnvMapSourceType), EnvMapSourceType.None),
+    type: S.LiteralUnion(Object.values(EnvMapSourceType), EnvMapSourceType.Skybox),
     envMapTextureType: S.LiteralUnion(Object.values(EnvMapTextureType), EnvMapTextureType.Equirectangular),
     envMapSourceColor: S.Color(0xfff),
     envMapSourceURL: S.String(''),


### PR DESCRIPTION
## Summary
When adding GLTF's in we are just adding in a Envmap component that is defaulted to None. Which doesn't do anything for us. So lets change the default.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
