### PR TITLE
Partial update to support GCP services

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,7 +44,7 @@ have to modify some of these variables, downloads, and calls to use another serv
 This action uses several other secrets to control what repo it is interacting with:
 *`EKS_AWS_ACCESS_KEY_ID`: The public key of an IAM user that has EKS access
 *`EKS_AWS_ACCESS_KEY_SECRET`: The secret key of an IAM user that has EKS access
-*`AWS_REGION`: The region of the EKS cluster/ECR repo to which this built image will be pushed and deployed
+*`CLOUD_REGION`: The region of the cloud image repo to which this built image will be pushed and deployed
 *`CLUSTER_NAME`: The name of the cluster to which this built image will be deployed
 *`DEV_REPO_NAME`: The name of the repo that this built image will be deployed to; most easily set to `etherealengine-dev-builder`
 (also have a repo `etherealengine-dev` for the final built image)
@@ -87,7 +87,7 @@ have to modify some of these variables, downloads, and calls to use another serv
 This action uses several other secrets to control what repo it is interacting with:
 *`EKS_AWS_ACCESS_KEY_ID`: The public key of an IAM user that has EKS access
 *`EKS_AWS_ACCESS_KEY_SECRET`: The secret key of an IAM user that has EKS access
-*`AWS_REGION`: The region of the EKS cluster/ECR repo to which this built image will be pushed and deployed
+*`CLOUD_REGION`: The region of the cloud image repo to which this built image will be pushed and deployed
 *`CLUSTER_NAME`: The name of the cluster to which this built image will be deployed
 *`PROD_REPO_NAME`: The name of the repo that this built image will be deployed to; most easily set to `etherealengine-prod-builder`
 (also have a repo `etherealengine-prod` for the final built image)

--- a/.github/workflows/publish-gh-container.yml
+++ b/.github/workflows/publish-gh-container.yml
@@ -26,17 +26,17 @@ jobs:
         with:
           node-version: 18.x
       - name: Setup AWS
-        run: scripts/setup_aws.sh $EKS_AWS_ACCESS_KEY_ID $EKS_AWS_ACCESS_KEY_SECRET $AWS_REGION $CLUSTER_NAME
+        run: scripts/setup_aws.sh $EKS_AWS_ACCESS_KEY_ID $EKS_AWS_ACCESS_KEY_SECRET $CLOUD_REGION $CLUSTER_NAME
         env:
           EKS_AWS_ACCESS_KEY_ID: ${{ secrets.EKS_AWS_ACCESS_KEY_ID }}
           EKS_AWS_ACCESS_KEY_SECRET: ${{ secrets.EKS_AWS_ACCESS_KEY_SECRET }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          CLOUD_REGION: ${{ secrets.CLOUD_REGION }}
           CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
       - name: Build Docker Image
-        run: bash scripts/build_docker.sh dev $PRIVATE_REPO $AWS_REGION
+        run: bash scripts/build_docker.sh dev $PRIVATE_REPO #CLOUD_REGION
         env:
           REPO_NAME: ${{ secrets.DEV_REPO_NAME }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          CLOUD_REGION: ${{ secrets.CLOUD_REGION }}
           REPO_URL: ${{ secrets.DEV_REPO_URL }}
           REPO_PROVIDER: ${{ secrets.REPO_PROVIDER }}
           PRIVATE_REPO: ${{ secrets.PRIVATE_REPO }}

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@feathersjs/feathers": "5.0.5",
     "@feathersjs/schema": "5.0.5",
     "@feathersjs/typebox": "5.0.5",
+    "@google-cloud/artifact-registry": "^3.5.0",
     "@swc/core": "1.7.35",
     "app-root-path": "3.1.0",
     "cli": "1.0.1",

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -59,6 +59,7 @@
     "@feathersjs/koa": "5.0.5",
     "@feathersjs/transport-commons": "5.0.5",
     "@ffprobe-installer/ffprobe": "^2.0.0",
+    "@google-cloud/artifact-registry": "^3.5.0",
     "@ir-engine/common": "^1.6.0",
     "@ir-engine/engine": "^1.6.0",
     "@ir-engine/matchmaking": "^1.6.0",

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -97,7 +97,8 @@ import IDockerImage = google.devtools.artifactregistry.v1.IDockerImage
 export const dockerHubRegex = /^[\w\d\s\-_]+\/[\w\d\s\-_]+:([\w\d\s\-_.]+)$/
 export const publicECRRepoRegex = /^public.ecr.aws\/[a-zA-Z0-9]+\/([a-z0-9\-_\\]+)$/
 export const publicECRTagRegex = /^public.ecr.aws\/[a-zA-Z0-9]+\/[a-z0-9\-_\\]+:([\w\d\s\-_.]+?)$/
-export const GCPArtifactRegistryRepoRegex = /^[a-zA-Z0-9\-]+-docker.pkg.dev\/[a-zA-Z0-9\-_\\]+\/([a-zA-Z0-9\-_\\]+)$/
+export const GCPArtifactRegistryRepoRegex =
+  /^[a-zA-Z0-9\-]+-docker.pkg.dev\/[a-zA-Z0-9\-_\\]+\/([a-zA-Z0-9\-_\\]+)\/([a-zA-Z0-9\-_\\]+)$/
 export const privateECRRepoRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaws.com\/([a-z0-9\-_\\]+)$/
 export const privateECRTagRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaws.com\/[a-z0-9\-_\\]+:([\w\d\s\-_.]+)$/
 
@@ -133,6 +134,12 @@ interface GitHubFile {
       html: string
     }
   }
+}
+
+const getParent = (repoName: string) => {
+  const repoSplit = repoName.split('/')
+  const region = repoSplit[0].replace('-docker.pkg.dev', '')
+  return `projects/${repoSplit[1]}/locations/${region}/repositories/${repoSplit[2]}`
 }
 
 export const updateBuilder = async (
@@ -886,13 +893,20 @@ export const findBuilderTags = async (): Promise<Array<ProjectBuilderTagsType>> 
     const arClient = new ArtifactRegistryClient()
     let images = [] as IDockerImage[]
     const input = {
-      parent: builderRepo
+      parent: getParent(builderRepo)
     } as any
     try {
       const iterableResponse = arClient.listDockerImagesAsync(input)
       for await (const item of iterableResponse) images = images.concat(item)
       return images
-        .filter((image) => image.tags && image.tags.length > 0 && image.uploadTime)
+        .filter(
+          (image) =>
+            image.uri &&
+            new RegExp(builderRepo).test(image.uri) &&
+            image.tags &&
+            image.tags.length > 0 &&
+            image.uploadTime
+        )
         .sort((a, b) => (b.uploadTime!.seconds as number) - (a.uploadTime!.seconds as number))
         .map((image) => {
           const tag = image.tags!.find((tag) => !/latest/.test(tag)) as string
@@ -901,7 +915,7 @@ export const findBuilderTags = async (): Promise<Array<ProjectBuilderTagsType>> 
             tag,
             commitSHA: tagSplit.length === 1 ? tagSplit[0] : tagSplit[1],
             engineVersion: tagSplit.length === 1 ? 'unknown' : tagSplit[0],
-            pushedAt: new Date((image.uploadTime!.seconds as number) * 1000).toJSON() as string
+            pushedAt: new Date(parseInt(image.uploadTime!.seconds as string) * 1000).toJSON() as string
           }
         })
     } catch (err) {

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -32,6 +32,7 @@ import { DescribeImagesCommand, ECRPUBLICClient } from '@aws-sdk/client-ecr-publ
 import { fromIni } from '@aws-sdk/credential-providers'
 import { BadRequest, Forbidden, NotFound } from '@feathersjs/errors'
 import { Paginated } from '@feathersjs/feathers'
+import { v1 } from '@google-cloud/artifact-registry'
 import * as k8s from '@kubernetes/client-node'
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest'
 import appRootPath from 'app-root-path'
@@ -71,6 +72,7 @@ import { AssetLoader } from '@ir-engine/engine/src/assets/classes/AssetLoader'
 import { getState } from '@ir-engine/hyperflux'
 import { ProjectConfigInterface, ProjectEventHooks } from '@ir-engine/projects/ProjectConfigInterface'
 
+import { google } from '@google-cloud/artifact-registry/build/protos/protos'
 import { EngineSettings } from '@ir-engine/common/src/constants/EngineSettings'
 import { BUILDER_CHART_REGEX } from '@ir-engine/common/src/regex'
 import { engineSettingPath } from '@ir-engine/common/src/schema.type.module'
@@ -90,10 +92,12 @@ import { getGitConfigData, getGitHeadData, getGitOrigHeadData } from '../../util
 import { useGit } from '../../util/gitHelperFunctions'
 import { getAuthenticatedRepo, getOctokitForChecking, getUserRepos } from './github-helper'
 import { ProjectParams } from './project.class'
+import IDockerImage = google.devtools.artifactregistry.v1.IDockerImage
 
 export const dockerHubRegex = /^[\w\d\s\-_]+\/[\w\d\s\-_]+:([\w\d\s\-_.]+)$/
 export const publicECRRepoRegex = /^public.ecr.aws\/[a-zA-Z0-9]+\/([a-z0-9\-_\\]+)$/
 export const publicECRTagRegex = /^public.ecr.aws\/[a-zA-Z0-9]+\/[a-z0-9\-_\\]+:([\w\d\s\-_.]+?)$/
+export const GCPArtifactRegistryRepoRegex = /^[a-zA-Z0-9\-]+-docker.pkg.dev\/[a-zA-Z0-9\-_\\]+\/([a-zA-Z0-9\-_\\]+)$/
 export const privateECRRepoRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaws.com\/([a-z0-9\-_\\]+)$/
 export const privateECRTagRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaws.com\/[a-z0-9\-_\\]+:([\w\d\s\-_.]+)$/
 
@@ -104,6 +108,8 @@ const awsPath = './.aws/eks'
 const credentialsPath = `${awsPath}/credentials`
 
 const execAsync = promisify(exec)
+
+const ArtifactRegistryClient = v1.ArtifactRegistryClient
 
 interface GitHubFile {
   status: number
@@ -793,6 +799,7 @@ export const findBuilderTags = async (): Promise<Array<ProjectBuilderTagsType>> 
   const builderRepo = `${process.env.SOURCE_REPO_URL}/${process.env.SOURCE_REPO_NAME_STEM}-builder`
   const publicECRExec = publicECRRepoRegex.exec(builderRepo)
   const privateECRExec = privateECRRepoRegex.exec(builderRepo)
+  const gcpECRRegex = GCPArtifactRegistryRepoRegex.exec(builderRepo)
   if (publicECRExec) {
     const awsCredentials = `[default]\naws_access_key_id=${config.aws.eks.accessKeyId}\naws_secret_access_key=${config.aws.eks.secretAccessKey}\n[role]\nrole_arn = ${config.aws.eks.roleArn}\nsource_profile = default`
 
@@ -872,6 +879,34 @@ export const findBuilderTags = async (): Promise<Array<ProjectBuilderTagsType>> 
     } catch (err) {
       logger.error('Failure to get private ECR images')
       logger.error('Command that was sent %o', result)
+      logger.error(err)
+      return []
+    }
+  } else if (gcpECRRegex) {
+    const arClient = new ArtifactRegistryClient()
+    let images = [] as IDockerImage[]
+    const input = {
+      parent: builderRepo
+    } as any
+    try {
+      const iterableResponse = arClient.listDockerImagesAsync(input)
+      for await (const item of iterableResponse) images = images.concat(item)
+      return images
+        .filter((image) => image.tags && image.tags.length > 0 && image.uploadTime)
+        .sort((a, b) => (b.uploadTime!.seconds as number) - (a.uploadTime!.seconds as number))
+        .map((image) => {
+          const tag = image.tags!.find((tag) => !/latest/.test(tag)) as string
+          const tagSplit = tag ? tag.split('_') : ''
+          return {
+            tag,
+            commitSHA: tagSplit.length === 1 ? tagSplit[0] : tagSplit[1],
+            engineVersion: tagSplit.length === 1 ? 'unknown' : tagSplit[0],
+            pushedAt: new Date((image.uploadTime!.seconds as number) * 1000).toJSON() as string
+          }
+        })
+    } catch (err) {
+      logger.error('Failure to get GCP Artifact Registry Images')
+      logger.error('Repo that was fetched from %s', builderRepo)
       logger.error(err)
       return []
     }

--- a/scripts/build_and_publish_package.sh
+++ b/scripts/build_and_publish_package.sh
@@ -19,6 +19,8 @@ if [ "$DESTINATION_REPO_PROVIDER" = "aws" ]; then
     aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $DESTINATION_REPO_URL
     aws ecr-public describe-repositories --repository-names $DESTINATION_REPO_NAME_STEM-$PACKAGE --region us-east-1 || aws ecr-public create-repository --repository-name $DESTINATION_REPO_NAME_STEM-$PACKAGE --region us-east-1
   fi
+elif [ "$DESTINATION_REPO_PROVIDER" == "gcp" ]; then
+  # Insert GCP credentials fetching here, and apply that to docker login
 else
   echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 fi
@@ -51,6 +53,9 @@ if [ "$DOCKERFILE" != "client-serve-static" ]; then
     --build-arg STORAGE_AWS_ACCESS_KEY_SECRET=$STORAGE_AWS_ACCESS_KEY_SECRET \
     --build-arg STORAGE_AWS_ROLE_ARN=$STORAGE_AWS_ROLE_ARN \
     --build-arg STORAGE_AWS_ENABLE_ACLS=$STORAGE_AWS_ENABLE_ACLS \
+    --build-arg STORAGE_GCP_ACCESS_KEY_ID=$STORAGE_GCP_ACCESS_KEY_ID \
+    --build-arg STORAGE_GCP_ACCESS_KEY_SECRET=$STORAGE_GCP_ACCESS_KEY_SECRET \
+    --build-arg STORAGE_GCP_ROLE_ARN=$STORAGE_GCP_ROLE_ARN \
     --build-arg STORAGE_S3_REGION=$STORAGE_S3_REGION \
     --build-arg STORAGE_S3_AVATAR_DIRECTORY=$STORAGE_S3_AVATAR_DIRECTORY \
     --build-arg SERVE_CLIENT_FROM_STORAGE_PROVIDER=$SERVE_CLIENT_FROM_STORAGE_PROVIDER \
@@ -101,6 +106,9 @@ else
     --build-arg STORAGE_AWS_ACCESS_KEY_SECRET=$STORAGE_AWS_ACCESS_KEY_SECRET \
     --build-arg STORAGE_AWS_ROLE_ARN=$STORAGE_AWS_ROLE_ARN \
     --build-arg STORAGE_AWS_ENABLE_ACLS=$STORAGE_AWS_ENABLE_ACLS \
+    --build-arg STORAGE_GCP_ACCESS_KEY_ID=$STORAGE_GCP_ACCESS_KEY_ID \
+    --build-arg STORAGE_GCP_ACCESS_KEY_SECRET=$STORAGE_GCP_ACCESS_KEY_SECRET \
+    --build-arg STORAGE_GCP_ROLE_ARN=$STORAGE_GCP_ROLE_ARN \
     --build-arg STORAGE_S3_REGION=$STORAGE_S3_REGION \
     --build-arg STORAGE_S3_AVATAR_DIRECTORY=$STORAGE_S3_AVATAR_DIRECTORY \
     --build-arg SERVE_CLIENT_FROM_STORAGE_PROVIDER=$SERVE_CLIENT_FROM_STORAGE_PROVIDER \

--- a/scripts/build_and_publish_package.sh
+++ b/scripts/build_and_publish_package.sh
@@ -20,6 +20,7 @@ if [ "$DESTINATION_REPO_PROVIDER" = "aws" ]; then
     aws ecr-public describe-repositories --repository-names $DESTINATION_REPO_NAME_STEM-$PACKAGE --region us-east-1 || aws ecr-public create-repository --repository-name $DESTINATION_REPO_NAME_STEM-$PACKAGE --region us-east-1
   fi
 elif [ "$DESTINATION_REPO_PROVIDER" == "gcp" ]; then
+  echo "Log into Docker with GCP credentials"
   # Insert GCP credentials fetching here, and apply that to docker login
 else
   echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/scripts/build_docker_builder.sh
+++ b/scripts/build_docker_builder.sh
@@ -54,4 +54,6 @@ then
   else
     npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $REPO_NAME-builder --region us-east-1 --service builder --releaseName $STAGE --public
   fi
+elif [ $REPO_PROVIDER === "gcp" ]; then
+  npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $REPO_NAME-builder --service builder --releaseName $STAGE
 fi

--- a/scripts/prune_gcp_ar_images.ts
+++ b/scripts/prune_gcp_ar_images.ts
@@ -26,10 +26,8 @@ Infinite Reality Engine. All Rights Reserved.
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import { v1 } from '@google-cloud/artifact-registry'
-import config from '@ir-engine/server-core/src/appconfig'
 import * as k8s from '@kubernetes/client-node'
 import cli from 'cli'
-import fs from 'fs'
 
 cli.enable('status')
 
@@ -59,19 +57,28 @@ const getAllPods = async (k8Client, continueValue, labelSelector, pods = []) => 
   else return pods
 }
 
+const getParent = (includePackage = false) => {
+  const repoSplit = options.repoName.split('/')
+  const region = repoSplit[0].replace('-docker.pkg.dev', '')
+  let returned = `projects/${repoSplit[1]}/locations/${region}/repositories/${repoSplit[2]}`
+  if (includePackage) returned += `/packages/${repoSplit[3]}`
+  return returned
+}
+
 const getAllImages = async (arClient: any, repoName: string, images = [] as any[]) => {
   const input = {
-    parent: repoName
+    parent: getParent(false)
   } as any
   const iterableResponse = arClient.listDockerImagesAsync(input)
   for await (const item of iterableResponse) images = images.concat(item)
-  return images
+  return images.filter((image) => new RegExp(repoName).test(image.uri))
 }
 
 const deleteImages = async (arClient, toBeDeleted) => {
+  const parent = getParent(true)
   const localOptions = {
-    names: toBeDeleted.map((image) => image.name),
-    parent: options.repoName || 'ir-engine'
+    names: toBeDeleted.map((image) => parent + '/versions/' + image.name.split('@')[1]),
+    parent
   }
   const [operation] = await arClient.batchDeleteVersions(localOptions)
   return await operation.promise()
@@ -112,11 +119,6 @@ cli.main(async () => {
       currentImages = [...new Set(currentImages)]
     }
 
-    const awsCredentials = `[default]\naws_access_key_id=${config.aws.eks.accessKeyId}\naws_secret_access_key=${config.aws.eks.secretAccessKey}\n[role]\nrole_arn = ${config.aws.eks.roleArn}\nsource_profile = default`
-
-    if (!fs.existsSync(awsPath)) fs.mkdirSync(awsPath, { recursive: true })
-    if (!fs.existsSync(credentialsPath)) fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
-
     const arClient = new ArtifactRegistryClient({})
 
     const images = await getAllImages(arClient, options.repoName || 'ir-engine', [])
@@ -135,7 +137,11 @@ cli.main(async () => {
       // were made within 10 seconds of the tagged manifest.
       excludedImageUris.push(
         ...images
-          .filter((image) => latestImageTime - image.uploadTime <= 10000 && latestImageTime - image.uploadTime >= 0)
+          .filter(
+            (image) =>
+              latestImageTime.seconds - image.uploadTime.seconds <= 10000 &&
+              latestImageTime.seconds - image.uploadTime.seconds >= 0
+          )
           .map((image) => image.uri)
       )
     }
@@ -149,14 +155,15 @@ cli.main(async () => {
           ...images
             .filter(
               (image) =>
-                currentTaggedImageTime - image.uploadTime <= 10000 && currentTaggedImageTime - image.uploadTime >= 0
+                currentTaggedImageTime.seconds - image.uploadTime.seconds <= 10000 &&
+                currentTaggedImageTime.seconds - image.uploadTime.seconds >= 0
             )
             .map((image) => image.uri)
         )
       }
     }
     const withoutLatestOrCurrent = images.filter((image) => excludedImageUris.indexOf(image.uri) < 0)
-    const sorted = withoutLatestOrCurrent.sort((a, b) => b.uploadTime - a.uploadTime)
+    const sorted = withoutLatestOrCurrent.sort((a, b) => b.uploadTime.seconds - a.uploadTime.seconds)
     let toBeDeleted = sorted.slice(9)
     if (toBeDeleted.length > 0) {
       await deleteImages(arClient, toBeDeleted)

--- a/scripts/prune_gcp_ar_images.ts
+++ b/scripts/prune_gcp_ar_images.ts
@@ -1,0 +1,169 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+import { v1 } from '@google-cloud/artifact-registry'
+import config from '@ir-engine/server-core/src/appconfig'
+import * as k8s from '@kubernetes/client-node'
+import cli from 'cli'
+import fs from 'fs'
+
+cli.enable('status')
+
+const options = cli.parse({
+  repoName: [false, 'Name of repository', 'string'],
+  service: [true, 'Name of service', 'string'],
+  releaseName: [true, 'Name of release', 'string']
+})
+
+const ArtifactRegistryClient = v1.ArtifactRegistryClient
+
+const K8S_PAGE_LIMIT = 1
+
+const getAllPods = async (k8Client, continueValue, labelSelector, pods = []) => {
+  const matchingPods = await k8Client.listNamespacedPod(
+    'default',
+    'false',
+    false,
+    continueValue,
+    undefined,
+    labelSelector,
+    K8S_PAGE_LIMIT
+  )
+  if (matchingPods?.body?.items) pods = pods.concat(matchingPods.body.items)
+  if (matchingPods.body.metadata?._continue)
+    return await getAllPods(k8Client, matchingPods.body.metadata._continue, labelSelector, pods)
+  else return pods
+}
+
+const getAllImages = async (arClient: any, repoName: string, images = [] as any[]) => {
+  const input = {
+    parent: repoName
+  } as any
+  const iterableResponse = arClient.listDockerImagesAsync(input)
+  for await (const item of iterableResponse) images = images.concat(item)
+  return images
+}
+
+const deleteImages = async (arClient, toBeDeleted) => {
+  const localOptions = {
+    names: toBeDeleted.map((image) => image.name),
+    parent: options.repoName || 'ir-engine'
+  }
+  const [operation] = await arClient.batchDeleteVersions(localOptions)
+  return await operation.promise()
+}
+
+cli.main(async () => {
+  try {
+    let matchingPods,
+      excludedImageUris = [] as string[],
+      currentImages = [] as string[]
+    if (options.service !== 'builder') {
+      const kc = new k8s.KubeConfig()
+      kc.loadFromDefault()
+      const k8DefaultClient = kc.makeApiClient(k8s.CoreV1Api)
+      if (options.service === 'instanceserver') {
+        matchingPods = await getAllPods(k8DefaultClient, undefined, `agones.dev/role=gameserver`, [])
+        const releaseAnnotation = `${options.releaseName}-instanceserver`
+        matchingPods = matchingPods.filter(
+          (item) => item.metadata.annotations['agones.dev/container'] === releaseAnnotation
+        )
+
+        currentImages = matchingPods.map(
+          (item) =>
+            item.spec.containers.find((container) => container.name === `${options.releaseName}-instanceserver`).image
+        )
+      } else if (options.repoName !== 'root') {
+        matchingPods = await getAllPods(
+          k8DefaultClient,
+          undefined,
+          `app.kubernetes.io/instance=${options.releaseName},app.kubernetes.io/component=${options.service}`,
+          []
+        )
+
+        currentImages = matchingPods.map(
+          (item) => item.spec.containers.find((container) => container.name === 'ir-engine').image.split(':')[1]
+        )
+      }
+      currentImages = [...new Set(currentImages)]
+    }
+
+    const awsCredentials = `[default]\naws_access_key_id=${config.aws.eks.accessKeyId}\naws_secret_access_key=${config.aws.eks.secretAccessKey}\n[role]\nrole_arn = ${config.aws.eks.roleArn}\nsource_profile = default`
+
+    if (!fs.existsSync(awsPath)) fs.mkdirSync(awsPath, { recursive: true })
+    if (!fs.existsSync(credentialsPath)) fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
+
+    const arClient = new ArtifactRegistryClient({})
+
+    const images = await getAllImages(arClient, options.repoName || 'ir-engine', [])
+    if (!images) return
+    const latestImage = images.find(
+      (image) =>
+        image.tags &&
+        (image.tags.indexOf(`latest_${options.releaseName}`) >= 0 ||
+          image.tags.indexOf(`latest_${options.releaseName}_cache`) >= 0)
+    )
+    if (latestImage) {
+      const latestImageTime = latestImage.uploadTime
+      // ECR automatically supports multi-architecture builds, which results in multiple images/image indexes. In order
+      // to not accidentally delete related images, we need to keep all of them for a given tag. Ran into problems
+      // trying to inspect the image (and pulling it would be time-consuming), so just checking for images that
+      // were made within 10 seconds of the tagged manifest.
+      excludedImageUris.push(
+        ...images
+          .filter((image) => latestImageTime - image.uploadTime <= 10000 && latestImageTime - image.uploadTime >= 0)
+          .map((image) => image.uri)
+      )
+    }
+    const currentTaggedImages = images.filter(
+      (image) => image.tags && image.tags.some((item) => currentImages.includes(item))
+    )
+    if (currentTaggedImages) {
+      for (let currentTaggedImage of currentTaggedImages) {
+        const currentTaggedImageTime = currentTaggedImage.uploadTime
+        excludedImageUris.push(
+          ...images
+            .filter(
+              (image) =>
+                currentTaggedImageTime - image.uploadTime <= 10000 && currentTaggedImageTime - image.uploadTime >= 0
+            )
+            .map((image) => image.uri)
+        )
+      }
+    }
+    const withoutLatestOrCurrent = images.filter((image) => excludedImageUris.indexOf(image.uri) < 0)
+    const sorted = withoutLatestOrCurrent.sort((a, b) => b.uploadTime - a.uploadTime)
+    let toBeDeleted = sorted.slice(9)
+    if (toBeDeleted.length > 0) {
+      await deleteImages(arClient, toBeDeleted)
+      process.exit(0)
+    } else process.exit(0)
+  } catch (err) {
+    console.log('Error in deleting old ECR images:')
+    console.log(err)
+  }
+})

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -54,7 +54,7 @@ then
   fi
 elif [ $DESTIONATION_REPO_PROVIDER == "gcp" ]
   echo "Log into Docker with GCP credentials"
-# Insert code for getting Artifact Registry credentials and doing docker login with them
+  # Insert code for getting Artifact Registry credentials and doing docker login with them
 fi
 
 mkdir -p ./project-package-jsons/projects/default-project
@@ -105,7 +105,7 @@ then
     npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --service instanceserver --releaseName $RELEASE_NAME
     npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --service taskserver --releaseName $RELEASE_NAME
   fi
-elif [ "$SERVE_CLIENT_FROM_API" = "true" ]
+elif [ "$SERVE_CLIENT_FROM_API" == "true" ]
 then
   bash ./scripts/build_and_publish_package.sh $RELEASE_NAME api api-client $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >api-build-logs.txt 2>api-build-error.txt &
   bash ./scripts/build_and_publish_package.sh $RELEASE_NAME instanceserver instanceserver $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >instanceserver-build-logs.txt 2>instanceserver-build-error.txt &
@@ -193,7 +193,7 @@ bash ./scripts/cleanup_builder.sh
 END_TIME=`date +"%d-%m-%yT%H-%M-%S"`
 echo "Started build at $START_TIME, deployed image to K8s at $DEPLOY_TIME, ended at $END_TIME"
 sleep 3m
-if [ "$SERVE_CLIENT_FROM_STORAGE_PROVIDER" = "true" ] && [ "$STORAGE_PROVIDER" = "s3" ] ; then
+if [ "$SERVE_CLIENT_FROM_STORAGE_PROVIDER" == "true" ] && [ "$STORAGE_PROVIDER" == "s3" ] ; then
   npx ts-node --swc scripts/delete-old-s3-files.ts;
   echo "Deleted old client files from S3"
 fi

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -16,6 +16,7 @@ then
   bash ./scripts/setup_aws.sh $EKS_AWS_ACCESS_KEY_ID $EKS_AWS_ACCESS_KEY_SECRET $CLOUD_REGION $CLUSTER_NAME $EKS_AWS_ROLE_ARN
 elif [ $DESTINATION_REPO_PROVIDER == "gcp" ]
 then
+  echo "Need to set up GCP"
   # Insert script for setting up GCP credentials
   #bash ./scripts/setup_gcp.sh
 fi
@@ -52,6 +53,7 @@ then
     aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $DESTINATION_REPO_URL
   fi
 elif [ $DESTIONATION_REPO_PROVIDER == "gcp" ]
+  echo "Log into Docker with GCP credentials"
 # Insert code for getting Artifact Registry credentials and doing docker login with them
 fi
 

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -11,7 +11,14 @@ START_TIME=`date +"%d-%m-%yT%H-%M-%S"`
 mkdir -pv ~/.docker
 cp -v /var/lib/docker/certs/client/* ~/.docker
 touch ./builder-started.txt
-bash ./scripts/setup_aws.sh $EKS_AWS_ACCESS_KEY_ID $EKS_AWS_ACCESS_KEY_SECRET $AWS_REGION $CLUSTER_NAME $EKS_AWS_ROLE_ARN
+if [ $DESTINATION_REPO_PROVIDER == "aws"]
+then
+  bash ./scripts/setup_aws.sh $EKS_AWS_ACCESS_KEY_ID $EKS_AWS_ACCESS_KEY_SECRET $CLOUD_REGION $CLUSTER_NAME $EKS_AWS_ROLE_ARN
+elif [ $DESTINATION_REPO_PROVIDER == "gcp" ]
+then
+  # Insert script for setting up GCP credentials
+  #bash ./scripts/setup_gcp.sh
+fi
 npx ts-node --swc scripts/check-db-exists.ts
 npm run prepare-database
 npm run create-build-status
@@ -36,11 +43,16 @@ fi
 bash ./scripts/cleanup_builder.sh
 
 
-if [ $PRIVATE_REPO == "true" ]
+if [ $DESTINATION_REPO_PROVIDER == "aws"]
 then
-  aws ecr get-login-password --region $AWS_REGION | docker login -u AWS --password-stdin $DESTINATION_REPO_URL
-else
-  aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $DESTINATION_REPO_URL
+  if [ $PRIVATE_REPO == "true" ]
+  then
+    aws ecr get-login-password --region $CLOUD_REGION | docker login -u AWS --password-stdin $DESTINATION_REPO_URL
+  else
+    aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $DESTINATION_REPO_URL
+  fi
+elif [ $DESTIONATION_REPO_PROVIDER == "gcp" ]
+# Insert code for getting Artifact Registry credentials and doing docker login with them
 fi
 
 mkdir -p ./project-package-jsons/projects/default-project
@@ -48,15 +60,15 @@ cp packages/projects/default-project/package.json ./project-package-jsons/projec
 find packages/projects/projects/ -name package.json -exec bash -c 'mkdir -p ./project-package-jsons/$(dirname $1) && cp $1 ./project-package-jsons/$(dirname $1)' - '{}' \;
 
 
-if [ "$SERVE_CLIENT_FROM_STORAGE_PROVIDER" = "true" ] && [ "$STORAGE_PROVIDER" = "s3" ]
+if [ "$SERVE_CLIENT_FROM_STORAGE_PROVIDER" == "true" ]
 then
   npx ts-node --swc scripts/get-deletable-client-files.ts
 
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME api api $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >api-build-logs.txt 2>api-build-error.txt &
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME client client-serve-static $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >client-build-logs.txt 2>client-build-error.txt &
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME instanceserver instanceserver $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >instanceserver-build-logs.txt 2>instanceserver-build-error.txt &
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME taskserver taskserver $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >taskserver-build-logs.txt 2>taskserver-build-error.txt &
-  #bash ./scripts/build_and_publish_package.sh $RELEASE_NAME testbot testbot $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >testbot-build-logs.txt 2>testbot-build-error.txt && &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME api api $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >api-build-logs.txt 2>api-build-error.txt &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME client client-serve-static $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >client-build-logs.txt 2>client-build-error.txt &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME instanceserver instanceserver $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >instanceserver-build-logs.txt 2>instanceserver-build-error.txt &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME taskserver taskserver $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >taskserver-build-logs.txt 2>taskserver-build-error.txt &
+  #bash ./scripts/build_and_publish_package.sh $RELEASE_NAME testbot testbot $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >testbot-build-logs.txt 2>testbot-build-error.txt && &
 
   wait < <(jobs -p)
 
@@ -72,24 +84,31 @@ then
     if [ $PRIVATE_REPO == "true" ]
     then
       echo "PRUNING PRIVATE REPOS"
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region $AWS_REGION --service api --releaseName $RELEASE_NAME
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-client --region $AWS_REGION --service client --releaseName $RELEASE_NAME
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region $AWS_REGION --service instanceserver --releaseName $RELEASE_NAME
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region $AWS_REGION --service taskserver --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region $CLOUD_REGION --service api --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-client --region $CLOUD_REGION --service client --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region $CLOUD_REGION --service instanceserver --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region $CLOUD_REGION --service taskserver --releaseName $RELEASE_NAME
     else
       echo "PRUNING PUBLIC REPOS"
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region us-east-1 --service api --releaseName $RELEASE_NAME --public
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-client --region us-east-1 --service client --releaseName $RELEASE_NAME --public
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instancserver --releaseName $RELEASE_NAME --public
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instanceserver --releaseName $RELEASE_NAME --public
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region us-east-1 --service taskserver --releaseName $RELEASE_NAME --public
     fi
+  elif [ $DESTINATION_REPO_PROVIDER == "gcp"]
+  then
+    echo "PRUNING GCP ARTIFACT REGISTRY REPOS"
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --service api --releaseName $RELEASE_NAME
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-client --service client --releaseName $RELEASE_NAME
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --service instanceserver --releaseName $RELEASE_NAME
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --service taskserver --releaseName $RELEASE_NAME
   fi
 elif [ "$SERVE_CLIENT_FROM_API" = "true" ]
 then
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME api api-client $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >api-build-logs.txt 2>api-build-error.txt &
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME instanceserver instanceserver $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >instanceserver-build-logs.txt 2>instanceserver-build-error.txt &
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME taskserver taskserver $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >taskserver-build-logs.txt 2>taskserver-build-error.txt &
-  #bash ./scripts/build_and_publish_package.sh $RELEASE_NAME testbot testbot $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >testbot-build-logs.txt 2>testbot-build-error.txt && &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME api api-client $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >api-build-logs.txt 2>api-build-error.txt &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME instanceserver instanceserver $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >instanceserver-build-logs.txt 2>instanceserver-build-error.txt &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME taskserver taskserver $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >taskserver-build-logs.txt 2>taskserver-build-error.txt &
+  #bash ./scripts/build_and_publish_package.sh $RELEASE_NAME testbot testbot $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >testbot-build-logs.txt 2>testbot-build-error.txt && &
 
   wait < <(jobs -p)
 
@@ -104,22 +123,28 @@ then
     if [ $PRIVATE_REPO == "true" ]
     then
       echo "PRUNING PRIVATE REPOS"
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region $AWS_REGION --service api --releaseName $RELEASE_NAME
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region $AWS_REGION --service instanceserver --releaseName $RELEASE_NAME
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region $AWS_REGION --service taskserver --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region $CLOUD_REGION --service api --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region $CLOUD_REGION --service instanceserver --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region $CLOUD_REGION --service taskserver --releaseName $RELEASE_NAME
     else
       echo "PRUNING PUBLIC REPOS"
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region us-east-1 --service api --releaseName $RELEASE_NAME --public
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instancserver --releaseName $RELEASE_NAME --public
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instanceserver --releaseName $RELEASE_NAME --public
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region us-east-1 --service taskserver --releaseName $RELEASE_NAME --public
     fi
+  elif [ $DESTINATION_REPO_PROVIDER == "gcp"]
+  then
+    echo "PRUNING GCP ARTIFACT REGISTRY REPOS"
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --service api --releaseName $RELEASE_NAME
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --service instanceserver --releaseName $RELEASE_NAME
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --service taskserver --releaseName $RELEASE_NAME
   fi
 else
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME api api $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >api-build-logs.txt 2>api-build-error.txt &
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME client client $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >client-build-logs.txt 2>client-build-error.txt &
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME instanceserver instanceserver $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >instanceserver-build-logs.txt 2>instanceserver-build-error.txt &
-  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME taskserver taskserver $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >taskserver-build-logs.txt 2>taskserver-build-error.txt &
-  #bash ./scripts/build_and_publish_package.sh $RELEASE_NAME testbot testbot $START_TIME $AWS_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >testbot-build-logs.txt 2>testbot-build-error.txt && &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME api api $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >api-build-logs.txt 2>api-build-error.txt &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME client client $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >client-build-logs.txt 2>client-build-error.txt &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME instanceserver instanceserver $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >instanceserver-build-logs.txt 2>instanceserver-build-error.txt &
+  bash ./scripts/build_and_publish_package.sh $RELEASE_NAME taskserver taskserver $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >taskserver-build-logs.txt 2>taskserver-build-error.txt &
+  #bash ./scripts/build_and_publish_package.sh $RELEASE_NAME testbot testbot $START_TIME $CLOUD_REGION $NODE_ENV $DESTINATION_REPO_PROVIDER $PRIVATE_REPO >testbot-build-logs.txt 2>testbot-build-error.txt && &
 
   wait < <(jobs -p)
 
@@ -133,16 +158,23 @@ else
   then
     if [ $PRIVATE_REPO == "true" ]
     then
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region $AWS_REGION --service api --releaseName $RELEASE_NAME
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-client --region $AWS_REGION --service client --releaseName $RELEASE_NAME
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region $AWS_REGION --service instanceserver --releaseName $RELEASE_NAME
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region $AWS_REGION --service taskserver --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region $CLOUD_REGION --service api --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-client --region $CLOUD_REGION --service client --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region $CLOUD_REGION --service instanceserver --releaseName $RELEASE_NAME
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region $CLOUD_REGION --service taskserver --releaseName $RELEASE_NAME
     else
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --region us-east-1 --service api --releaseName $RELEASE_NAME --public
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-client --region us-east-1 --service client --releaseName $RELEASE_NAME --public
-      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instancserver --releaseName $RELEASE_NAME --public
+      npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instanceserver --releaseName $RELEASE_NAME --public
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region us-east-1 --service taskserver --releaseName $RELEASE_NAME --public
     fi
+  elif [ $DESTINATION_REPO_PROVIDER == "gcp"]
+  then
+    echo "PRUNING GCP ARTIFACT REGISTRY REPOS"
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --service api --releaseName $RELEASE_NAME
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-client --service client --releaseName $RELEASE_NAME
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --service instanceserver --releaseName $RELEASE_NAME
+    npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --service taskserver --releaseName $RELEASE_NAME
   fi
 fi
 

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -11,7 +11,7 @@ START_TIME=`date +"%d-%m-%yT%H-%M-%S"`
 mkdir -pv ~/.docker
 cp -v /var/lib/docker/certs/client/* ~/.docker
 touch ./builder-started.txt
-if [ $DESTINATION_REPO_PROVIDER == "aws"]
+if [ $DESTINATION_REPO_PROVIDER == "aws" ]
 then
   bash ./scripts/setup_aws.sh $EKS_AWS_ACCESS_KEY_ID $EKS_AWS_ACCESS_KEY_SECRET $CLOUD_REGION $CLUSTER_NAME $EKS_AWS_ROLE_ARN
 elif [ $DESTINATION_REPO_PROVIDER == "gcp" ]
@@ -44,7 +44,7 @@ fi
 bash ./scripts/cleanup_builder.sh
 
 
-if [ $DESTINATION_REPO_PROVIDER == "aws"]
+if [ $DESTINATION_REPO_PROVIDER == "aws" ]
 then
   if [ $PRIVATE_REPO == "true" ]
   then
@@ -98,7 +98,7 @@ then
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instanceserver --releaseName $RELEASE_NAME --public
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region us-east-1 --service taskserver --releaseName $RELEASE_NAME --public
     fi
-  elif [ $DESTINATION_REPO_PROVIDER == "gcp"]
+  elif [ $DESTINATION_REPO_PROVIDER == "gcp" ]
   then
     echo "PRUNING GCP ARTIFACT REGISTRY REPOS"
     npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --service api --releaseName $RELEASE_NAME
@@ -135,7 +135,7 @@ then
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instanceserver --releaseName $RELEASE_NAME --public
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region us-east-1 --service taskserver --releaseName $RELEASE_NAME --public
     fi
-  elif [ $DESTINATION_REPO_PROVIDER == "gcp"]
+  elif [ $DESTINATION_REPO_PROVIDER == "gcp" ]
   then
     echo "PRUNING GCP ARTIFACT REGISTRY REPOS"
     npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --service api --releaseName $RELEASE_NAME
@@ -171,7 +171,7 @@ else
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-instanceserver --region us-east-1 --service instanceserver --releaseName $RELEASE_NAME --public
       npx ts-node --swc ./scripts/prune_ecr_images.ts --repoName $DESTINATION_REPO_NAME_STEM-taskserver --region us-east-1 --service taskserver --releaseName $RELEASE_NAME --public
     fi
-  elif [ $DESTINATION_REPO_PROVIDER == "gcp"]
+  elif [ $DESTINATION_REPO_PROVIDER == "gcp" ]
   then
     echo "PRUNING GCP ARTIFACT REGISTRY REPOS"
     npx ts-node --swc ./scripts/prune_gcp_ar_images.ts --repoName $DESTINATION_REPO_NAME_STEM-api --service api --releaseName $RELEASE_NAME

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -53,6 +53,7 @@ then
     aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $DESTINATION_REPO_URL
   fi
 elif [ $DESTIONATION_REPO_PROVIDER == "gcp" ]
+then
   echo "Log into Docker with GCP credentials"
   # Insert code for getting Artifact Registry credentials and doing docker login with them
 fi


### PR DESCRIPTION
## Summary

Added a new script for pruning Artifact Registry images. Updated every place prune_ecr_images to alternatively call that if running in/against GCP.

Updated findBuilderTags to work with Artifact Registry.

Updated run-builder.sh to use GCP. Some things are just stubbed out, like setting up the GCP CLI instead of the aws CLI.

Changed AWS_REGION variable to CLOUD_REGION to avoid having a lot of basically copy-pasted lines with a GCP-specific variable.

Resolves IGM-62

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
