### PR TITLE
Pinned helmet to ^6.0.0

### DIFF
--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -81,6 +81,7 @@
     "feathers-sync": "3.0.2",
     "flatted": "3.1.0",
     "fs-blob-store": "6.0.0",
+    "helmet": "^6.0.0",
     "internal-ip": "^6.1.0",
     "ipfs-http-client": "^56.0.3",
     "jose": "^5.9.2",


### PR DESCRIPTION
## Summary

Fixes weird recent issue where v4 of helmet was installed, and that broke createApp for some reason. koa-helmet couldn't import helmet in that situation.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
