### PR TITLE
Fixed Apple SSO login

### DIFF
--- a/packages/server-core/src/user/strategies/apple.ts
+++ b/packages/server-core/src/user/strategies/apple.ts
@@ -213,7 +213,7 @@ export class AppleStrategy extends CustomOAuthStrategy {
     await this.validateSignInUser(authentication, originalParams, 'apple')
     const entity: string = this.configuration.entity
     const { provider, ...params } = originalParams
-    const profile = await super.getProfile(authentication, params)
+    const profile = await this.getProfile(authentication, params)
     const existingEntity = (await super.findEntity(profile, params)) || (await super.getCurrentEntity(params))
 
     const authEntity = !existingEntity


### PR DESCRIPTION
## Summary

Implementation of account auto-association had mistakenly called super.getProfile for Apple when it needed to call this.getProfile, as Apple needs a custom getProfile function to return the proper information.

Resolves IR-6706

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
