### PR TITLE
IR-6330: Unstable fetch reference in useFind

### DIFF
--- a/packages/common/src/utils/FeathersHooks.tsx
+++ b/packages/common/src/utils/FeathersHooks.tsx
@@ -192,13 +192,8 @@ export const useService = <S extends keyof ServiceTypes, M extends Methods>(
         }
       })
       fetch()
-    } else {
-      // Update `fetch` if dependencies change
-      state[serviceName][queryId].merge({
-        fetch
-      })
     }
-  }, [serviceName, method, queryId, fetch])
+  }, [serviceName, method, queryId])
 
   const query = state[serviceName]?.[queryId]
   const queryObj = state.get(NO_PROXY)[serviceName]?.[queryId]

--- a/packages/common/src/utils/FeathersHooks.tsx
+++ b/packages/common/src/utils/FeathersHooks.tsx
@@ -36,7 +36,7 @@ Infinite Reality Engine. All Rights Reserved.
  */
 
 import { Params, Query } from '@feathersjs/feathers'
-import React, { useCallback, useEffect, useLayoutEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { ServiceTypes } from '../../declarations'
 
 import {
@@ -135,8 +135,8 @@ export const useService = <S extends keyof ServiceTypes, M extends Methods>(
   }
 
   const queryId = `${method.substring(0, 1)}:${hashObject(queryParams)}` as QueryHash
-
-  const fetch = () => {
+  const fetchRef = useRef<() => void>()
+  fetchRef.current = () => {
     if (method === 'get' && (!args || args[0] == null || args[0] === '')) {
       state[serviceName][queryId].merge({
         status: 'error',
@@ -174,6 +174,10 @@ export const useService = <S extends keyof ServiceTypes, M extends Methods>(
       })
   }
 
+  const fetch = useCallback(() => {
+    fetchRef.current?.()
+  }, [fetchRef])
+
   // use immediate effect to get the stack trace of the react context, then add it to the state
   useImmediateEffect(() => {
     if (!state.get(NO_PROXY)[serviceName]) state[serviceName].set({})
@@ -188,8 +192,13 @@ export const useService = <S extends keyof ServiceTypes, M extends Methods>(
         }
       })
       fetch()
+    } else {
+      // Update `fetch` if dependencies change
+      state[serviceName][queryId].merge({
+        fetch
+      })
     }
-  }, [serviceName, method, queryId])
+  }, [serviceName, method, queryId, fetch])
 
   const query = state[serviceName]?.[queryId]
   const queryObj = state.get(NO_PROXY)[serviceName]?.[queryId]
@@ -204,7 +213,7 @@ export const useService = <S extends keyof ServiceTypes, M extends Methods>(
       error,
       refetch: fetch
     }),
-    [data, query?.response, query?.status, query?.error]
+    [data, query?.response, query?.status, query?.error, fetch]
   )
 }
 

--- a/packages/common/src/utils/FeathersHooks.tsx
+++ b/packages/common/src/utils/FeathersHooks.tsx
@@ -144,7 +144,7 @@ export const useService = <S extends keyof ServiceTypes, M extends Methods>(
       })
       return
     }
-    state[serviceName][queryId].merge({
+    state[serviceName][queryId]?.merge({
       status: 'pending',
       error: ''
     })
@@ -153,7 +153,7 @@ export const useService = <S extends keyof ServiceTypes, M extends Methods>(
       Error.captureStackTrace?.(trace, fetch)
       const stack = trace.stack.split('\n')
       stack.shift()
-      state[serviceName][queryId].merge({ $stack: stack })
+      state[serviceName][queryId]?.merge({ $stack: stack })
     }
     // prettier-ignore
     return API.instance.service(serviceName)[method](...args)


### PR DESCRIPTION
## Summary

This update ensures that the fetch function is recalculated only when its dependencies change, providing a stable reference to fetch across re-renders.

This issue can be observed in the studio's files panel when using a custom thumbnail for any file. The change should trigger a real-time update and call `filesQuery.refetch` in https://github.com/ir-engine/ir-engine/blob/9bddd459fb95f76d44bb11e8939aca6d7d891f0c/packages/editor/src/panels/files/helpers.tsx#L123
However, due to an unstable fetch reference, the request uses outdated parameters, resulting in the state for the current directory not being updated as expected.
https://github.com/ir-engine/ir-engine/blob/9bddd459fb95f76d44bb11e8939aca6d7d891f0c/packages/common/src/utils/FeathersHooks.tsx#L162

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
