### PR TITLE
XrCamera system execute wasn't ported to new viewerEntity

### DIFF
--- a/packages/spatial/src/xr/XRCameraSystem.ts
+++ b/packages/spatial/src/xr/XRCameraSystem.ts
@@ -27,7 +27,6 @@ import { ArrayCamera, PerspectiveCamera, Vector2, Vector3, Vector4 } from 'three
 
 import { AnimationSystemGroup } from '@ir-engine/ecs'
 import { getComponent, getOptionalComponent } from '@ir-engine/ecs/src/ComponentFunctions'
-import { Engine } from '@ir-engine/ecs/src/Engine'
 import { defineSystem } from '@ir-engine/ecs/src/SystemFunctions'
 import { defineActionQueue, getMutableState, getState } from '@ir-engine/hyperflux'
 
@@ -214,10 +213,11 @@ let _currentDepthFar = null as number | null
 const _vec = new Vector2()
 
 export function updateXRCamera() {
-  const renderer = getOptionalComponent(Engine.instance.viewerEntity, RendererComponent)?.renderer
+  const viewerEntity = getState(ReferenceSpaceState).viewerEntity
+  const renderer = getOptionalComponent(viewerEntity, RendererComponent)?.renderer
   if (!renderer) return
 
-  const camera = getComponent(Engine.instance.cameraEntity, CameraComponent)
+  const camera = getComponent(viewerEntity, CameraComponent)
   const xrState = getState(XRState)
   const session = xrState.session
 


### PR DESCRIPTION
## Summary
Looked like this error was blocking loading on deployments. Couldn't repro locally but an error is still an error.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
