### PR TITLE
Fixed issues with static client build process

### DIFF
--- a/packages/common/src/regex/index.ts
+++ b/packages/common/src/regex/index.ts
@@ -133,3 +133,5 @@ export const VALID_PROJECT_NAME = /^(?!\s)[\w\-\s]+$/
 
 export const MAIN_CHART_REGEX = /ir-engine-([0-9]+\.[0-9]+\.[0-9]+)/g
 export const BUILDER_CHART_REGEX = /ir-engine-builder-([0-9]+\.[0-9]+\.[0-9]+)/g
+
+export const UNIQUEIFIED_VITE_KEY_REGEX = /[.-]{1}[a-zA-Z0-9-_]{8}.(js|css)(.map)?$/

--- a/packages/common/tests/regex.test.ts
+++ b/packages/common/tests/regex.test.ts
@@ -37,6 +37,7 @@ import {
   PROJECT_REGEX,
   PROJECT_THUMBNAIL_REGEX,
   PUBLIC_SIGNED_REGEX,
+  UNIQUEIFIED_VITE_KEY_REGEX,
   USER_ID_REGEX,
   VALID_FILENAME_REGEX,
   VALID_HEIRARCHY_SEARCH_REGEX,
@@ -700,6 +701,43 @@ describe('regex.test', () => {
         const matches = chart.matchAll(BUILDER_CHART_REGEX)
         const matchesArray = Array.from(matches)
         assert.ok(matchesArray.length === 0, `Expected '${chart}' to not match BUILDER_CHART_REGEX`)
+      })
+    })
+  })
+
+  describe('UNIQUEIFIED_VITE_KEY_REGEX', () => {
+    it('should match valid file keys', () => {
+      const positiveCases = [
+        'client/assets/AccountDetailsPage-Br_QAdyQ.js',
+        'client/assets/AccountDetailsPage-Br_QAdyQ.css',
+        'client/assets/Apppage-Br_QAdyQ.css.map',
+        'client/AccountDetailsPage-BraQAdyQ.css.map',
+        'AccountDetailsPage-Br_QAd-Q.css.map'
+      ]
+
+      positiveCases.forEach((item) => {
+        const match = UNIQUEIFIED_VITE_KEY_REGEX.exec(item)
+        assert.ok(match, `Expected '${item}' to match UNIQUEIFIED_VITE_KEY_REGEX`)
+      })
+    })
+
+    it('should not match invalid file keys', () => {
+      const negativeCases = [
+        'client/assets/AccountDetailsPage-Br_$Ad*Q.js',
+        'client/assets/AccountDetailsPage-Br_$AdyQ.js',
+        'client/assets/AccountDetailsPage.css',
+        'client/assets/AccountDetailsPage-Br_QAdyQ.tsx',
+        'client/assets/AccountDetailsPage-BraQAdyQ.tsx.map',
+        'client/AccountDetailsPage-Br_QQ.css.map',
+        'AccountDetailsPage-Br_QAd-QQQ.css.map',
+        'root-cookie-accessor.html'
+      ]
+      negativeCases.forEach((item) => {
+        assert.doesNotMatch(
+          item,
+          UNIQUEIFIED_VITE_KEY_REGEX,
+          `Expected '${item}' to not match UNIQUEIFIED_VITE_KEY_REGEX`
+        )
       })
     })
   })

--- a/scripts/delete-old-s3-files.ts
+++ b/scripts/delete-old-s3-files.ts
@@ -38,7 +38,7 @@ cli.main(async () => {
   try {
     await createDefaultStorageProvider()
     const storageProvider = getStorageProvider()
-    let filesToPruneResponse = await storageProvider.getObject('client/S3FilesToRemove.json')
+    let filesToPruneResponse = await storageProvider.getObject('client/S3FilesToRemoveFinal.json')
     let filesToPrune = JSON.parse(filesToPruneResponse.Body.toString('utf-8'))
     while (filesToPrune.length > 0) {
       const toDelete = filesToPrune.splice(0, 1000)

--- a/scripts/get-deletable-client-files.ts
+++ b/scripts/get-deletable-client-files.ts
@@ -32,7 +32,7 @@ import {
   getStorageProvider
 } from '@ir-engine/server-core/src/media/storageprovider/storageprovider'
 
-const UNIQUIFIED_FILE_NAME_REGEX = /[.-]{1}[a-zA-Z0-9]{8}$/
+const UNIQUEIFIED_KEY_REGEX = /[.-]{1}[a-zA-Z0-9-_]{8}.(js|css)(.map)?$/
 
 cli.enable('status')
 
@@ -40,12 +40,12 @@ cli.main(async () => {
   try {
     await createDefaultStorageProvider()
     const storageProvider = getStorageProvider()
-    let files = await storageProvider.listFolderContent('client', true)
-    files = files.filter((file) => UNIQUIFIED_FILE_NAME_REGEX.test(file.name))
+    let files = await storageProvider.listFolderContent('client/assets', true)
+    files = files.filter((file) => UNIQUEIFIED_KEY_REGEX.test(file.key))
     const putData = {
       Body: Buffer.from(JSON.stringify(files.map((file) => file.key))),
       ContentType: 'application/json',
-      Key: 'client/S3FilesToRemove.json'
+      Key: 'client/S3FilesToRemoveInitial.json'
     }
     await storageProvider.putObject(putData, { isDirectory: false })
     console.log('Created list of S3 files to delete after deployment')

--- a/scripts/get-deletable-client-files.ts
+++ b/scripts/get-deletable-client-files.ts
@@ -25,14 +25,13 @@ Infinite Reality Engine. All Rights Reserved.
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+import { UNIQUEIFIED_VITE_KEY_REGEX } from '@ir-engine/common/src/regex'
 import cli from 'cli'
 
 import {
   createDefaultStorageProvider,
   getStorageProvider
 } from '@ir-engine/server-core/src/media/storageprovider/storageprovider'
-
-const UNIQUEIFIED_KEY_REGEX = /[.-]{1}[a-zA-Z0-9-_]{8}.(js|css)(.map)?$/
 
 cli.enable('status')
 
@@ -41,7 +40,7 @@ cli.main(async () => {
     await createDefaultStorageProvider()
     const storageProvider = getStorageProvider()
     let files = await storageProvider.listFolderContent('client/assets', true)
-    files = files.filter((file) => UNIQUEIFIED_KEY_REGEX.test(file.key))
+    files = files.filter((file) => UNIQUEIFIED_VITE_KEY_REGEX.test(file.key))
     const putData = {
       Body: Buffer.from(JSON.stringify(files.map((file) => file.key))),
       ContentType: 'application/json',

--- a/scripts/push-client-to-s3.ts
+++ b/scripts/push-client-to-s3.ts
@@ -47,7 +47,7 @@ cli.main(async () => {
     const storageProvider = getStorageProvider()
     const clientPath = path.resolve(appRootPath.path, `packages/client/dist`)
     const files = getFilesRecursive(clientPath)
-    let filesToPruneResponse = await storageProvider.getObject('client/S3FilesToRemove.json')
+    let filesToPruneResponse = await storageProvider.getObject('client/S3FilesToRemoveInitial.json')
     const filesToPush: string[] = []
     await Promise.all(
       files.map((file) => {
@@ -89,7 +89,7 @@ cli.main(async () => {
     const putData = {
       Body: Buffer.from(JSON.stringify(filesToPrune)),
       ContentType: 'application/json',
-      Key: 'client/S3FilesToRemove.json',
+      Key: 'client/S3FilesToRemoveFinal.json',
       Metadata: {
         'Cache-Control': 'no-cache'
       }


### PR DESCRIPTION
## Summary

On some occasions, the static client build process was removing files it had just pushed to S3, resulting in the deployment not functioning because those static files were missing.

The suspected reason was that, after a build had stripped out its current files and pushed that list to S3FilesToRemove.json, but before it pruned away those files after the deployment had been applied, another build process was overwriting S3FilesToRemove.json

The build process now uses an Initial and Final version of S3FilesToRemove.json The former is written by get-deletable-client-files.ts. push-client-to-s3.ts now reads from that, strips out any matching files it just built, and pushes the results to the Final version. delete-old-s3-files.ts uses the Final version to perform the prune.

envmap versions of client files were not getting pruned, nor were client files with dashes or underscores. This was solved by adding to the regex used to match files, and having it look at the key of the file rather than the name. The former problem came from .map files' name being e.g. 'test-abcd1234.js', which was not matching the old regex.

Only macthing files in client/assets, as that is where all of the vite-build files go. There were occasional false matches with e.g. root-cookie-accessor.html simply because 'accessor' has 8 characters like the vite-built suffixes do.

Resolves IR-6178

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
