### PR TITLE
Fixed opening files in new tab

### DIFF
--- a/packages/editor/src/panels/files/contextmenu.tsx
+++ b/packages/editor/src/panels/files/contextmenu.tsx
@@ -156,7 +156,7 @@ export function FileContextMenu({
           <DropdownItem
             data-testid="files-panel-file-item-context-menu-open-in-new-tab-button"
             onClick={() => {
-              selectedFiles.filter((file) => !file.isFolder).forEach((file) => window.open(file.url.value))
+              selectedFiles.filter((file) => !file.isFolder.value).forEach((file) => window.open(file.url.value))
               setAnchorEvent(undefined)
             }}
             title={t('editor:layout.assetGrid.openInNewTab')}


### PR DESCRIPTION
## Summary

Non-folder filter was accidentally omitting all files by not using .value, and thus not opening anything in the following forEach.

Resolves IR-5543

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
