### PR TITLE
Adding support for ' ' (space) and '–' (en-dash) characters in the names of files and scenes

### DIFF
--- a/packages/common/src/regex/index.ts
+++ b/packages/common/src/regex/index.ts
@@ -32,9 +32,7 @@ A filename is valid if:
   - any other characters are either alphanumeric, '_', '-', or '.'
 */
 
-// eslint-disable-next-line no-control-regex
-export const VALID_FILENAME_REGEX = /^([^_\W])([\w\-\.]{2,62})([^_\W])$/
-// eslint-disable-next-line no-control-regex
+export const VALID_FILENAME_REGEX = /^([^_\W])([\w\-\.– ]{2,62})([^_\W])$/
 export const WINDOWS_RESERVED_NAME_REGEX = /^(con|prn|aux|nul|com\d|lpt\d)$/i
 export const VALID_SCENE_NAME_REGEX = VALID_FILENAME_REGEX
 export const VALID_HEIRARCHY_SEARCH_REGEX = /[.*+?^${}()|[\]\\]/g
@@ -117,7 +115,7 @@ export const PROJECT_PUBLIC_REGEX = /projects\/+[a-zA-Z0-9-_@]+\/[a-zA-Z0-9-_]+\
  */
 export const PROJECT_THUMBNAIL_REGEX = /projects\/+[a-zA-Z0-9-_@]+\/[a-zA-Z0-9-_]+\/thumbnails\//
 
-export const VALID_PROJECT_NAME = /^(?!\s)[\w\-\s]+$/
+export const VALID_PROJECT_NAME = /^(?!\s)[\w\-\s–]+$/
 
 // =======================================================================
 // ========================= Helm Regex Patterns =========================

--- a/packages/common/tests/regex.test.ts
+++ b/packages/common/tests/regex.test.ts
@@ -59,7 +59,6 @@ describe('regex.test', () => {
         'asterisk*char',
         'control\0char',
         'another\ncontrol',
-        'file name',
         '< tag >',
         'key : value',
         'quote " example',
@@ -76,9 +75,7 @@ describe('regex.test', () => {
 
     it('should match valid filenames', () => {
       const validFilenames = [
-        'hello_world',
-        'hello-world',
-        'hello.world',
+        'hello_. -–world',
         'filename',
         'emailexample.com',
         'pathtofile',
@@ -489,8 +486,8 @@ describe('regex.test', () => {
     it('should match valid project paths', () => {
       const positiveCases = [
         'projects/ir-engine/project123',
-        'projects/ir-engine/project-name',
-        'projects/ir-engine/project_name',
+        'projects/ir-engine/project-–name',
+        'projects/ir-engine/project_ name',
         'projects/project/123',
         'projects/project/abc_def'
       ]


### PR DESCRIPTION
Closes [IR-4621](https://tsu.atlassian.net/browse/IR-4621).

[IR-4621]: https://tsu.atlassian.net/browse/IR-4621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ