### PR TITLE
fix physics entities appearing before scene load

### DIFF
--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -65,7 +65,6 @@ import { SceneComponent } from '@ir-engine/spatial/src/renderer/components/Scene
 import { ObjectLayers } from '@ir-engine/spatial/src/renderer/constants/ObjectLayers'
 import { MaterialStateComponent } from '@ir-engine/spatial/src/renderer/materials/MaterialComponent'
 import {
-  getAncestorWithComponents,
   useAncestorWithComponents,
   useChildrenWithComponents
 } from '@ir-engine/spatial/src/transform/components/EntityTree'
@@ -375,8 +374,7 @@ const DependencyReactor = (props: { gltfComponentEntity: Entity; dependencies: C
 
   useEffect(() => {
     return () => {
-      const ancestor = getAncestorWithComponents(gltfComponentEntity, [SceneComponent])
-      const scene = getOptionalMutableComponent(ancestor, SceneComponent)
+      const scene = getOptionalMutableComponent(gltfComponentEntity, SceneComponent)
       if (scene) scene.active.set(true)
       removeError(gltfComponentEntity, GLTFComponent, 'LOADING_ERROR')
       removeError(gltfComponentEntity, GLTFComponent, 'INVALID_SOURCE')


### PR DESCRIPTION
## Summary

We do not want child GLTFs of a scene GLTF triggering the scene to be made active. only the scene GLTF should do so.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
