### PR TITLE
[IR-5213] scene saving modal updates

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1447,11 +1447,14 @@
       "title": "Save",
       "lbl-thumbnail": "Generate thumbnail & envmap",
       "lbl-confirm": "Save Scene",
+      "discard-quit": "Discard Changes and Quit",
+      "lbl-save-quit": "Save and Quit",
       "info-confirm": "Are you sure you want to save the scene?",
-      "info-question": "Do you want to save the current scene?",
+      "info-question": "Save changes to the current scene?",
+      "info-warning": "Discarted changes can not be recovered",
       "info-save-success": "Scene Saved",
       "unsavedChanges": {
-        "title": "Unsaved Changes"
+        "title": "Quit to Dashboard"
       }
     },
     "saveNewScene": {

--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1449,7 +1449,7 @@
       "lbl-confirm": "Save Scene",
       "info-confirm": "Are you sure you want to save the scene?",
       "info-question": "Do you want to save the current scene?",
-      "info-save-success": "Scene saved successfully!",
+      "info-save-success": "Scene Saved",
       "unsavedChanges": {
         "title": "Unsaved Changes"
       }

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -37,7 +37,6 @@ import { cmdOrCtrlString } from '../functions/utils'
 import { EditorErrorState } from '../services/EditorErrorServices'
 import { EditorState } from '../services/EditorServices'
 import { SelectionState } from '../services/SelectionServices'
-import { SaveSceneDialog } from './dialogs/SaveSceneDialog'
 import { DndWrapper } from './dnd/DndWrapper'
 import DragLayer from './dnd/DragLayer'
 
@@ -54,7 +53,7 @@ import Tooltip from '@ir-engine/ui/src/primitives/tailwind/Tooltip'
 import 'rc-dock/dist/rc-dock.css'
 import { useTranslation } from 'react-i18next'
 import { IoHelpCircleOutline } from 'react-icons/io5'
-import { setCurrentEditorScene } from '../functions/sceneFunctions'
+import { onSaveScene, setCurrentEditorScene } from '../functions/sceneFunctions'
 import { AssetsPanelTab } from '../panels/assets'
 import { FilesPanelTab } from '../panels/files'
 import { HierarchyPanelTab } from '../panels/hierarchy'
@@ -205,7 +204,7 @@ const EditorContainer = () => {
 
   useHotkeys(`${cmdOrCtrlString}+s`, (e) => {
     e.preventDefault()
-    PopoverState.showPopupover(<SaveSceneDialog />)
+    onSaveScene()
   })
 
   const { initialized, isWidgetVisible, openChat } = useZendesk()

--- a/packages/editor/src/components/dialogs/QuitToDashboardConfirmationDialog.tsx
+++ b/packages/editor/src/components/dialogs/QuitToDashboardConfirmationDialog.tsx
@@ -1,0 +1,77 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import Button from '@ir-engine/ui/src/primitives/tailwind/Button'
+import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { onSaveScene } from '../../functions/sceneFunctions'
+
+export default function QuitToDashboardConfirmationDialog({ resolve }: { resolve: (value: unknown) => void }) {
+  const { t } = useTranslation()
+
+  const onClose = (quit: boolean) => {
+    resolve(quit)
+    PopoverState.hidePopupover()
+  }
+  return (
+    <Modal
+      title={t('editor:dialog.saveScene.unsavedChanges.title')}
+      className="w-[50vw] max-w-xl"
+      hideFooter={true}
+      onClose={() => {
+        resolve(false)
+        PopoverState.hidePopupover()
+      }}
+      rawChildren={
+        <>
+          <div className="py-6 text-center">
+            <span>{t('editor:dialog.saveScene.info-question')}</span>
+            <p className="text-xs text-red-600">{t('editor:dialog.saveScene.info-warning')}</p>
+          </div>
+          <div className="grid grid-flow-col border-t border-t-theme-primary px-5 py-6">
+            <Button variant="transparent" className="border border-theme-primary" onClick={() => onClose(true)}>
+              {t('editor:dialog.saveScene.discard-quit')}
+            </Button>
+            <div className="flex flex-1 place-content-end gap-2">
+              <Button variant="secondary" onClick={() => onClose(false)}>
+                {t('common:components.cancel')}
+              </Button>
+              <Button
+                onClick={async () => {
+                  await onSaveScene()
+                  resolve(true)
+                }}
+              >
+                {t('editor:dialog.saveScene.lbl-save-quit')}
+              </Button>
+            </div>
+          </div>
+        </>
+      }
+    />
+  )
+}

--- a/packages/editor/src/components/dialogs/SaveNewSceneDialog.tsx
+++ b/packages/editor/src/components/dialogs/SaveNewSceneDialog.tsx
@@ -22,7 +22,6 @@ Original Code is the Infinite Reality Engine team.
 All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
 Infinite Reality Engine. All Rights Reserved.
 */
-import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import isValidSceneName from '@ir-engine/common/src/utils/validateSceneName'
 import { getComponent } from '@ir-engine/ecs'
@@ -30,7 +29,6 @@ import { GLTFModifiedState } from '@ir-engine/engine/src/gltf/GLTFDocumentState'
 import { SourceComponent } from '@ir-engine/engine/src/scene/components/SourceComponent'
 import { getMutableState, getState, none, useHookstate } from '@ir-engine/hyperflux'
 import { Input } from '@ir-engine/ui'
-import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 import ErrorDialog from '@ir-engine/ui/src/components/tailwind/ErrorDialog'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import React from 'react'
@@ -38,64 +36,7 @@ import { useTranslation } from 'react-i18next'
 import { saveSceneGLTF } from '../../functions/sceneFunctions'
 import { EditorState } from '../../services/EditorServices'
 
-export const SaveSceneDialog = (props: { isExiting?: boolean; onConfirm?: () => void; onCancel?: () => void }) => {
-  const { t } = useTranslation()
-  const modalProcessing = useHookstate(false)
-
-  const handleSubmit = async () => {
-    modalProcessing.set(true)
-    const { sceneAssetID, projectName, sceneName, rootEntity } = getState(EditorState)
-    const sceneModified = EditorState.isModified()
-
-    if (!projectName) {
-      PopoverState.hidePopupover()
-      if (props.onCancel) props.onCancel()
-      return
-    } else if (!sceneName) {
-      PopoverState.hidePopupover()
-      PopoverState.showPopupover(<SaveNewSceneDialog onConfirm={props.onConfirm} onCancel={props.onCancel} />)
-      return
-    } else if (!sceneModified) {
-      PopoverState.hidePopupover()
-      if (props.onCancel) props.onCancel()
-      NotificationService.dispatchNotify(t('editor:dialog.saveScene.info-save-success'), { variant: 'success' })
-      return
-    }
-
-    const abortController = new AbortController()
-
-    try {
-      await saveSceneGLTF(sceneAssetID!, projectName, sceneName, abortController.signal)
-      NotificationService.dispatchNotify(t('editor:dialog.saveScene.info-save-success'), { variant: 'success' })
-      const sourceID = getComponent(rootEntity, SourceComponent)
-      getMutableState(GLTFModifiedState)[sourceID].set(none)
-
-      PopoverState.hidePopupover()
-      if (props.onConfirm) props.onConfirm()
-    } catch (error) {
-      console.error(error)
-      PopoverState.showPopupover(
-        <ErrorDialog title={t('editor:savingError')} description={error.message || t('editor:savingErrorMsg')} />
-      )
-      if (props.onCancel) props.onCancel()
-    }
-    modalProcessing.set(false)
-  }
-
-  return (
-    <ConfirmDialog
-      title={props.isExiting ? t('editor:dialog.saveScene.unsavedChanges.title') : t('editor:dialog.saveScene.title')}
-      onSubmit={handleSubmit}
-      onClose={() => {
-        PopoverState.hidePopupover()
-        if (props.onCancel) props.onCancel()
-      }}
-      text={props.isExiting ? t('editor:dialog.saveScene.info-question') : t('editor:dialog.saveScene.info-confirm')}
-    />
-  )
-}
-
-export const SaveNewSceneDialog = (props: { onConfirm?: () => void; onCancel?: () => void }) => {
+export default function SaveNewSceneDialog(props: { onConfirm?: () => void; onCancel?: () => void }) {
   const { t } = useTranslation()
   const inputSceneName = useHookstate('New-Scene')
   const modalProcessing = useHookstate(false)

--- a/packages/editor/src/components/toolbar/Toolbar.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar.tsx
@@ -52,6 +52,7 @@ import CreatePrefabPanel from '../dialogs/CreatePrefabPanelDialog'
 import CreateSceneDialog from '../dialogs/CreateScenePanelDialog'
 import ImportSettingsPanel from '../dialogs/ImportSettingsPanelDialog'
 import SaveNewSceneDialog from '../dialogs/SaveNewSceneDialog'
+import QuitToDashboardConfirmationDialog from './../dialogs/QuitToDashboardConfirmationDialog'
 
 const onImportAsset = async () => {
   const { projectName } = getState(EditorState)
@@ -69,7 +70,9 @@ export const confirmSceneSaveIfModified = async () => {
   const isModified = EditorState.isModified()
 
   if (isModified) {
-    return onSaveScene()
+    return new Promise((resolve) => {
+      PopoverState.showPopupover(<QuitToDashboardConfirmationDialog resolve={resolve} />)
+    })
   }
   return true
 }

--- a/packages/editor/src/components/toolbar/Toolbar.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar.tsx
@@ -44,14 +44,14 @@ import { MdOutlineKeyboardArrowDown } from 'react-icons/md'
 import { RxHamburgerMenu } from 'react-icons/rx'
 import { twMerge } from 'tailwind-merge'
 import { inputFileWithAddToScene } from '../../functions/assetFunctions'
-import { onNewScene } from '../../functions/sceneFunctions'
+import { onNewScene, onSaveScene } from '../../functions/sceneFunctions'
 import { cmdOrCtrlString } from '../../functions/utils'
 import { EditorState } from '../../services/EditorServices'
 import { UIAddonsState } from '../../services/UIAddonsState'
 import CreatePrefabPanel from '../dialogs/CreatePrefabPanelDialog'
 import CreateSceneDialog from '../dialogs/CreateScenePanelDialog'
 import ImportSettingsPanel from '../dialogs/ImportSettingsPanelDialog'
-import { SaveNewSceneDialog, SaveSceneDialog } from '../dialogs/SaveSceneDialog'
+import SaveNewSceneDialog from '../dialogs/SaveNewSceneDialog'
 
 const onImportAsset = async () => {
   const { projectName } = getState(EditorState)
@@ -69,11 +69,7 @@ export const confirmSceneSaveIfModified = async () => {
   const isModified = EditorState.isModified()
 
   if (isModified) {
-    return new Promise((resolve) => {
-      PopoverState.showPopupover(
-        <SaveSceneDialog isExiting onConfirm={() => resolve(true)} onCancel={() => resolve(false)} />
-      )
-    })
+    return onSaveScene()
   }
   return true
 }
@@ -121,7 +117,7 @@ const generateToolbarMenu = () => {
     {
       name: t('editor:menubar.saveScene'),
       hotkey: `${cmdOrCtrlString}+s`,
-      action: () => PopoverState.showPopupover(<SaveSceneDialog />)
+      action: onSaveScene
     },
     {
       name: t('editor:menubar.saveAs'),


### PR DESCRIPTION
## Summary
related ticket [IR-5213](https://tsu.atlassian.net/browse/IR-5213)


https://github.com/user-attachments/assets/70bad176-e359-41d5-9155-39960b7bd1f2


## Subtasks Checklist

## Breaking Changes

## References
fixes [IR-3973](https://tsu.atlassian.net/browse/IR-3973)

## QA Steps

- Create a new scene
- Add an entity
- Click hamburger menu > quit to dashboard
- Observe the confirmation window text
Actual result: to the question if I want to save the current scene there are two options: confirm and cancel, the option quit without saving is missing


[IR-5213]: https://tsu.atlassian.net/browse/IR-5213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IR-3973]: https://tsu.atlassian.net/browse/IR-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ