### PR TITLE
IR-5538 Clean up armature hierarchies after retargeting

### DIFF
--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.tsx
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.tsx
@@ -53,6 +53,10 @@ import { XRState } from '@ir-engine/spatial/src/xr/XRState'
 
 import { SkinnedMeshComponent } from '@ir-engine/spatial/src/renderer/components/SkinnedMeshComponent'
 import { RendererComponent } from '@ir-engine/spatial/src/renderer/WebGLRendererSystem'
+import {
+  EntityTreeComponent,
+  removeEntityNodeRecursively
+} from '@ir-engine/spatial/src/transform/components/EntityTree'
 import React from 'react'
 import { DomainConfigState } from '../../assets/state/DomainConfigState'
 import { GLTFComponent } from '../../gltf/GLTFComponent'
@@ -355,6 +359,8 @@ const AnimationReactor = () => {
         bindAnimationClipFromMixamo(animation)
       }
       getMutableState(AnimationState).loadedAnimations[animations[i]].set(loadedAnimationEntity[1]!)
+      for (const entity of getComponent(loadedAnimationEntity[1], EntityTreeComponent).children)
+        removeEntityNodeRecursively(entity)
       i++
     }
   }, [loadedAnimations])


### PR DESCRIPTION
## Summary
The ephemeral animation load hook (useLoadAnimation/FromBatchGLTF) has functionality for removing entities built in, however this is not used due to the need to keep these hierarchies around for retargeting calculations (conversion to vrm normalized pose space). This PR adds a line to recursively remove the armature entity hierarchies after retargeting.

## Subtasks Checklist

## Breaking Changes

## References
https://tsu.atlassian.net/browse/IR-5538

## QA Steps
