### PR TITLE
Increase `z-index` of Modal background

### DIFF
--- a/packages/ui/src/primitives/tailwind/ClickawayListener/index.tsx
+++ b/packages/ui/src/primitives/tailwind/ClickawayListener/index.tsx
@@ -33,7 +33,7 @@ const ClickawayListener = (props: { children: JSX.Element }) => {
   const childOver = useHookstate(false)
   return (
     <div
-      className="fixed inset-0 z-40 bg-gray-800 bg-opacity-50"
+      className="fixed inset-0 z-[1000] bg-gray-800 bg-opacity-50"
       onMouseDown={() => {
         if (childOver.value) return
         PopoverState.hidePopupover()


### PR DESCRIPTION
## Summary

RC-Dock's `z-index` is 250, and the Modal background's `z-index` was 50. Hence, it wasn't visible currently. Bumping modal's z-index to 1000 will make it standout in almost all pages.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-6764

## QA Steps
