### PR TITLE
IR-5464: Feature flag names as unique ids

### DIFF
--- a/packages/client-core/src/admin/components/settings/tabs/features.tsx
+++ b/packages/client-core/src/admin/components/settings/tabs/features.tsx
@@ -47,12 +47,12 @@ const FeaturesTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableR
 
   useEffect(() => {
     if (featureFlagSettings.status === 'success') {
-      const defaultTypes = getAllStringValueNodes(FeatureFlags)
-      const missingTypes = defaultTypes.filter(
-        (type) =>
+      const defaultFlagNames = getAllStringValueNodes(FeatureFlags)
+      const missingFlagNames = defaultFlagNames.filter(
+        (flagName) =>
           !featureFlagSettings.data.find(
             (flag) =>
-              flag.flagName === type &&
+              flag.flagName === flagName &&
               !Object.keys(flag)
                 .filter((key) => !defaultProps.includes(key))
                 .some((item) => !item)
@@ -60,8 +60,8 @@ const FeaturesTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableR
       )
 
       const updatedFeatures: FeatureFlagSettingType[] = [
-        ...missingTypes.map((type) => ({
-          flagName: type,
+        ...missingFlagNames.map((flagName) => ({
+          flagName,
           flagValue: true,
           id: '',
           createdAt: '',

--- a/packages/client-core/src/admin/components/settings/tabs/features.tsx
+++ b/packages/client-core/src/admin/components/settings/tabs/features.tsx
@@ -37,7 +37,7 @@ import { getAllStringValueNodes } from '@ir-engine/common/src/utils/getAllString
 import Accordion from '@ir-engine/ui/src/primitives/tailwind/Accordion'
 import Tooltip from '@ir-engine/ui/src/primitives/tailwind/Tooltip'
 
-const defaultProps = ['id', 'flagName', 'flagValue', 'userId', 'createdAt', 'updatedAt']
+const defaultProps = ['id', 'flagValue', 'userId', 'createdAt', 'updatedAt']
 
 const FeaturesTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableRefObject<HTMLDivElement>) => {
   const { t } = useTranslation()
@@ -49,10 +49,10 @@ const FeaturesTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableR
     if (featureFlagSettings.status === 'success') {
       const defaultFlagNames = getAllStringValueNodes(FeatureFlags)
       const missingFlagNames = defaultFlagNames.filter(
-        (flagName) =>
+        (flagId) =>
           !featureFlagSettings.data.find(
             (flag) =>
-              flag.flagName === flagName &&
+              flag.id === flagId &&
               !Object.keys(flag)
                 .filter((key) => !defaultProps.includes(key))
                 .some((item) => !item)
@@ -60,8 +60,8 @@ const FeaturesTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableR
       )
 
       const updatedFeatures: FeatureFlagSettingType[] = [
-        ...missingFlagNames.map((flagName) => ({
-          flagName,
+        ...missingFlagNames.map((flagId) => ({
+          flagId,
           flagValue: true,
           id: '',
           createdAt: '',
@@ -85,9 +85,9 @@ const FeaturesTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableR
       <div className="mt-6 grid grid-cols-1 gap-6">
         {displayedFeatures.value
           .toSorted()
-          .sort((a, b) => a.flagName.localeCompare(b.flagName))
+          .sort((a, b) => a.id.localeCompare(b.id))
           .map((feature) => (
-            <FeatureItem key={feature.flagName} feature={feature} />
+            <FeatureItem key={feature.id} feature={feature} />
           ))}
       </div>
     </Accordion>
@@ -105,7 +105,7 @@ const FeatureItem = ({ feature }: { feature: FeatureFlagSettingType }) => {
       await featureFlagSettingMutation.patch(feature.id, { flagValue: enabled })
     } else {
       await featureFlagSettingMutation.create({
-        flagName: feature.flagName,
+        id: feature.id,
         flagValue: enabled
       })
     }
@@ -115,7 +115,7 @@ const FeatureItem = ({ feature }: { feature: FeatureFlagSettingType }) => {
     <div key={feature.id} className="flex items-center">
       <Toggle
         containerClassName="justify-start"
-        label={feature.flagName}
+        label={feature.id}
         value={feature.flagValue}
         onChange={(value) => createOrUpdateFeatureFlag(feature, value)}
       />

--- a/packages/client-core/src/admin/components/settings/tabs/features.tsx
+++ b/packages/client-core/src/admin/components/settings/tabs/features.tsx
@@ -44,26 +44,27 @@ const FeaturesTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableR
   const displayedFeatures = useHookstate<FeatureFlagSettingType[]>([])
 
   const featureFlagSettings = useFind(featureFlagSettingPath, { query: { paginate: false } })
-
+  const missingFlagNames = useHookstate<string[]>([])
   useEffect(() => {
     if (featureFlagSettings.status === 'success') {
       const defaultFlagNames = getAllStringValueNodes(FeatureFlags)
-      const missingFlagNames = defaultFlagNames.filter(
-        (flagId) =>
-          !featureFlagSettings.data.find(
-            (flag) =>
-              flag.id === flagId &&
-              !Object.keys(flag)
-                .filter((key) => !defaultProps.includes(key))
-                .some((item) => !item)
-          )
+      missingFlagNames.set(
+        defaultFlagNames.filter(
+          (flagId) =>
+            !featureFlagSettings.data.find(
+              (flag) =>
+                flag.id === flagId &&
+                !Object.keys(flag)
+                  .filter((key) => !defaultProps.includes(key))
+                  .some((item) => !item)
+            )
+        )
       )
 
       const updatedFeatures: FeatureFlagSettingType[] = [
-        ...missingFlagNames.map((flagId) => ({
-          flagId,
+        ...missingFlagNames.value.map((id) => ({
+          id,
           flagValue: true,
-          id: '',
           createdAt: '',
           updatedAt: ''
         })),
@@ -87,21 +88,21 @@ const FeaturesTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableR
           .toSorted()
           .sort((a, b) => a.id.localeCompare(b.id))
           .map((feature) => (
-            <FeatureItem key={feature.id} feature={feature} />
+            <FeatureItem key={feature.id} feature={feature} exists={!missingFlagNames.value.includes(feature.id)} />
           ))}
       </div>
     </Accordion>
   )
 })
 
-const FeatureItem = ({ feature }: { feature: FeatureFlagSettingType }) => {
+const FeatureItem = ({ feature, exists }: { feature: FeatureFlagSettingType; exists: boolean }) => {
   const { t } = useTranslation()
 
   const featureFlagSettingMutation = useMutation(featureFlagSettingPath)
   const additionalProps = Object.keys(feature).filter((key) => !defaultProps.includes(key))
 
   const createOrUpdateFeatureFlag = async (feature: FeatureFlagSettingType, enabled: boolean) => {
-    if (feature.id) {
+    if (exists) {
       await featureFlagSettingMutation.patch(feature.id, { flagValue: enabled })
     } else {
       await featureFlagSettingMutation.create({

--- a/packages/client-core/src/hooks/useFeatureFlags.tsx
+++ b/packages/client-core/src/hooks/useFeatureFlags.tsx
@@ -26,10 +26,10 @@ Infinite Reality Engine. All Rights Reserved.
 import { useFind } from '@ir-engine/common'
 import { featureFlagSettingPath } from '@ir-engine/common/src/schema.type.module'
 
-const useFeatureFlags = (flagNames: string[]): boolean[] => {
+const useFeatureFlags = (flagIDs: string[]): boolean[] => {
   const response = useFind(featureFlagSettingPath, {
     query: {
-      $or: flagNames.map((flagName) => ({ flagName })),
+      $or: flagIDs.map((flagID) => ({ flagID })),
       paginate: false
     }
   })
@@ -38,8 +38,8 @@ const useFeatureFlags = (flagNames: string[]): boolean[] => {
     return []
   }
 
-  return flagNames.map((flagName) => {
-    const flag = response.data.find(({ flagName: name }) => name === flagName)
+  return flagIDs.map((flagID) => {
+    const flag = response.data.find(({ id }) => id === flagID)
     return flag ? flag.flagValue : true
   })
 }

--- a/packages/client-core/src/hooks/useFeatureFlags.tsx
+++ b/packages/client-core/src/hooks/useFeatureFlags.tsx
@@ -29,7 +29,7 @@ import { featureFlagSettingPath } from '@ir-engine/common/src/schema.type.module
 const useFeatureFlags = (flagIDs: string[]): boolean[] => {
   const response = useFind(featureFlagSettingPath, {
     query: {
-      $or: flagIDs.map((flagID) => ({ flagID })),
+      $or: flagIDs.map((id) => ({ id })),
       paginate: false
     }
   })
@@ -38,8 +38,8 @@ const useFeatureFlags = (flagIDs: string[]): boolean[] => {
     return []
   }
 
-  return flagIDs.map((flagID) => {
-    const flag = response.data.find(({ id }) => id === flagID)
+  return flagIDs.map((id) => {
+    const flag = response.data.find((flag) => flag.id === id)
     return flag ? flag.flagValue : true
   })
 }

--- a/packages/common/src/schemas/setting/feature-flag-setting.schema.ts
+++ b/packages/common/src/schemas/setting/feature-flag-setting.schema.ts
@@ -40,7 +40,6 @@ export const featureFlagSettingSchema = Type.Object(
     id: Type.String({
       format: 'uuid'
     }),
-    flagName: Type.String(),
     flagValue: Type.Boolean(),
     userId: Type.Optional(
       TypedString<UserID>({
@@ -55,7 +54,7 @@ export const featureFlagSettingSchema = Type.Object(
 export interface FeatureFlagSettingType extends Static<typeof featureFlagSettingSchema> {}
 
 // Schema for creating new entries
-export const featureFlagSettingDataSchema = Type.Pick(featureFlagSettingSchema, ['flagName', 'flagValue', 'userId'], {
+export const featureFlagSettingDataSchema = Type.Pick(featureFlagSettingSchema, ['id', 'flagValue', 'userId'], {
   $id: 'FeatureFlagSettingData'
 })
 export interface FeatureFlagSettingData extends Static<typeof featureFlagSettingDataSchema> {}
@@ -67,7 +66,7 @@ export const featureFlagSettingPatchSchema = Type.Partial(featureFlagSettingSche
 export interface FeatureFlagSettingPatch extends Static<typeof featureFlagSettingPatchSchema> {}
 
 // Schema for allowed query properties
-export const featureFlagSettingQueryProperties = Type.Pick(featureFlagSettingSchema, ['id', 'flagName', 'flagValue'])
+export const featureFlagSettingQueryProperties = Type.Pick(featureFlagSettingSchema, ['id', 'flagValue'])
 export const featureFlagSettingQuerySchema = Type.Intersect(
   [
     querySyntax(featureFlagSettingQueryProperties),

--- a/packages/common/src/schemas/setting/feature-flag-setting.schema.ts
+++ b/packages/common/src/schemas/setting/feature-flag-setting.schema.ts
@@ -58,9 +58,12 @@ export const featureFlagSettingDataSchema = Type.Pick(featureFlagSettingSchema, 
 export interface FeatureFlagSettingData extends Static<typeof featureFlagSettingDataSchema> {}
 
 // Schema for updating existing entries
-export const featureFlagSettingPatchSchema = Type.Partial(featureFlagSettingSchema, {
-  $id: 'FeatureFlagSettingPatch'
-})
+export const featureFlagSettingPatchSchema = Type.Partial(
+  Type.Pick(featureFlagSettingSchema, ['id', 'flagValue', 'userId']),
+  {
+    $id: 'FeatureFlagSettingPatch'
+  }
+)
 export interface FeatureFlagSettingPatch extends Static<typeof featureFlagSettingPatchSchema> {}
 
 // Schema for allowed query properties

--- a/packages/common/src/schemas/setting/feature-flag-setting.schema.ts
+++ b/packages/common/src/schemas/setting/feature-flag-setting.schema.ts
@@ -37,9 +37,7 @@ export const featureFlagSettingMethods = ['find', 'get', 'create', 'patch', 'rem
 // Main data model schema
 export const featureFlagSettingSchema = Type.Object(
   {
-    id: Type.String({
-      format: 'uuid'
-    }),
+    id: Type.String(),
     flagValue: Type.Boolean(),
     userId: Type.Optional(
       TypedString<UserID>({

--- a/packages/server-core/src/setting/feature-flag-setting/feature-flag-setting.resolvers.ts
+++ b/packages/server-core/src/setting/feature-flag-setting/feature-flag-setting.resolvers.ts
@@ -25,7 +25,6 @@ Infinite Reality Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   FeatureFlagSettingQuery,
@@ -45,9 +44,6 @@ export const featureFlagSettingExternalResolver = resolve<FeatureFlagSettingType
 })
 
 export const featureFlagSettingDataResolver = resolve<FeatureFlagSettingType, HookContext>({
-  id: async () => {
-    return uuidv4()
-  },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql
 })

--- a/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
+++ b/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
@@ -1,0 +1,109 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import {
+  FeatureFlagSettingType,
+  featureFlagSettingPath
+} from '@ir-engine/common/src/schemas/setting/feature-flag-setting.schema'
+import type { Knex } from 'knex'
+import { v4 as uuidv4 } from 'uuid'
+
+type OldFeatureFlagSettingType = FeatureFlagSettingType & {
+  flagName: string
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  // as in "upgrade"
+
+  const flagNameColumnExists = await knex.schema.hasColumn(featureFlagSettingPath, 'flagName')
+
+  if (!flagNameColumnExists) {
+    return
+  }
+
+  const oldRows = await knex.select<OldFeatureFlagSettingType[]>().from(featureFlagSettingPath)
+
+  await knex.schema.dropTable(featureFlagSettingPath)
+
+  await knex.schema.createTable(featureFlagSettingPath, (table) => {
+    table.string('id').primary()
+    table.boolean('flagValue').notNullable()
+    table.dateTime('createdAt').notNullable()
+    table.dateTime('updatedAt').notNullable()
+  })
+
+  await knex
+    .insert(
+      oldRows.map((oldRow) => {
+        return {
+          ...oldRow,
+          id: oldRow.flagName
+        }
+      })
+    )
+    .into(featureFlagSettingPath)
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {
+  // as in "downgrade"
+
+  const flagNameColumnExists = await knex.schema.hasColumn(featureFlagSettingPath, 'flagName')
+  if (flagNameColumnExists) {
+    return
+  }
+
+  const newRows = await knex.select<FeatureFlagSettingType[]>().from(featureFlagSettingPath)
+
+  await knex.schema.dropTable(featureFlagSettingPath)
+
+  await knex.schema.createTable(featureFlagSettingPath, (table) => {
+    //@ts-ignore
+    table.uuid('id').collate('utf8mb4_bin').primary()
+    table.string('flagName').notNullable()
+    table.boolean('flagValue').notNullable()
+    table.dateTime('createdAt').notNullable()
+    table.dateTime('updatedAt').notNullable()
+  })
+
+  await knex
+    .insert(
+      newRows.map((newRow) => {
+        return {
+          ...newRow,
+          flagName: newRow.id,
+          id: uuidv4()
+        }
+      })
+    )
+    .into(featureFlagSettingPath)
+}

--- a/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
+++ b/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
@@ -41,51 +41,54 @@ type OldFeatureFlagSettingType = FeatureFlagSettingType & {
 export async function up(knex: Knex): Promise<void> {
   // as in "upgrade"
 
-  const flagNameColumnExists = await knex.schema.hasColumn(featureFlagSettingPath, 'flagName')
+  await knex.raw('SET FOREIGN_KEY_CHECKS=0')
 
-  if (!flagNameColumnExists) {
-    return
-  }
+  migrateUp: {
+    const flagNameColumnExists = await knex.schema.hasColumn(featureFlagSettingPath, 'flagName')
 
-  const oldRows = await knex.select<OldFeatureFlagSettingType[]>().from(featureFlagSettingPath)
-
-  console.log('Old rows:', oldRows)
-
-  const oldRowsByFlagName = new Map<string, OldFeatureFlagSettingType>()
-
-  for (const oldRow of oldRows) {
-    const flagName = oldRow.flagName
-    const existingUpdatedAt = oldRowsByFlagName.get(flagName)?.updatedAt
-    if (existingUpdatedAt != null && existingUpdatedAt > oldRow.updatedAt) {
-      continue
+    if (!flagNameColumnExists) {
+      break migrateUp
     }
-    oldRowsByFlagName.set(flagName, oldRow)
-  }
 
-  await knex.schema.dropTable(featureFlagSettingPath)
+    const oldRows = await knex.select<OldFeatureFlagSettingType[]>().from(featureFlagSettingPath)
+    const oldRowsByFlagName = new Map<string, OldFeatureFlagSettingType>()
 
-  await knex.schema.createTable(featureFlagSettingPath, (table) => {
-    table.string('id').primary()
-    table.uuid('userId').nullable()
-    table.boolean('flagValue').notNullable()
-    table.dateTime('createdAt').notNullable()
-    table.dateTime('updatedAt').notNullable()
-  })
+    for (const oldRow of oldRows) {
+      const flagName = oldRow.flagName
+      const existingUpdatedAt = oldRowsByFlagName.get(flagName)?.updatedAt
+      if (existingUpdatedAt != null && existingUpdatedAt > oldRow.updatedAt) {
+        continue
+      }
+      oldRowsByFlagName.set(flagName, oldRow)
+    }
 
-  const newRows = [...oldRowsByFlagName.values()].map((oldRow) => {
-    return {
+    await knex.schema.dropTable(featureFlagSettingPath)
+
+    await knex.schema.createTable(featureFlagSettingPath, (table) => {
+      table.string('id').primary()
+
+      //@ts-ignore
+      table.uuid('userId', 36).collate('utf8mb4_bin').nullable().index()
+      table.foreign('userId').references('id').inTable('user').onDelete('SET NULL').onUpdate('CASCADE')
+
+      table.boolean('flagValue').notNullable()
+      table.dateTime('createdAt').notNullable()
+      table.dateTime('updatedAt').notNullable()
+    })
+
+    const newRows = [...oldRowsByFlagName.values()].map((oldRow) => ({
       ...oldRow,
       id: oldRow.flagName
+    }))
+
+    if (newRows.length === 0) {
+      break migrateUp
     }
-  })
 
-  console.log('New rows:', newRows)
-
-  if (newRows.length === 0) {
-    return
+    await knex.insert(newRows).into(featureFlagSettingPath)
   }
 
-  await knex.insert(newRows).into(featureFlagSettingPath)
+  await knex.raw('SET FOREIGN_KEY_CHECKS=1')
 }
 
 /**
@@ -95,40 +98,44 @@ export async function up(knex: Knex): Promise<void> {
 export async function down(knex: Knex): Promise<void> {
   // as in "downgrade"
 
-  const flagNameColumnExists = await knex.schema.hasColumn(featureFlagSettingPath, 'flagName')
-  if (flagNameColumnExists) {
-    return
-  }
+  await knex.raw('SET FOREIGN_KEY_CHECKS=0')
 
-  const newRows = await knex.select<FeatureFlagSettingType[]>().from(featureFlagSettingPath)
+  migrateDown: {
+    const flagNameColumnExists = await knex.schema.hasColumn(featureFlagSettingPath, 'flagName')
+    if (flagNameColumnExists) {
+      break migrateDown
+    }
 
-  console.log('New rows:', newRows)
+    const newRows = await knex.select<FeatureFlagSettingType[]>().from(featureFlagSettingPath)
 
-  await knex.schema.dropTable(featureFlagSettingPath)
+    await knex.schema.dropTable(featureFlagSettingPath)
 
-  await knex.schema.createTable(featureFlagSettingPath, (table) => {
-    //@ts-ignore
-    table.uuid('id').collate('utf8mb4_bin').primary()
-    table.string('flagName').notNullable()
-    table.uuid('userId').nullable()
-    table.boolean('flagValue').notNullable()
-    table.dateTime('createdAt').notNullable()
-    table.dateTime('updatedAt').notNullable()
-  })
+    await knex.schema.createTable(featureFlagSettingPath, (table) => {
+      //@ts-ignore
+      table.uuid('id').collate('utf8mb4_bin').primary()
+      table.string('flagName').notNullable()
 
-  const oldRows = newRows.map((newRow) => {
-    return {
+      //@ts-ignore
+      table.uuid('userId', 36).collate('utf8mb4_bin').nullable().index()
+      table.foreign('userId').references('id').inTable('user').onDelete('SET NULL').onUpdate('CASCADE')
+
+      table.boolean('flagValue').notNullable()
+      table.dateTime('createdAt').notNullable()
+      table.dateTime('updatedAt').notNullable()
+    })
+
+    const oldRows = newRows.map((newRow) => ({
       ...newRow,
       flagName: newRow.id,
       id: uuidv4()
+    }))
+
+    if (oldRows.length === 0) {
+      break migrateDown
     }
-  })
 
-  console.log('Old rows:', oldRows)
-
-  if (oldRows.length === 0) {
-    return
+    await knex.insert(oldRows).into(featureFlagSettingPath)
   }
 
-  await knex.insert(oldRows).into(featureFlagSettingPath)
+  await knex.raw('SET FOREIGN_KEY_CHECKS=1')
 }

--- a/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
+++ b/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
@@ -66,6 +66,7 @@ export async function up(knex: Knex): Promise<void> {
 
   await knex.schema.createTable(featureFlagSettingPath, (table) => {
     table.string('id').primary()
+    table.uuid('userId').nullable()
     table.boolean('flagValue').notNullable()
     table.dateTime('createdAt').notNullable()
     table.dateTime('updatedAt').notNullable()
@@ -109,6 +110,7 @@ export async function down(knex: Knex): Promise<void> {
     //@ts-ignore
     table.uuid('id').collate('utf8mb4_bin').primary()
     table.string('flagName').notNullable()
+    table.uuid('userId').nullable()
     table.boolean('flagValue').notNullable()
     table.dateTime('createdAt').notNullable()
     table.dateTime('updatedAt').notNullable()

--- a/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
+++ b/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
@@ -76,10 +76,13 @@ export async function up(knex: Knex): Promise<void> {
       table.dateTime('updatedAt').notNullable()
     })
 
-    const newRows = [...oldRowsByFlagName.values()].map((oldRow) => ({
-      ...oldRow,
-      id: oldRow.flagName
-    }))
+    const newRows = [...oldRowsByFlagName.values()].map((oldRow) => {
+      const { flagName: id, ...properties } = oldRow
+      return {
+        ...properties,
+        id
+      }
+    })
 
     if (newRows.length === 0) {
       break migrateUp

--- a/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
+++ b/packages/server-core/src/setting/feature-flag-setting/migrations/20241105001200_primary_flagNames.ts
@@ -49,6 +49,19 @@ export async function up(knex: Knex): Promise<void> {
 
   const oldRows = await knex.select<OldFeatureFlagSettingType[]>().from(featureFlagSettingPath)
 
+  console.log('Old rows:', oldRows)
+
+  const oldRowsByFlagName = new Map<string, OldFeatureFlagSettingType>()
+
+  for (const oldRow of oldRows) {
+    const flagName = oldRow.flagName
+    const existingUpdatedAt = oldRowsByFlagName.get(flagName)?.updatedAt
+    if (existingUpdatedAt != null && existingUpdatedAt > oldRow.updatedAt) {
+      continue
+    }
+    oldRowsByFlagName.set(flagName, oldRow)
+  }
+
   await knex.schema.dropTable(featureFlagSettingPath)
 
   await knex.schema.createTable(featureFlagSettingPath, (table) => {
@@ -58,16 +71,20 @@ export async function up(knex: Knex): Promise<void> {
     table.dateTime('updatedAt').notNullable()
   })
 
-  await knex
-    .insert(
-      oldRows.map((oldRow) => {
-        return {
-          ...oldRow,
-          id: oldRow.flagName
-        }
-      })
-    )
-    .into(featureFlagSettingPath)
+  const newRows = [...oldRowsByFlagName.values()].map((oldRow) => {
+    return {
+      ...oldRow,
+      id: oldRow.flagName
+    }
+  })
+
+  console.log('New rows:', newRows)
+
+  if (newRows.length === 0) {
+    return
+  }
+
+  await knex.insert(newRows).into(featureFlagSettingPath)
 }
 
 /**
@@ -84,6 +101,8 @@ export async function down(knex: Knex): Promise<void> {
 
   const newRows = await knex.select<FeatureFlagSettingType[]>().from(featureFlagSettingPath)
 
+  console.log('New rows:', newRows)
+
   await knex.schema.dropTable(featureFlagSettingPath)
 
   await knex.schema.createTable(featureFlagSettingPath, (table) => {
@@ -95,15 +114,19 @@ export async function down(knex: Knex): Promise<void> {
     table.dateTime('updatedAt').notNullable()
   })
 
-  await knex
-    .insert(
-      newRows.map((newRow) => {
-        return {
-          ...newRow,
-          flagName: newRow.id,
-          id: uuidv4()
-        }
-      })
-    )
-    .into(featureFlagSettingPath)
+  const oldRows = newRows.map((newRow) => {
+    return {
+      ...newRow,
+      flagName: newRow.id,
+      id: uuidv4()
+    }
+  })
+
+  console.log('Old rows:', oldRows)
+
+  if (oldRows.length === 0) {
+    return
+  }
+
+  await knex.insert(oldRows).into(featureFlagSettingPath)
 }


### PR DESCRIPTION
Feature flags were getting duplicated in rare circumstances (related to how quickly a user changed a feature flag in the admin panel). We now assign flag IDs to the id field of the table, guaranteeing uniqueness.

https://tsu.atlassian.net/browse/IR-5464