### PR TITLE
Fixed renaming of scenes

### DIFF
--- a/packages/client-core/src/world/SceneAPI.ts
+++ b/packages/client-core/src/world/SceneAPI.ts
@@ -53,10 +53,12 @@ export const renameScene = async (
   projectName: string,
   params?: Params
 ) => {
-  const oldPath = resource.key
-  const newPath = newKey
-  const oldName = resource.key.split('/').pop()!
-  const newName = newKey.split('/').pop()!
+  const oldKeySplit = resource.key.split('/')
+  const newKeySplit = newKey.split('/')
+  const oldName = oldKeySplit.splice(oldKeySplit.length - 1)[0]
+  const newName = newKeySplit.splice(newKeySplit.length - 1)[0]
+  const oldPath = oldKeySplit.join('/')
+  const newPath = newKeySplit.join('/')
   try {
     return await API.instance
       .service(fileBrowserPath)


### PR DESCRIPTION
## Summary
RenameSceneModal was passing the full path of the scene file, including the file name, on oldPath and newPath, and also having the file names be oldName and newName. This was causing the backend to not match the concatenated file path and not do anything. e.g. it was trying to move a file named
projects/thisorg/thisproject/public/scenes/newscene.gltf/newscene.gltf to projects/thisorg/thisproject/public/scenes/newscene2.gltf/newscene2.gltf

Resolve IR-6255

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
