### PR TITLE
Log error when failing to connect to logstash service

### DIFF
--- a/packages/server-core/src/ServerLogger.ts
+++ b/packages/server-core/src/ServerLogger.ts
@@ -228,8 +228,8 @@ isLogStashRunning()
     console.info(`Logstash is running on ${logStashAddress}:${logStashPort}`)
     multiStream.add(streamToLogstash)
   })
-  .catch(() => {
-    console.error(`Logstash is not running on ${logStashAddress}:${logStashPort}`)
+  .catch((err) => {
+    console.error(`Logstash Connection Error: ${err} when connecting to ${logStashAddress}:${logStashPort}`)
   })
 
 logger.debug('Debug message for testing')


### PR DESCRIPTION
## Summary
IR Engine API Server is unable to connect to logstash although it is running. The catch does not log the actual error. This change is the log that error.

## Subtasks Checklist

## Breaking Changes
None.

## References
closes #_insert number here_

## QA Steps

