### PR TITLE
IR-4341 fixing distance calculation for follow camera startDistance, will rea…

### DIFF
--- a/packages/spatial/src/camera/components/FollowCameraComponent.ts
+++ b/packages/spatial/src/camera/components/FollowCameraComponent.ts
@@ -149,8 +149,8 @@ export const FollowCameraComponent = defineComponent({
       const distance = (windowHeight / windowWidth) * cameraSettings.startCameraDistance
 
       follow.merge({
-        distance: distance,
-        targetDistance: distance,
+        distance: cameraSettings.startCameraDistance,
+        targetDistance: cameraSettings.startCameraDistance,
         thirdPersonMinDistance: cameraSettings.minCameraDistance,
         thirdPersonMaxDistance: cameraSettings.maxCameraDistance,
         effectiveMinDistance: cameraSettings.minCameraDistance,


### PR DESCRIPTION
## Summary
fixing distance calculation for follow camera startDistance, will reactively update but will not lerp, as this would cause lerping on fresh load-in instead of actually starting at the startDistance

## References
[https://tsu.atlassian.net/browse/IR-4341](https://tsu.atlassian.net/browse/IR-4341)

## QA Steps
Create a new scene

Add entities

Click on preview scene

Go to camera settings component

Change start camera distance

Observe the app behavior