### PR TITLE
Skip scale lock in tab index

### DIFF
--- a/packages/ui/src/components/editor/input/Vector3/index.tsx
+++ b/packages/ui/src/components/editor/input/Vector3/index.tsx
@@ -132,6 +132,7 @@ export const Vector3Input = ({
           startIcon={uniformEnabled.value ? <LuLock /> : <LuUnlock />}
           onClick={onToggleUniform}
           className="p-0"
+          tabIndex={-1}
         />
       )}
       <NumericInput


### PR DESCRIPTION
Adjust the tab index to skip over the scale lock element, improving keyboard navigation.