### PR TITLE
fix optional access to viewer transform

### DIFF
--- a/packages/engine/src/scene/systems/SceneObjectDynamicLoadSystem.ts
+++ b/packages/engine/src/scene/systems/SceneObjectDynamicLoadSystem.ts
@@ -24,7 +24,7 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { PresentationSystemGroup } from '@ir-engine/ecs'
-import { getComponent, getMutableComponent } from '@ir-engine/ecs/src/ComponentFunctions'
+import { getComponent, getMutableComponent, getOptionalComponent } from '@ir-engine/ecs/src/ComponentFunctions'
 import { ECSState } from '@ir-engine/ecs/src/ECSState'
 import { defineQuery } from '@ir-engine/ecs/src/QueryFunctions'
 import { defineSystem } from '@ir-engine/ecs/src/SystemFunctions'
@@ -59,7 +59,9 @@ const execute = () => {
   accumulator = 0
 
   const viewerEntity = getState(EngineState).viewerEntity
-  const viewerWorldMatrix = getComponent(viewerEntity, TransformComponent).matrixWorld
+  const viewerTransform = getOptionalComponent(viewerEntity, TransformComponent)
+  if (!viewerTransform) return
+  const viewerWorldMatrix = viewerTransform.matrixWorld
 
   for (const entity of dynamicLoadQuery()) {
     const dynamicComponent = getComponent(entity, SceneDynamicLoadTagComponent)


### PR DESCRIPTION
## Summary
The latest Dynamic Load Component fixes are causing crashes in dev.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
