### PR TITLE
IR-5189 hiding synchronize option in media component editor until it can be fixed

### DIFF
--- a/packages/ui/src/components/editor/properties/media/index.tsx
+++ b/packages/ui/src/components/editor/properties/media/index.tsx
@@ -131,14 +131,14 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
       >
         <Checkbox checked={media.autoplay.value} onChange={commitProperty(MediaComponent, 'autoplay')} />
       </InputGroup>
-
-      <InputGroup
-        name="Synchronize"
-        label={t('editor:properties.media.lbl-synchronize')}
-        info={t('editor:properties.media.info-synchronize')}
-      >
-        <Checkbox checked={media.synchronize.value} onChange={commitProperty(MediaComponent, 'synchronize')} />
-      </InputGroup>
+      {/*hiding synchronize option until it can be fixed*/}
+      {/*<InputGroup*/}
+      {/*  name="Synchronize"*/}
+      {/*  label={t('editor:properties.media.lbl-synchronize')}*/}
+      {/*  info={t('editor:properties.media.info-synchronize')}*/}
+      {/*>*/}
+      {/*  <Checkbox checked={media.synchronize.value} onChange={commitProperty(MediaComponent, 'synchronize')} />*/}
+      {/*</InputGroup>*/}
 
       <ArrayInputGroup
         label={t('editor:properties.media.paths')}


### PR DESCRIPTION
## Summary
hiding synchronize option in media component editor until it can be fixed

## References
[https://tsu.atlassian.net/browse/IR-5189](https://tsu.atlassian.net/browse/IR-5189)

## QA Steps
inspect a media component
observe there is no longer a "synchronize" checkbox