### PR TITLE
IR-4001: Prevent folder copy to overwrite original folder

### DIFF
--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -340,7 +340,8 @@ export class FileBrowserService
       await this.moveFolderRecursively(
         storageProvider,
         path.join(oldDirectory, oldName),
-        path.join(newDirectory, fileName)
+        path.join(newDirectory, fileName),
+        !!data?.isCopy
       )
     } else {
       await storageProvider.moveObject(oldName, fileName, oldDirectory, newDirectory, data.isCopy)
@@ -414,7 +415,12 @@ export class FileBrowserService
     return results
   }
 
-  private async moveFolderRecursively(storageProvider: StorageProviderInterface, oldPath: string, newPath: string) {
+  private async moveFolderRecursively(
+    storageProvider: StorageProviderInterface,
+    oldPath: string,
+    newPath: string,
+    isCopy: boolean
+  ) {
     const items = await storageProvider.listFolderContent(oldPath + '/')
 
     for (const item of items) {
@@ -422,9 +428,9 @@ export class FileBrowserService
       const newItemPath = path.join(newPath, item.name)
 
       if (item.type === 'directory') {
-        await this.moveFolderRecursively(storageProvider, oldItemPath, newItemPath)
+        await this.moveFolderRecursively(storageProvider, oldItemPath, newItemPath, isCopy)
       } else {
-        await storageProvider.moveObject(item.name, item.name, oldPath, newPath, false)
+        await storageProvider.moveObject(item.name, item.name, oldPath, newPath, isCopy)
       }
     }
 
@@ -434,7 +440,7 @@ export class FileBrowserService
       path.basename(newPath),
       path.dirname(oldPath),
       path.dirname(newPath),
-      false
+      isCopy
     )
   }
 

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -335,7 +335,6 @@ export class FileBrowserService
 
     const isDirectory = await storageProvider.isDirectory(oldName, oldDirectory)
     const fileName = await getIncrementalName(newName, newDirectory, storageProvider, isDirectory)
-
     if (isDirectory) {
       await this.moveFolderRecursively(
         storageProvider,
@@ -430,7 +429,9 @@ export class FileBrowserService
       if (item.type === 'directory') {
         await this.moveFolderRecursively(storageProvider, oldItemPath, newItemPath, isCopy)
       } else {
-        await storageProvider.moveObject(item.name, item.name, oldPath, newPath, isCopy)
+        //The local storage provider requires the file extension because it interacts with the filesystem and needs the full path, including the extension.
+        const fileName = config.server.storageProvider === 'local' ? `${item.name}.${item.type}` : item.name
+        await storageProvider.moveObject(fileName, fileName, oldPath, newPath, isCopy)
       }
     }
 


### PR DESCRIPTION
## Summary

This change prevents the original folder being overwritten when copied, previously when a folder was copied it, the copy replaced the original folder. i.e New Folder would be replaced by New Folder (1)

**related ticket:**[IR-4001](https://tsu.atlassian.net/browse/IR-4001)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

1. Create new scene
2. Click on the file menu
3. Upload the folder
4. Copy the uploaded folder and paste it

**Expected result:** Original folder is preserved and its copy is created.

[IR-4001]: https://tsu.atlassian.net/browse/IR-4001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ