### PR TITLE
IR-5822: update avatar selection & avatar creator menus

### DIFF
--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -393,9 +393,9 @@
     "enterThumbnailUrl": "Enter Thumbnail URL",
     "avatarName": "Avatar Name",
     "done": "Done",
-    "finishEditing": "Finish Editing",
     "discardAvatarChanges": "Discard Your Avatar?",
-    "InputAvatarName": "Enter an Avatar Name",
+    "InputAvatarName": "Name Your Avatar",
+    "saveAvatar": "Save Avatar",
     "savingAvatar": "Saving {{avatar}}",
     "packagingAvatar": "Packaging & adding avatar to your Account..."
   },

--- a/packages/client-core/src/user/components/UserMenu/menus/AvatarCreatorMenu2.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/AvatarCreatorMenu2.tsx
@@ -36,7 +36,7 @@ import { Button, Input } from '@ir-engine/ui'
 import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
-import { IoArrowBackOutline } from 'react-icons/io5'
+import { IoArrowBackOutline, IoCloseOutline } from 'react-icons/io5'
 import AvatarPreview from '../../../../common/components/AvatarPreview'
 import { PopoverState } from '../../../../common/services/PopoverState'
 import { AVATAR_ID_REGEX, generateAvatarId } from '../../../../util/avatarIdFunctions'
@@ -117,7 +117,6 @@ const AvatarCreatorMenu = (selectedSdk: string) => () => {
       loading.set(LoadingState.Downloading)
       error.set('')
       avatarName.set(message.data.avatarId)
-
       try {
         const res = await fetch(message.data.url)
         const data = await res.blob()
@@ -194,7 +193,6 @@ const AvatarCreatorMenu = (selectedSdk: string) => () => {
       : avatarUrl.value.split('/').pop() + '.glb'
 
     const blob = await getCanvasBlob(canvas)
-
     await AvatarService.createAvatar(
       new File([selectedBlob.value!], modelName),
       new File([blob!], thumbnailName),
@@ -203,7 +201,7 @@ const AvatarCreatorMenu = (selectedSdk: string) => () => {
     )
 
     loading.set(LoadingState.None)
-    PopupMenuServices.showPopupMenu()
+    PopupMenuServices.showPopupMenu(UserMenus.AvatarSelect2)
   }
 
   const loadingMessages = {
@@ -229,16 +227,37 @@ const AvatarCreatorMenu = (selectedSdk: string) => () => {
             <div className="grid h-14 w-full grid-cols-[2rem,1fr,2rem] border-b border-b-theme-primary px-8">
               <Button
                 data-testid="edit-avatar-button"
-                className=" h-6 w-6 self-center bg-transparent"
+                className=" h-6 w-6 self-center bg-transparent hover:bg-transparent focus:bg-transparent"
                 onClick={() => PopupMenuServices.showPopupMenu(UserMenus.AvatarSelect2)}
               >
-                <IoArrowBackOutline size={16} />
+                <span>
+                  <IoArrowBackOutline size={16} />
+                </span>
               </Button>
               <Text className="col-start-2  place-self-center self-center">
                 {loading.value !== LoadingState.Uploading
                   ? t('user:avatar.titleCustomizeAvatar')
                   : t('user:avatar.savingAvatar', { avatar: avatarName.value })}
               </Text>
+              <Button
+                fullWidth={false}
+                data-testid="edit-avatar-button"
+                className=" h-6 w-6 self-center bg-transparent hover:bg-transparent focus:bg-transparent"
+                onClick={() =>
+                  PopoverState.showPopupover(
+                    <DiscardAvatarChangesModal
+                      handleConfirm={() => {
+                        PopoverState.hidePopupover()
+                        PopupMenuServices.showPopupMenu()
+                      }}
+                    />
+                  )
+                }
+              >
+                <span>
+                  <IoCloseOutline size={16} />
+                </span>
+              </Button>
             </div>
             <div className="grid h-full w-full flex-1 grid-cols-[1fr,50%,1fr] gap-6 px-10 py-2">
               {loading.value === LoadingState.LoadingCreator && (
@@ -267,15 +286,20 @@ const AvatarCreatorMenu = (selectedSdk: string) => () => {
               )}
             </div>
             {avatarPreviewLoaded && (
-              <div className="mx-auto mb-2 flex py-2">
-                <Input
-                  value={avatarName.value || ''}
-                  labelProps={{
-                    text: t('user:avatar.InputAvatarName'),
-                    position: 'top'
-                  }}
-                  onChange={(e) => avatarName.set(e.target.value)}
-                />
+              <div className="mx-auto mb-2 flex items-center gap-2 py-2">
+                <Text className="" fontSize="sm">
+                  {t('user:avatar.InputAvatarName')}
+                </Text>
+                <Input value={avatarName.value || ''} onChange={(e) => avatarName.set(e.target.value)} />
+                <Button
+                  size="sm"
+                  disabled={loading.value !== LoadingState.None}
+                  data-testid="upload-avatar-button"
+                  onClick={uploadAvatar}
+                  className="w-fit place-self-center text-sm"
+                >
+                  {t('user:avatar.saveAvatar')}
+                </Button>
               </div>
             )}
             {loading.value !== LoadingState.None && loading.value !== LoadingState.LoadingCreator && (
@@ -287,33 +311,6 @@ const AvatarCreatorMenu = (selectedSdk: string) => () => {
                 />
               </div>
             )}
-            <div className="flex w-full items-center justify-center border-t border-t-theme-primary px-6 py-2">
-              <Button
-                disabled={loading.value === LoadingState.Downloading || loading.value === LoadingState.Uploading}
-                data-testid="discard-changes-button"
-                onClick={() =>
-                  PopoverState.showPopupover(
-                    <DiscardAvatarChangesModal
-                      handleConfirm={() => {
-                        PopoverState.hidePopupover()
-                        PopupMenuServices.showPopupMenu()
-                      }}
-                    />
-                  )
-                }
-                className="w-full max-w-[20%] place-self-center text-sm"
-              >
-                {t('user:common.discardChanges')}
-              </Button>
-              <Button
-                disabled={loading.value !== LoadingState.None}
-                data-testid="upload-avatar-button"
-                onClick={uploadAvatar}
-                className="ml-2 w-full max-w-[20%] place-self-center text-sm"
-              >
-                {t('user:avatar.finishEditing')}
-              </Button>
-            </div>
           </div>
         }
       ></Modal>

--- a/packages/client-core/src/user/components/UserMenu/menus/AvatarSelectMenu2.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/AvatarSelectMenu2.tsx
@@ -39,18 +39,16 @@ import { useTranslation } from 'react-i18next'
 import useFeatureFlags from '@ir-engine/client-core/src/hooks/useFeatureFlags'
 import { FeatureFlags } from '@ir-engine/common/src/constants/FeatureFlags'
 import { Button, Input } from '@ir-engine/ui'
-import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
-import { PopoverState } from '../../../../common/services/PopoverState'
+import { IoArrowBackOutline, IoCloseOutline } from 'react-icons/io5'
 import { UserMenus } from '../../../UserUISystem'
 import { AuthService, AuthState } from '../../../services/AuthService'
 import { PopupMenuServices } from '../PopupMenuService'
-import { DiscardAvatarChangesModal } from './DiscardAvatarChangesModal'
 
 const AVATAR_PAGE_LIMIT = 100
 
-const AvatarMenu2 = () => {
+const AvatarMenu2 = ({ showBackButton }: { showBackButton: boolean }) => {
   const { t } = useTranslation()
   const authState = useMutableState(AuthState)
   const userId = authState.user?.id?.value
@@ -128,6 +126,13 @@ const AvatarMenu2 = () => {
 
   useEffect(() => clearTimeout(debouncedSearchQueryRef.current), [])
 
+  const handleClose = async () => {
+    if (userAvatarId !== selectedAvatarId.value) {
+      await handleConfirmAvatar()
+    }
+    PopupMenuServices.showPopupMenu()
+  }
+
   return (
     <div className="fixed top-0 z-[35] flex h-[100vh] w-full bg-[rgba(0,0,0,0.75)]">
       <Modal
@@ -135,11 +140,37 @@ const AvatarMenu2 = () => {
         className="min-w-34 pointer-events-auto m-auto flex h-[95vh] w-[70vw] max-w-6xl rounded-xl [&>div]:flex [&>div]:h-full [&>div]:max-h-full [&>div]:w-full  [&>div]:flex-1 [&>div]:flex-col"
         hideFooter={true}
         rawChildren={
-          <div className="grid h-full w-full grid-rows-[3.5rem,1fr,3.5rem]">
+          <div className="grid h-full w-full grid-rows-[3.5rem,1fr]">
             <div className="grid h-14 w-full grid-cols-[2rem,1fr,2rem] border-b border-b-theme-primary px-8">
+              {showBackButton && (
+                <Button
+                  data-testid="edit-avatar-button"
+                  className=" h-6 w-6 self-center bg-transparent hover:bg-transparent focus:bg-transparent"
+                  onClick={async () => {
+                    if (userAvatarId !== selectedAvatarId.value) {
+                      await handleConfirmAvatar()
+                    }
+                    PopupMenuServices.showPopupMenu(UserMenus.Profile)
+                  }}
+                >
+                  <span>
+                    <IoArrowBackOutline size={16} />
+                  </span>
+                </Button>
+              )}
               <Text className="col-start-2  place-self-center self-center">{t('user:avatar.titleSelectAvatar')}</Text>
+              <Button
+                fullWidth={false}
+                data-testid="edit-avatar-button"
+                className="h-6 w-6 self-center bg-transparent hover:bg-transparent focus:bg-transparent"
+                onClick={handleClose}
+              >
+                <span>
+                  <IoCloseOutline size={16} />
+                </span>
+              </Button>
             </div>
-            <div className="grid h-full max-h-[calc(95vh-7rem)] w-full flex-1 grid-cols-[60%,40%] gap-6 px-10 py-2">
+            <div className="grid h-full max-h-[calc(95vh-3.5rem)] w-full flex-1 grid-cols-[60%,40%] gap-6 px-10 py-2">
               <div className="relative h-full min-h-0 min-w-0 rounded-lg bg-gradient-to-b from-[#162941] to-[#114352]">
                 <div className="stars absolute left-0 top-0 h-[2px] w-[2px] animate-twinkling bg-transparent"></div>
                 <AvatarPreview fill avatarUrl={currentAvatar?.modelResource?.url} />
@@ -182,7 +213,7 @@ const AvatarMenu2 = () => {
                     </Button>
                   )}
                 </div>
-                <div className="max-h-[calc(95vh-11rem)] overflow-y-auto pb-6 pr-2">
+                <div className="max-h-[calc(95vh-7.5rem)] overflow-y-auto pb-6 pr-2">
                   <div className="grid grid-cols-1 gap-2">
                     {avatarsData.map((avatar) => (
                       <div key={avatar.id} className="w-full">
@@ -201,37 +232,6 @@ const AvatarMenu2 = () => {
                   </div>
                 </div>
               </div>
-            </div>
-            <div className="flex h-14 w-full items-center justify-center border-t border-t-theme-primary px-6 py-2">
-              <Button
-                data-testid="discard-changes-button"
-                onClick={() => {
-                  if (userAvatarId !== selectedAvatarId.value) {
-                    PopoverState.showPopupover(
-                      <DiscardAvatarChangesModal
-                        handleConfirm={() => {
-                          PopoverState.hidePopupover()
-                          PopupMenuServices.showPopupMenu()
-                        }}
-                      />
-                    )
-                  } else {
-                    PopupMenuServices.showPopupMenu()
-                  }
-                }}
-                className="w-fit place-self-center text-sm"
-              >
-                {t('user:common.discardChanges')}
-              </Button>
-              <Button
-                data-testid="select-avatar-button"
-                disabled={userAvatarId === selectedAvatarId.value}
-                onClick={handleConfirmAvatar}
-                className="ml-2 w-fit place-self-center text-sm"
-              >
-                {t('user:avatar.finishEditing')}
-                {avatarLoading.value ? <LoadingView spinnerOnly className="h-6 w-6" /> : undefined}
-              </Button>
             </div>
           </div>
         }

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -461,7 +461,7 @@ const ProfileMenu = ({ hideLogin, onClose, isPopover }: Props): JSX.Element => {
           <Avatar
             imageSrc={avatarThumbnail}
             showChangeButton={hasAcceptedTermsAndAge}
-            onChange={() => PopupMenuServices.showPopupMenu(UserMenus.AvatarSelect2)}
+            onChange={() => PopupMenuServices.showPopupMenu(UserMenus.AvatarSelect2, { showBackButton: true })}
           />
 
           <Box className={styles.profileDetails}>


### PR DESCRIPTION
## Summary

- Removed buttons in footer. Now changes are saved when modal is dismissed
- Added back arrow that redirects to profile (only in /location) 
- Updated labels
- Redirect back to avatar list after RPM avatar is exported

![image](https://github.com/user-attachments/assets/01f4c46b-ffa2-4ccb-9115-e8ef3638a215)

![image](https://github.com/user-attachments/assets/592547d3-0d53-4e29-a4ce-755bc271be28)

![image](https://github.com/user-attachments/assets/c5fe9c62-035f-4987-97e4-8fd6d441dfd0)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
