### PR TITLE
Add await conditions to gltf loader tests to prevent race conditions

### DIFF
--- a/packages/engine/src/gltf/GLTFLoader.test.tsx
+++ b/packages/engine/src/gltf/GLTFLoader.test.tsx
@@ -343,7 +343,12 @@ describe('GLTF Loader', () => {
     const { rerender, unmount } = render(<></>)
     applyIncomingActions()
     await act(() => rerender(<></>))
-
+    await vi.waitFor(
+      () => {
+        expect(getOptionalComponent(entity, AnimationComponent)).toBeTruthy()
+      },
+      { timeout: 20000 }
+    )
     const instanceID = GLTFComponent.getInstanceID(entity)
     const gltfDocumentState = getState(GLTFDocumentState)
     const gltf = gltfDocumentState[instanceID]
@@ -367,7 +372,7 @@ describe('GLTF Loader', () => {
       () => {
         expect(getOptionalComponent(entity, AnimationComponent)).toBeTruthy()
       },
-      { timeout: 100000 }
+      { timeout: 20000 }
     )
     const instanceID = GLTFComponent.getInstanceID(entity)
     const gltfDocumentState = getState(GLTFDocumentState)
@@ -388,7 +393,12 @@ describe('GLTF Loader', () => {
     const { rerender, unmount } = render(<></>)
     applyIncomingActions()
     await act(() => rerender(<></>))
-
+    await vi.waitFor(
+      () => {
+        expect(getOptionalComponent(entity, AnimationComponent)).toBeTruthy()
+      },
+      { timeout: 20000 }
+    )
     const instanceID = GLTFComponent.getInstanceID(entity)
     const gltfDocumentState = getState(GLTFDocumentState)
     const gltf = gltfDocumentState[instanceID]
@@ -497,6 +507,12 @@ describe('GLTF Loader', () => {
     const { rerender, unmount } = render(<></>)
     applyIncomingActions()
     await act(() => rerender(<></>))
+    await vi.waitFor(
+      () => {
+        expect(getChildrenWithComponents(entity, [EXTMeshGPUInstancingComponent]).length).toBeTruthy()
+      },
+      { timeout: 20000 }
+    )
 
     const instanceID = GLTFComponent.getInstanceID(entity)
     const gltfDocumentState = getState(GLTFDocumentState)


### PR DESCRIPTION
## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
