### PR TITLE
IR-5340 fixing vanishing avatar at quality setting 0

### DIFF
--- a/packages/spatial/src/renderer/materials/constants/plugins/TransparencyDitheringComponent.tsx
+++ b/packages/spatial/src/renderer/materials/constants/plugins/TransparencyDitheringComponent.tsx
@@ -70,7 +70,8 @@ export const TransparencyDitheringPluginComponent = defineComponent({
       if (!materialComponent) return
       const material = materialComponent.material as Material
       const callback = (shader) => {
-        material.alphaTest = 0.5
+        //this auto-injects alphaTest into the shader but causes a race condition with the injecting the ditheringAlphatestChunk
+        // material.alphaTest = 0.5
         material.side = FrontSide
         const plugin = getComponent(entity, TransparencyDitheringPluginComponent)
 

--- a/packages/spatial/src/renderer/materials/constants/plugins/ditherShaderChunk.ts
+++ b/packages/spatial/src/renderer/materials/constants/plugins/ditherShaderChunk.ts
@@ -61,6 +61,7 @@ uniform int useWorldCalculation[2];
 export const ditheringAlphatestChunk = `
 // sample sine at screen space coordinates for dithering pattern
 float distance = 1.0;
+float alphaTest = 0.5;
 for(int i = 0; i < 2; i++){
     distance *= pow(clamp(distances[i]*length(centers[i] - (useWorldCalculation[i] == 1 ? vWorldPosition : vLocalPosition)), 0.0, 1.0), exponents[i]);
 }

--- a/packages/spatial/src/renderer/materials/constants/plugins/ditherShaderChunk.ts
+++ b/packages/spatial/src/renderer/materials/constants/plugins/ditherShaderChunk.ts
@@ -23,27 +23,32 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+/*
+NOTE: commenting out the #ifndef LAMBERT and #endif in the ditheringVertexUniform and ditheringVertex and ditheringFragUniform due to
+issue where avatar would vanish when forcing to LAMBERT material in qualitySettings 0 (sceneObjectSYstem.tsx and PerformanceState - forceBasicMaterials)
+- leaving as comments rather than removing for future context, as this used to work before but something changed
+*/
 /** glsl, vertex uniforms */
 export const ditheringVertexUniform = `
-#ifndef LAMBERT
+//#ifndef LAMBERT
     varying vec3 vWorldPosition;
-#endif
+//#endif
 varying vec3 vLocalPosition;
 `
 
 /** glsl, vertex main */
 export const ditheringVertex = `
-#ifndef LAMBERT
+//#ifndef LAMBERT
     vWorldPosition = (modelMatrix * vec4( transformed, 1.0 )).xyz;
-#endif
+//#endif
 vLocalPosition = position.xyz;
 `
 
 /** glsl, fragment uniforms */
 export const ditheringFragUniform = `
-#ifndef LAMBERT
+//#ifndef LAMBERT
     varying vec3 vWorldPosition;
-#endif
+//#endif
 varying vec3 vLocalPosition; 
 
 uniform vec3 centers[2];


### PR DESCRIPTION
## Summary
fixing issue with the shader find/replace when switching to lambert in the ditheringShaderChunk. commenting rather than removing for future context

## References
[https://tsu.atlassian.net/browse/IR-5340](https://tsu.atlassian.net/browse/IR-5340)

## QA Steps
open a location, go to profile ->settings->quality tab
change quality to 0
observe the avatar does not vanish (and should no longer be shiny)