### PR TITLE
Fix entire scene unloading every time a user disconnects in client/server networking

### DIFF
--- a/packages/network/src/EntityNetworkState.tsx
+++ b/packages/network/src/EntityNetworkState.tsx
@@ -115,7 +115,6 @@ const EntityNetworkReactor = (props: { uuid: EntityUUID }) => {
   useLayoutEffect(() => {
     if (!userConnected) return
     const entity = UUIDComponent.getOrCreateEntityByUUID(props.uuid)
-    console.log(userConnected, entity)
     return () => {
       if (userHasPeer) removeEntity(entity)
     }

--- a/packages/network/src/EntityNetworkState.tsx
+++ b/packages/network/src/EntityNetworkState.tsx
@@ -115,8 +115,9 @@ const EntityNetworkReactor = (props: { uuid: EntityUUID }) => {
   useLayoutEffect(() => {
     if (!userConnected) return
     const entity = UUIDComponent.getOrCreateEntityByUUID(props.uuid)
+    console.log(userConnected, entity)
     return () => {
-      removeEntity(entity)
+      if (userHasPeer) removeEntity(entity)
     }
   }, [userConnected])
 


### PR DESCRIPTION
## Summary
Fixes the entire scene unloading in non-p2p mode every time a user disconnects, by adding a check before removing the networked entity.

## Subtasks Checklist

## Breaking Changes

## References
Closes https://tsu.atlassian.net/browse/IR-6211

## QA Steps
