### PR TITLE
IR-6318 converting spaces to underscores when sanitizing filenames

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -69,6 +69,7 @@
     "sceneCreationFail": "Scene creation failed. {{reason}}",
     "uploadAborted": "Upload aborted",
     "uploadFailed": "Upload failed {{reason}}",
+    "fileUploadFailed": "File upload failed",
     "assetDeletionFail": "Asset deletion failed. {{reason}}",
     "projectAssetDeletionFail": "Project Asset deletion failed. {{reason}}",
     "networkError": "Network Error: {{status}}. {{text}}",

--- a/packages/common/src/utils/cleanFileName.ts
+++ b/packages/common/src/utils/cleanFileName.ts
@@ -42,7 +42,7 @@ export const cleanFileNameString = (fullFileName: string, useStorageProviderLeng
     const lastDotIndex = hasExtension ? _lastDotIndex : fileName.length
 
     // Split the name into the part before and after the dot
-    let nameWithoutExtension = fileName.substring(0, lastDotIndex)
+    let nameWithoutExtension = fileName.substring(0, lastDotIndex).replace(' ', '_')
     const extension = fileName.substring(lastDotIndex + 1).toLowerCase()
 
     //Used by backend uploads to storage provider, which has different length restrictions than other uses

--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -43,6 +43,7 @@ import { pathJoin } from '@ir-engine/engine/src/assets/functions/miscUtils'
 import { modelResourcesPath } from '@ir-engine/engine/src/assets/functions/pathResolver'
 import { getMutableState } from '@ir-engine/hyperflux'
 import { KTX2Encoder } from '@ir-engine/xrui/core/textures/KTX2Encoder'
+import { t } from 'i18next'
 import { showMultipleFileModal } from '../panels/files/toolbar'
 import { ImportSettingsState } from '../services/ImportSettingsState'
 
@@ -212,7 +213,9 @@ export const handleUploadFiles = (projectName: string, directoryPath: string, fi
             contentType: file.type
           }
         ]
-      }).promise
+      }).promise.catch(() => {
+        NotificationService.dispatchNotify(t('editor:errors.fileUploadFailed') as string, { variant: 'error' })
+      })
     })
   )
 }


### PR DESCRIPTION
## Summary
converting spaces to underscores when sanitizing filenames (only on the file name string itself, not path folders)

## References
[https://tsu.atlassian.net/browse/IR-6318](https://tsu.atlassian.net/browse/IR-6318)

## QA Steps
try to upload a file with a space in the name

observe that it no longer silently fails, and you now have that file uploaded with underscores replacing any spaces in the name