### PR TITLE
Fix make-user-admin script to update isGuest field

### DIFF
--- a/scripts/make-user-admin.ts
+++ b/scripts/make-user-admin.ts
@@ -76,6 +76,9 @@ cli.main(async () => {
       .first()
 
     if (userMatch != null) {
+      // Update isGuest to false
+      await knexClient.from(userPath).where({ id: options.id }).update({ isGuest: false })
+
       for (const { type } of scopeTypeSeed) {
         try {
           const existingScope = await knexClient


### PR DESCRIPTION
# Update isGuest Field in make-user-admin Script

## Problem
When promoting a user to admin using the make-user-admin script, their `isGuest` field remained unchanged. This could lead to conflicts where an admin user might still be marked as a guest, potentially causing unexpected behavior.

## Solution
Modified the make-user-admin script to explicitly set `isGuest: false` when promoting a user to admin. This ensures that admin users are properly marked as non-guests.

### Changes Made
- Added a database update operation in the make-user-admin script to set `isGuest: false` when promoting a user to admin
- This update happens before adding the admin scopes, ensuring the user is properly configured

### Testing
Please verify:
- [ ] Running make-user-admin successfully promotes a user to admin
- [ ] The promoted user's `isGuest` field is set to false in the database
- [ ] All admin privileges work correctly for the promoted user

### Related Issues
Fixes IR-5894