### PR TITLE
WebSocket Connection Stability Improvements

### DIFF
--- a/.env.local.default
+++ b/.env.local.default
@@ -49,6 +49,11 @@ VITE_EMAILJS_TEMPLATE_ID=
 VITE_EMAILJS_USER_ID=
 VITE_ROOT_REDIRECT=false
 VITE_READY_PLAYER_ME_URL=https://xre.readyplayer.me/avatar?frameApi
+
+# WebSocket Configuration --------
+VITE_WEBSOCKET_PING_TIMEOUT=30000
+VITE_WEBSOCKET_PING_INTERVAL=10000
+
 VITE_AVATURN_URL="https://demo.avaturn.dev" #using public one
 VITE_AVATURN_API=https://api.avaturn.me/
 VITE_PWA_ENABLED=false

--- a/packages/client-core/src/API.ts
+++ b/packages/client-core/src/API.ts
@@ -52,7 +52,9 @@ export class API {
     const feathersClient = feathers()
 
     const primus = new Primus(`${config.client.serverUrl}?pathName=${window.location.pathname}`, {
-      withCredentials: true
+      withCredentials: true,
+      pingTimeout: config.websocket.pingTimeout,
+      pingInterval: config.websocket.pingInterval
     })
     feathersClient.configure(primusClient(primus, { timeout: 10000 }))
 

--- a/packages/client-core/src/transports/mediasoup/MediasoupClientFunctions.ts
+++ b/packages/client-core/src/transports/mediasoup/MediasoupClientFunctions.ts
@@ -219,12 +219,18 @@ export const connectToInstance = (
         (config.client.appEnv === 'development' && config.client.localNginx !== 'true')
       ) {
         const queryString = new URLSearchParams(query).toString()
-        primus = new Primus(`https://${ipAddress as string}:${port.toString()}?${queryString}`)
+        primus = new Primus(`https://${ipAddress as string}:${port.toString()}?${queryString}`, {
+          pingTimeout: config.websocket.pingTimeout,
+          pingInterval: config.websocket.pingInterval
+        })
       } else {
         query.address = ipAddress
         query.port = port.toString()
         const queryString = new URLSearchParams(query).toString()
-        primus = new Primus(`${config.client.instanceserverUrl}?${queryString}`)
+        primus = new Primus(`${config.client.instanceserverUrl}?${queryString}`, {
+          pingTimeout: config.websocket.pingTimeout,
+          pingInterval: config.websocket.pingInterval
+        })
       }
     } catch (err) {
       logger.error('Failed to connect to primus', err)
@@ -801,7 +807,8 @@ type Primus = EventEmitter & {
   online: boolean
   onlineHandler: () => void
   options: {
-    pingTimeout: 45000
+    pingTimeout: number
+    pingInterval: number
     queueSize: number
     reconnect: any
     strategy: string

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -102,7 +102,15 @@ const client = {
  * Full config
  */
 export const config = {
-  client
+  client,
+  websocket: {
+    pingTimeout: globalThis.process.env.VITE_WEBSOCKET_PING_TIMEOUT
+      ? parseInt(globalThis.process.env.VITE_WEBSOCKET_PING_TIMEOUT)
+      : 30000,
+    pingInterval: globalThis.process.env.VITE_WEBSOCKET_PING_INTERVAL
+      ? parseInt(globalThis.process.env.VITE_WEBSOCKET_PING_INTERVAL)
+      : 10000
+  }
 }
 
 export default config

--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -50,7 +50,7 @@ import { Application } from '../declarations'
 import packagejson from '../package.json'
 import { logger } from './ServerLogger'
 import { ServerMode, ServerState, ServerTypeMode } from './ServerState'
-import { default as appConfig, default as config } from './appconfig'
+import { default as appConfig } from './appconfig'
 import authenticate from './hooks/authenticate'
 import { logError } from './hooks/log-error'
 import persistHeaders from './hooks/persist-headers'
@@ -107,6 +107,8 @@ export const configurePrimus =
           transformer: 'websockets',
           origins: origin,
           methods: ['OPTIONS', 'GET', 'POST'],
+          pingInterval: commonConfig.websocket.pingInterval,
+          pingTimeout: commonConfig.websocket.pingTimeout,
           headers: '*',
           credentials: true
         },
@@ -180,7 +182,7 @@ export const createFeathersKoaApp = async (
   createEngine(createHyperStore())
 
   getMutableState(DomainConfigState).merge({
-    publicDomain: config.client.dist,
+    publicDomain: appConfig.client.dist,
     cloudDomain: commonConfig.client.fileServer,
     proxyDomain: commonConfig.client.cors.proxyUrl
   })


### PR DESCRIPTION
# WebSocket Connection Stability Improvements

## Problem
We were experiencing repeated WebSocket connection drops and rapid server instance creation in a local development environment due to mismatched ping settings between client and server Primus configurations. Not clear if this issue is evident in other environments. 

## Solution
Centralized the WebSocket ping configuration in the common package and standardized the settings across all Primus clients. This ensures consistent connection management between client and server.

### Changes Made
1. Configuration Changes:
   - Added WebSocket settings to `common/src/config.ts`:
     - `pingTimeout`: 30 seconds (configurable via `VITE_WEBSOCKET_PING_TIMEOUT`)
     - `pingInterval`: 10 seconds (configurable via `VITE_WEBSOCKET_PING_INTERVAL`)
   - Added environment variables to `.env.local.default`

2. Client Updates:
   - Updated Primus configuration in `API.ts` to use centralized settings
   - Updated MediaSoup client configurations to use the same settings
   - Removed hardcoded ping values

3. Server Updates:
   - Updated server's Primus configuration in `createApp.ts` to use the same settings
   - Ensured consistent configuration across all WebSocket connections

### Testing
Please verify:
- [ ] WebSocket connections remain stable for extended periods
- [ ] No unnecessary server instance creation
- [ ] Client reconnection behavior works as expected
- [ ] Both development and production environments handle connections properly

### Related Issues
Fixes IR-5893

### Notes
- The ping settings can be adjusted through environment variables if needed