### PR TITLE
Run npm install before projectEventHooks call

### DIFF
--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -83,6 +83,7 @@ import { getFileKeysRecursive } from '../../media/storageprovider/storageProvide
 import { createStaticResourceHash } from '../../media/upload-asset/upload-asset.service'
 import logger from '../../ServerLogger'
 import { ServerState } from '../../ServerState'
+import { execPromise } from '../../util/execPromise'
 import { getContentType } from '../../util/fileUtils'
 import { getGitConfigData, getGitHeadData, getGitOrigHeadData } from '../../util/getGitData'
 import { useGit } from '../../util/gitHelperFunctions'
@@ -1517,6 +1518,7 @@ export const updateProject = async (
     )
   }
   // run project install script
+  await execPromise(`npm install`, { cwd: appRootPath.path })
   if (projectConfig?.onEvent) {
     await onProjectEvent(app, returned, projectConfig.onEvent, existingProject ? 'onUpdate' : 'onInstall')
   }


### PR DESCRIPTION
## Summary

New projects may use dependencies that are not present in the core engine for their onInstall logic. We therefore need to run npm install before that so that those project-specific dependencies are installed on the pod running updateProject.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
