### PR TITLE
Fix client settings save button rendering issue in loading state

### DIFF
--- a/packages/client-core/src/admin/components/settings/tabs/client.tsx
+++ b/packages/client-core/src/admin/components/settings/tabs/client.tsx
@@ -516,7 +516,7 @@ const ClientTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableRef
           {t('admin:components.common.reset')}
         </Button>
         <Button size="sm" variant="primary" className="col-span-1" onClick={handleSubmit} fullWidth>
-          state.loading.value && <LoadingView spinnerOnly className="h-6 w-6" />
+          {state.loading.value && <LoadingView spinnerOnly className="h-6 w-6" />}
           {t('admin:components.common.save')}
         </Button>
       </div>


### PR DESCRIPTION
Add missing curly braces around the loading state to ensure proper rendering of the button.

![image](https://github.com/user-attachments/assets/14404454-efe5-4b94-b63a-a23fd808de7c)
