### PR TITLE
IR-5913: error uploading avatar

### DIFF
--- a/packages/server-core/src/user/avatar/avatar-helper.ts
+++ b/packages/server-core/src/user/avatar/avatar-helper.ts
@@ -157,11 +157,23 @@ export const uploadAvatarStaticResource = async (
   const folderName = isFromDomain ? data.path! : staticResourceKey
 
   delete params?.provider
-
   const modelKey = path.join(folderName, `${name}.${data.avatarFileType ?? 'glb'}`)
   const thumbnailKey = path.join(folderName, `${name}.png`)
 
   const storageProvider = getStorageProvider()
+
+  await Promise.all([
+    storageProvider.putObject({
+      Body: data.avatar,
+      Key: modelKey,
+      ContentType: CommonKnownContentTypes[data.avatarFileType ?? 'glb']
+    }),
+    storageProvider.putObject({
+      Body: data.thumbnail,
+      Key: thumbnailKey,
+      ContentType: CommonKnownContentTypes.png
+    })
+  ])
 
   const [modelResource, thumbnailResource] = await Promise.all([
     app.service(staticResourcePath).create(
@@ -182,17 +194,7 @@ export const uploadAvatarStaticResource = async (
         project: data.project
       },
       params
-    ),
-    storageProvider.putObject({
-      Body: data.avatar,
-      Key: modelKey,
-      ContentType: CommonKnownContentTypes[data.avatarFileType ?? 'glb']
-    }),
-    storageProvider.putObject({
-      Body: data.thumbnail,
-      Key: thumbnailKey,
-      ContentType: CommonKnownContentTypes.png
-    })
+    )
   ])
 
   logger.info('Successfully uploaded avatar %o %o', modelResource, thumbnailResource)


### PR DESCRIPTION
## Summary

This change ensures avatar files are uploaded to the storage provider before creating the static resource records.
This is necessary because static resources require a hash generated from the file. 
Previously, an error occurred during hash generation since the file had not been uploaded at that point.

**Error**
![image](https://github.com/user-attachments/assets/f49a9be5-d5f6-4bee-894d-7e8f00f5761d)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
