### PR TITLE
remove tab text background color

### DIFF
--- a/packages/ui/src/components/editor/layout/Panel.tsx
+++ b/packages/ui/src/components/editor/layout/Panel.tsx
@@ -28,7 +28,7 @@ import Text from '../../../primitives/tailwind/Text'
 
 export const PanelTitle = ({ children }: { children: ReactNode }) => {
   return (
-    <Text fontSize="sm" className="bg-[#212226] leading-none">
+    <Text fontSize="sm" className="leading-none">
       {children}
     </Text>
   )


### PR DESCRIPTION
## Summary

remove a wrongly set text background color on tabs

## QA Steps

### Before

(check the slight blackish background around the text)

![image](https://github.com/user-attachments/assets/3d0a47fa-a0ca-4963-904e-01314416cb22)


### Now

![image](https://github.com/user-attachments/assets/574da51f-5073-431a-b68f-629092f46ccb)

