### PR TITLE
Fix WSL Port Proxies to LAN

### DIFF
--- a/.env.local.default
+++ b/.env.local.default
@@ -67,6 +67,9 @@ VITE_8TH_WALL=
 #VITE_FORCE_CLIENT_LOG_AGGREGATE=true
 VITE_FORCE_CLIENT_LOG_AGGREGATE=false
 VITE_DISABLE_LOG=false
+
+# For WSL2 ip binding to 0.0.0.0, set this to the ipv4 of the windows host
+APP_HOST_ORIGIN_OVERRIDE=
 # --------------------------------
 
 LOG_TO_FILE=false

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -73,7 +73,10 @@ export const logger = multiLogger.child({ component: 'client-core:AuthService' }
 export const TIMEOUT_INTERVAL = 50 // ms per interval of waiting for authToken to be updated
 
 const iframe = document.getElementById('root-cookie-accessor') as HTMLIFrameElement
-const communicator = new ParentCommunicator('root-cookie-accessor', config.client.clientUrl) //Eventually we can configure iframe target seperatly
+const communicator = new ParentCommunicator(
+  'root-cookie-accessor',
+  config.client.hostOriginOverride ?? config.client.clientUrl
+) //Eventually we can configure iframe target seperatly
 
 export const UserSeed: UserType = {
   id: '' as UserID,

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -56,6 +56,9 @@ const client = {
     localBuildOrDev && globalThis.process.env.VITE_LOCAL_NGINX !== 'true'
       ? `https://${globalThis.process.env.VITE_APP_HOST}:${globalThis.process.env.VITE_APP_PORT}`
       : `https://${globalThis.process.env.VITE_APP_HOST}`,
+  hostOriginOverride: globalThis.process.env.APP_HOST_ORIGIN_OVERRIDE
+    ? `https://${globalThis.process.env.APP_HOST_ORIGIN_OVERRIDE}:${globalThis.process.env.VITE_APP_PORT}`
+    : null,
   serverHost: globalThis.process.env.VITE_SERVER_HOST,
   serverUrl:
     localBuildOrDev && globalThis.process.env.VITE_LOCAL_NGINX !== 'true'
@@ -90,7 +93,6 @@ const client = {
   key8thWall: globalThis.process.env.VITE_8TH_WALL!,
   featherStoreKey: globalThis.process.env.VITE_FEATHERS_STORE_KEY,
   gaMeasurementId: globalThis.process.env.VITE_GA_MEASUREMENT_ID,
-
   zendesk: {
     enabled: globalThis.process.env.VITE_ZENDESK_ENABLED,
     authenticationEnabled: globalThis.process.env.VITE_ZENDESK_AUTHENTICATION_ENABLED,


### PR DESCRIPTION
## Summary
Adds a host origin override to auth service, used with local dev on WSL to avoid using the VITE_HOST variable (which must be set to 0.0.0.0 in order to be bound to the Windows ipv4). This restores LAN/remote debugging support for WSL using Windows port proxies.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
