### PR TITLE
Increased the S3 request handler timeout and maxSockets

### DIFF
--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -131,6 +131,10 @@ export class S3Provider implements StorageProviderInterface {
     fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
 
     this.provider = new S3Client({
+      requestHandler: {
+        requestTimeout: 5_000,
+        httpsAgent: { maxSockets: 300 }
+      },
       credentials: fromIni({
         profile: config.aws.s3.roleArn ? 'role' : 'default',
         filepath: credentialsPath

--- a/scripts/record-build-error.ts
+++ b/scripts/record-build-error.ts
@@ -63,8 +63,12 @@ cli.main(async () => {
     const buildErrors = fs.readFileSync(`${options.service}-build-error.txt`).toString()
     const builderRun = fs.readFileSync('builder-run.txt').toString()
     if (options.isDocker) {
+      console.log('isDocker is true')
       const cacheMissRegex = new RegExp(`${options.service}:latest_${process.env.RELEASE_NAME}_cache: not found`)
+      console.log('exit code 1', /exit code: 1/.test(buildErrors))
+      console.log('Non cache miss ERROR', /ERROR:/.test(buildErrors) && !cacheMissRegex.test(buildErrors))
       if (/exit code: 1/.test(buildErrors) || (/ERROR:/.test(buildErrors) && !cacheMissRegex.test(buildErrors))) {
+        console.log('Recording error')
         const combinedLogs = `Docker task that errored: ${options.service}\n\nTask logs:\n\n${buildErrors}`
         await knexClient
           .from<BuildStatusType>(buildStatusPath)
@@ -76,6 +80,7 @@ cli.main(async () => {
             logs: combinedLogs,
             dateEnded: dateNow
           })
+        console.log('exiting with code 1')
         cli.exit(1)
       } else cli.exit(0)
     } else {


### PR DESCRIPTION
## Summary

The client build process was starting to frequently get clogged when pushing files to S3, which was leading to index.html not being pushed, but its child index.js files were getting pruned.

AWS documentation suggested increasing number of sockets in these situations. Added some logging so if it continues to happen, it's easier to detect why this isn't being flagged as an error by record-build-error.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
