### PR TITLE
IR-5897 removing redundant thumbnail generation from SceneSettings editor

### DIFF
--- a/packages/ui/src/components/editor/properties/scene/settings/index.tsx
+++ b/packages/ui/src/components/editor/properties/scene/settings/index.tsx
@@ -109,34 +109,34 @@ export const SceneSettingsEditor: EditorComponentType = (props) => {
       ) : (
         <></>
       )}
+      {/*@note disabled as this functionality was broken and it has been replaced by ScenePreviewCamera*/}
+      {/*<InputGroup*/}
+      {/*  name="Thumbnail"*/}
+      {/*  label={t('editor:properties.sceneSettings.lbl-thumbnail')}*/}
+      {/*  info={t('editor:properties.sceneSettings.info-thumbnail')}*/}
+      {/*  className="w-auto"*/}
+      {/*>*/}
+      {/*  <div>*/}
+      {/*    <ImageLink src={sceneThumbnailState.thumbnailURL.value ?? sceneSettingsComponent.thumbnailURL.value} />*/}
 
-      <InputGroup
-        name="Thumbnail"
-        label={t('editor:properties.sceneSettings.lbl-thumbnail')}
-        info={t('editor:properties.sceneSettings.info-thumbnail')}
-        className="w-auto"
-      >
-        <div>
-          <ImageLink src={sceneThumbnailState.thumbnailURL.value ?? sceneSettingsComponent.thumbnailURL.value} />
-
-          <Button onClick={SceneThumbnailState.createThumbnail} className="mt-2 w-full">
-            {t('editor:properties.sceneSettings.generate')}
-          </Button>
-          {sceneThumbnailState.uploadingThumbnail.value ? (
-            <LoadingView spinnerOnly />
-          ) : (
-            <Button
-              onClick={() => {
-                SceneThumbnailState.uploadThumbnail(props.entity)
-              }}
-              disabled={!sceneThumbnailState.thumbnail.value}
-              className="mt-2 w-full"
-            >
-              {t('editor:properties.sceneSettings.save')}
-            </Button>
-          )}
-        </div>
-      </InputGroup>
+      {/*    <Button onClick={SceneThumbnailState.createThumbnail} className="mt-2 w-full">*/}
+      {/*      {t('editor:properties.sceneSettings.generate')}*/}
+      {/*    </Button>*/}
+      {/*    {sceneThumbnailState.uploadingThumbnail.value ? (*/}
+      {/*      <LoadingView spinnerOnly />*/}
+      {/*    ) : (*/}
+      {/*      <Button*/}
+      {/*        onClick={() => {*/}
+      {/*          SceneThumbnailState.uploadThumbnail(props.entity)*/}
+      {/*        }}*/}
+      {/*        disabled={!sceneThumbnailState.thumbnail.value}*/}
+      {/*        className="mt-2 w-full"*/}
+      {/*      >*/}
+      {/*        {t('editor:properties.sceneSettings.save')}*/}
+      {/*      </Button>*/}
+      {/*    )}*/}
+      {/*  </div>*/}
+      {/*</InputGroup>*/}
       <InputGroup
         name="Loading Screen"
         label={t('editor:properties.sceneSettings.lbl-loading')}


### PR DESCRIPTION
## Summary
removing redundant thumbnail generation from SceneSettings editor, functionality has been replaced in ScenePreviewCamera

## References
[https://tsu.atlassian.net/browse/IR-5897](https://tsu.atlassian.net/browse/IR-5897)

## QA Steps
Open Dashboard [iR Studio](https://ir-engine-mt-dev.theinfinitereality.io/dashboard)

Create a new scene

1.
Click on the setting in hierarchy menu 

Go to render settings 

enable Force Spectator option

observe generate thumbnail is gone

click generate loading screen

Click on save

Observe the app behavour

2.
Click on the Scene Preview Camera

scroll to the ScenePreviewCamera component

click "update thumbnail" (and or set from viewport to align with scene view)

observe scene thumbnail is updated in scenes tab
