### PR TITLE
IR-4878 adding back reflectionprobecomponent to the shelf

### DIFF
--- a/packages/editor/src/services/ComponentShelfCategoriesState.ts
+++ b/packages/editor/src/services/ComponentShelfCategoriesState.ts
@@ -44,6 +44,7 @@ import { MountPointComponent } from '@ir-engine/engine/src/scene/components/Moun
 import { ParticleSystemComponent } from '@ir-engine/engine/src/scene/components/ParticleSystemComponent'
 import { PortalComponent } from '@ir-engine/engine/src/scene/components/PortalComponent'
 import { PrimitiveGeometryComponent } from '@ir-engine/engine/src/scene/components/PrimitiveGeometryComponent'
+import { ReflectionProbeComponent } from '@ir-engine/engine/src/scene/components/ReflectionProbeComponent.tsx'
 import { RenderSettingsComponent } from '@ir-engine/engine/src/scene/components/RenderSettingsComponent'
 import { ScenePreviewCameraComponent } from '@ir-engine/engine/src/scene/components/ScenePreviewCamera'
 import { SceneSettingsComponent } from '@ir-engine/engine/src/scene/components/SceneSettingsComponent'
@@ -102,7 +103,8 @@ export const ComponentShelfCategoriesState = defineState({
         SkyboxComponent,
         TextComponent,
         LookAtComponent,
-        FogSettingsComponent
+        FogSettingsComponent,
+        ReflectionProbeComponent
       ]
     } as Record<string, Component[]>
   },

--- a/packages/engine/src/scene/components/EnvmapComponent.tsx
+++ b/packages/engine/src/scene/components/EnvmapComponent.tsx
@@ -164,17 +164,19 @@ const EnvmapColorReactor = () => {
 
 const EnvmapProbesReactor = () => {
   const entity = useEntityContext()
-  const component = useComponent(entity, EnvmapComponent)
+
   const probeQuery = useQuery([ReflectionProbeComponent])
 
   useEffect(() => {
     return () => {
+      const component = getMutableComponent(entity, EnvmapComponent)
       if (entityExists(entity)) component.envmap.set(null)
     }
   }, [])
 
   useEffect(() => {
     const [renderTexture, unload] = createReflectionProbeRenderTarget(entity, probeQuery)
+    const component = getMutableComponent(entity, EnvmapComponent)
     component.envmap.set(renderTexture)
     return () => {
       unload()
@@ -242,39 +244,34 @@ export const EnvmapComponent = defineComponent({
       }
     }, [childrenMesh, component.envMapIntensity, component.envmap, hasRootMesh])
 
-    const getEnvmapChildReactor = () => {
-      switch (component.type.value) {
-        case 'Bake': {
-          if (bakeEntity) {
-            return (
-              <EnvBakeComponentReactor
-                key={bakeEntity}
-                envmapEntity={entity}
-                bakeEntity={bakeEntity}
-                childrenMesh={childrenMesh}
-              />
-            )
-          }
-          break
+    switch (component.type.value) {
+      case 'Bake': {
+        if (bakeEntity) {
+          return (
+            <EnvBakeComponentReactor
+              key={bakeEntity}
+              envmapEntity={entity}
+              bakeEntity={bakeEntity}
+              childrenMesh={childrenMesh}
+            />
+          )
         }
-        case 'Cubemap':
-          return <EnvmapCubemapReactor />
-        case 'Equirectangular':
-          return <EnvmapEquirectangularReactor />
-        case 'Color':
-          return <EnvmapColorReactor />
-        case 'Probes':
-          return <EnvmapProbesReactor />
-        case 'Skybox':
-        /** Setting the value from the skybox can be found in EnvironmentSystem */
-        default:
-          break
+        break
       }
-
-      return null
+      case 'Cubemap':
+        return <EnvmapCubemapReactor key={'EnvmapCubemapReactor'} />
+      case 'Equirectangular':
+        return <EnvmapEquirectangularReactor key={'EnvmapEquirectangularReactor'} />
+      case 'Color':
+        return <EnvmapColorReactor key={'EnvmapColorReactor'} />
+      case 'Probes':
+        return <EnvmapProbesReactor key={'EnvmapProbesReactor'} />
+      case 'Skybox':
+      /** Setting the value from the skybox can be found in EnvironmentSystem */
+      default:
+        break
     }
-
-    return <>{getEnvmapChildReactor()}</>
+    return null
   },
 
   errors: ['MISSING_FILE']

--- a/packages/engine/src/scene/components/ReflectionProbeComponent.tsx
+++ b/packages/engine/src/scene/components/ReflectionProbeComponent.tsx
@@ -55,6 +55,6 @@ export const ReflectionProbeComponent = defineComponent({
       if (!error) return
       probeComponent.texture.set(null)
       addError(entity, ReflectionProbeComponent, 'LOADING_ERROR', 'Failed to load reflection probe texture.')
-    })
+    }, [])
   }
 })


### PR DESCRIPTION
## Summary
adding back reflectionprobecomponent to the shelf, also making minor changes attempting to clean up envmap's infinite rerender of the reflection probes subreactor

## References
[https://tsu.atlassian.net/browse/IR-4878](https://tsu.atlassian.net/browse/IR-4878)


