### PR TITLE
Increase timeout for connection to logstash

### DIFF
--- a/packages/server-core/src/ServerLogger.ts
+++ b/packages/server-core/src/ServerLogger.ts
@@ -65,7 +65,7 @@ const isLogStashRunning = () => {
     const timer = setTimeout(() => {
       reject(new Error(`Timeout trying to connect to logstash ${logStashAddress}:${logStashPort}`))
       socket.destroy()
-    }, 3000)
+    }, 10000)
 
     // Connect to the port
     socket.connect(parseInt(logStashPort.toString()), logStashAddress, () => {


### PR DESCRIPTION
## Summary
Increase pino socket connection to logstash timeout to 10 seconds.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
