### PR TITLE
Temporarily disable location type selection in modal

### DIFF
--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -287,7 +287,7 @@ export default function AddEditLocationModal(props: {
               width="full"
               inputSizeVariant="xl"
             />
-            <Select
+            {/*<Select
               labelProps={{
                 text: t('admin:components.location.type'),
                 position: 'top'
@@ -298,7 +298,7 @@ export default function AddEditLocationModal(props: {
               disabled={true}
               width="full"
               inputSizeVariant="xl"
-            />
+            />*/}
             <Toggle
               label={t('admin:components.location.lbl-ve')}
               value={videoEnabled.value}


### PR DESCRIPTION
Comment out the location type select component in the AddEditLocationModal for temporary adjustments.