### PR TITLE
Use project name correctly and fix extension logic

### DIFF
--- a/packages/editor/src/components/assets/ImageCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ImageCompressionPanel.tsx
@@ -32,7 +32,7 @@ import {
   KTX2EncodeArguments,
   KTX2EncodeDefaultArguments
 } from '@ir-engine/engine/src/assets/constants/CompressionParms'
-import { ImmutableArray, useHookstate } from '@ir-engine/hyperflux'
+import { ImmutableArray, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { Button, Checkbox, Input, Select } from '@ir-engine/ui'
@@ -45,6 +45,7 @@ import { useTranslation } from 'react-i18next'
 import { MdClose } from 'react-icons/md'
 import { FileDataType } from '../../constants/AssetTypes'
 import { compressImage } from '../../functions/assetFunctions'
+import { EditorState } from '../../services/EditorServices'
 
 const UASTCFlagOptions = [
   { label: 'Fastest', value: 0 },
@@ -68,6 +69,7 @@ export default function ImageCompressionPanel({
   refreshDirectory: () => Promise<void>
 }) {
   const { t } = useTranslation()
+  const { projectName } = useMutableState(EditorState)
 
   const compressProperties = useHookstate<KTX2EncodeArguments>(KTX2EncodeDefaultArguments)
   const compressionLoading = useHookstate(false)
@@ -76,6 +78,7 @@ export default function ImageCompressionPanel({
     compressionLoading.set(true)
 
     for (const file of selectedFiles) {
+      compressProperties.src.set(file.type === 'folder' ? `${file.url}/${file.key}` : file.url)
       await uploadImage(file, await compressImage(compressProperties.value))
     }
     await refreshDirectory()
@@ -85,12 +88,9 @@ export default function ImageCompressionPanel({
   }
 
   const uploadImage = async (props: FileDataType, data: ArrayBuffer) => {
-    compressProperties.src.set(props.type === 'folder' ? `${props.url}/${props.key}` : props.url)
-
     const newFileName = props.key.replace(/.*\/(.*)\..*/, '$1') + '.ktx2'
     const path = props.key.replace(/(.*\/).*/, '$1')
-    const projectName = props.key.split('/')[1] // TODO: support projects with / in the name
-    const relativePath = path.replace('projects/' + projectName + '/', '')
+    const relativePath = path.replace('projects/' + projectName.value + '/', '')
 
     const file = new File([data], newFileName, { type: 'image/ktx2' })
 
@@ -98,7 +98,7 @@ export default function ImageCompressionPanel({
       await uploadToFeathersService(fileBrowserUploadPath, [file], {
         args: [
           {
-            project: projectName,
+            project: projectName.value,
             path: relativePath + file.name,
             contentType: file.type
           }

--- a/packages/editor/src/components/assets/ImageCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ImageCompressionPanel.tsx
@@ -27,14 +27,15 @@ import React from 'react'
 
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
 import { uploadToFeathersService } from '@ir-engine/client-core/src/util/upload'
-import { fileBrowserUploadPath } from '@ir-engine/common/src/schema.type.module'
+import { fileBrowserUploadPath, staticResourcePath } from '@ir-engine/common/src/schema.type.module'
 import {
   KTX2EncodeArguments,
   KTX2EncodeDefaultArguments
 } from '@ir-engine/engine/src/assets/constants/CompressionParms'
-import { ImmutableArray, useHookstate, useMutableState } from '@ir-engine/hyperflux'
+import { ImmutableArray, useHookstate } from '@ir-engine/hyperflux'
 
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { API } from '@ir-engine/common'
 import { Button, Checkbox, Input, Select } from '@ir-engine/ui'
 import { Slider } from '@ir-engine/ui/editor'
 import InputGroup from '@ir-engine/ui/src/components/editor/input/Group'
@@ -45,7 +46,6 @@ import { useTranslation } from 'react-i18next'
 import { MdClose } from 'react-icons/md'
 import { FileDataType } from '../../constants/AssetTypes'
 import { compressImage } from '../../functions/assetFunctions'
-import { EditorState } from '../../services/EditorServices'
 
 const UASTCFlagOptions = [
   { label: 'Fastest', value: 0 },
@@ -69,7 +69,6 @@ export default function ImageCompressionPanel({
   refreshDirectory: () => Promise<void>
 }) {
   const { t } = useTranslation()
-  const { projectName } = useMutableState(EditorState)
 
   const compressProperties = useHookstate<KTX2EncodeArguments>(KTX2EncodeDefaultArguments)
   const compressionLoading = useHookstate(false)
@@ -90,7 +89,12 @@ export default function ImageCompressionPanel({
   const uploadImage = async (props: FileDataType, data: ArrayBuffer) => {
     const newFileName = props.key.replace(/.*\/(.*)\..*/, '$1') + '.ktx2'
     const path = props.key.replace(/(.*\/).*/, '$1')
-    const relativePath = path.replace('projects/' + projectName.value + '/', '')
+
+    const staticResourceDetails = await API.instance.service(staticResourcePath).find({
+      query: { key: props.key }
+    })
+    const projectName = staticResourceDetails.data[0].project
+    const relativePath = path.replace('projects/' + projectName + '/', '')
 
     const file = new File([data], newFileName, { type: 'image/ktx2' })
 
@@ -98,7 +102,7 @@ export default function ImageCompressionPanel({
       await uploadToFeathersService(fileBrowserUploadPath, [file], {
         args: [
           {
-            project: projectName.value,
+            project: projectName,
             path: relativePath + file.name,
             contentType: file.type
           }

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -86,15 +86,24 @@ const ensureProjectPermissionAndPublicOrAssetsDirectory = async (
         '; directories can only contain alphanumeric characters, dashes, underscores, dots, and @'
     )
   if (!isDirectory) {
-    if (!isValidFileName(fileNameSplit[0]))
+    let fileName = '',
+      extension = ''
+    if (fileNameSplit.length > 1) {
+      fileName = fileNameSplit.slice(0, -1).join('.')
+      extension = fileNameSplit[fileNameSplit.length - 1]
+    } else {
+      fileName = fileNameSplit[0]
+      extension = ''
+    }
+    if (!isValidFileName(fileName))
       throw new BadRequest(
         'Invalid file name: ' +
-          fileNameSplit[0] +
+          fileName +
           '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
       )
-    if (!isValidFileExtension(fileNameSplit[1]))
+    if (!isValidFileExtension(extension))
       throw new BadRequest(
-        'Invalid file extension: ' + fileNameSplit[1] + '; file extension must be 2-4 alphanumeric characters'
+        'Invalid file extension: ' + extension + '; file extension must be 2-4 alphanumeric characters'
       )
   }
 


### PR DESCRIPTION
## Summary

Fixes Image Compression. The bug is at two areas:
1. Fetch projectName of the resource instead of `path.split('/')`
2. Fix extension extraction logic. Previously, `default.thumbnail.jpg` used to return `thumbnail` as the extension. Now it correctly returns `jpg`.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-6067

## QA Steps
