### PR TITLE
IR-6253: prevent default scene thumbnail to be deleted when deleting scene

### DIFF
--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -514,6 +514,14 @@ export class FileBrowserService
   }
 
   /**
+   *  Used to verify when a scene is deleted and has the default thumbnail.
+   * This prevents the default thumbnail from being deleted.
+   */
+  private isDefaultThumbnail(thumbnail: StaticResourceType): boolean {
+    return thumbnail.name === 'default.thumbnail.jpg' && thumbnail.project === 'ir-engine/default-project'
+  }
+
+  /**
    * Remove a directory
    */
   async remove(key: string, params?: FileBrowserParams) {
@@ -551,8 +559,7 @@ export class FileBrowserService
               query: { key: { $like: `%${resource.thumbnailKey}%` }, type: 'thumbnail' },
               paginate: false
             })) as any as StaticResourceType[]
-
-            if (thumbnail.length > 0) {
+            if (thumbnail.length > 0 && !this.isDefaultThumbnail(thumbnail[0])) {
               await storageProvider.deleteResources([thumbnail[0].key])
               await this.app.service(staticResourcePath).remove(thumbnail[0].id)
             }


### PR DESCRIPTION
## Summary

Scenes are created with a default thumbnail located in the default project. This is used to verify when a scene is deleted and still has the default thumbnail, preventing the default thumbnail from being deleted

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

1.- Create a new scene
2.- Delete the scene you just created 
3.- Create a new scene 

Expected result: 
The second scene created should be displayed with the default thumbnail
