### PR TITLE
prevent circular dependency from crashing /admin pages

### DIFF
--- a/packages/spatial/src/transform/systems/TransformSystem.ts
+++ b/packages/spatial/src/transform/systems/TransformSystem.ts
@@ -53,7 +53,6 @@ import { composeMatrix, TransformComponent } from '../components/TransformCompon
 import { TransformSerialization } from '../TransformSerialization'
 
 const transformQuery = defineQuery([TransformComponent])
-const groupQuery = defineQuery([GroupComponent, VisibleComponent])
 
 const boundingBoxQuery = defineQuery([BoundingBoxComponent])
 
@@ -173,6 +172,9 @@ const sortAndMakeDirtyEntities = () => {
 }
 
 const execute = () => {
+  // define groupQuery inside execute to avoid circular dependency
+  const groupQuery = defineQuery([GroupComponent, VisibleComponent])
+
   const dirtySortedTransformEntities = sortedTransformEntities.filter(isDirty)
   for (const entity of dirtySortedTransformEntities) computeTransformMatrix(entity)
 


### PR DESCRIPTION
## Summary
quick fix for this error that appears when trying to load /admin routes:
![image](https://github.com/user-attachments/assets/86c1cb32-04bd-4608-99d0-4468a2720f41)
![image](https://github.com/user-attachments/assets/382ca98c-577e-4071-b766-58526727f983)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
