### PR TITLE
Fixed a bug in migrating aws-settings

### DIFF
--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -139,9 +139,7 @@ export class S3Provider implements StorageProviderInterface {
         profile: config.aws.s3.roleArn ? 'role' : 'default',
         filepath: credentialsPath
       }),
-      endpoint: config.server.storageProviderExternalEndpoint
-        ? config.server.storageProviderExternalEndpoint
-        : config.aws.s3.endpoint,
+      endpoint: config.server.storageProviderExternalEndpoint || config.aws.s3.endpoint || undefined,
       region: config.aws.s3.region,
       forcePathStyle: true,
       maxAttempts: 5
@@ -166,18 +164,8 @@ export class S3Provider implements StorageProviderInterface {
   minioClient =
     config.aws.s3.s3DevMode === 'local'
       ? new Client({
-          endPoint: new URL(
-            config.server.storageProviderExternalEndpoint
-              ? config.server.storageProviderExternalEndpoint
-              : config.aws.s3.endpoint
-          ).hostname,
-          port: parseInt(
-            new URL(
-              config.server.storageProviderExternalEndpoint
-                ? config.server.storageProviderExternalEndpoint
-                : config.aws.s3.endpoint
-            ).port
-          ),
+          endPoint: new URL(config.server.storageProviderExternalEndpoint || config.aws.s3.endpoint).hostname,
+          port: parseInt(new URL(config.server.storageProviderExternalEndpoint || config.aws.s3.endpoint).port),
           useSSL: true,
           accessKey: config.aws.s3.accessKeyId,
           secretKey: config.aws.s3.secretAccessKey


### PR DESCRIPTION
## Summary

The S3 setting `endpoint` is normally not set at all in a production environment. But the migration to engine-settings for this value was setting it to an empty string. This was resulting in S3 trying to point to the endpoint <empty string>, which would fail on all commands.

Default is now to set this to undefined, both on migrating existing aws-settings tables and new seeds.

Also made S3 client endpoint require that s3.endpoint be a non-zero-length string in order to use it, otherwise it defaults to undefined, to make sure any existing errant migrations won't cause this problem.

Resolves IR-6663 IR-6665 IR-6669 IR-6673

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
