### PR TITLE
IR-6105: Fix IPv6 Support for Local File Server

### DIFF
--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -99,7 +99,9 @@ export class LocalStorage implements StorageProviderInterface {
           '8642',
           '--cors=*',
           '--brotli',
-          '--gzip'
+          '--gzip',
+          '-a',
+          '::'
         ],
         {
           cwd: process.cwd(),


### PR DESCRIPTION
In a local dev environment, the local file server was not properly handling IPv6 connections, causing ECONNREFUSED errors when trying to access resources via IPv6 addresses (::1). This affected file uploads and downloads in a local development environment, such as the ability to create new scenes within the studio. 

Technical Details:

Issue: File server only listened on IPv4 interfaces by default

Root Cause: Missing proper address binding configuration in http-server spawn command

Fix: Added '-a ::' option to http-server to bind to all IPv6 interfaces (which includes IPv4 via IPv4-mapped addresses)

Changes Made:

Modified local.storage.ts to configure http-server with proper IPv6 support:
```ts
[
  'http-server',
  `${this.PATH_PREFIX}`,
  '--ssl',
  '--cert',
  `${config.server.certPath}`,
  '--key',
  `${config.server.keyPath}`,
  '--port',
  '8642',
  '--cors=*',
  '--brotli',
  '-a',
  '::'
]```