### PR TITLE
IR-6111: Fixed crash caused by Redis Pub/Sub output buffer limits

### DIFF
--- a/packages/server-core/src/media/upload-asset/upload-asset.service.ts
+++ b/packages/server-core/src/media/upload-asset/upload-asset.service.ts
@@ -118,7 +118,9 @@ const uploadAssets = (app: Application) => async (data: AssetUploadType, params:
       ...(data.args as AvatarUploadArgsType)
     } as any
     if (data.path) callData.path = data.path
-
+    // Clear files from params to prevent them from being propagated in subsequent requests,
+    // which could lead to errors from exceeding Redis Pub/Sub output buffer limits.
+    params.files = []
     return await uploadAvatarStaticResource(app, callData, params)
   } else if (data.type === 'admin-file-upload') {
     if (!(await verifyScope('admin', 'admin')({ app, params } as any))) throw new Error('Unauthorized')


### PR DESCRIPTION
## Summary
This PR fixes the crash caused by Redis Pub/Sub output buffer limits. 

Files in params were included in requests to static resources which were being emitted 
in Redis Pub Sub by feathers-sync causing the buffer to reach its limits and forcing the connection to close. 
When Redis forces a connection to close the client will emit an error but if there are not listeners 
the process will terminate due to an unhandled exception

See: https://redis.io/docs/latest/develop/reference/clients/#output-buffer-limits


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
- Upload an avatar exported from RPM 
