### PR TITLE
IR-5342: hide user menu until location is ready

### DIFF
--- a/packages/client-core/src/user/UserUISystem.tsx
+++ b/packages/client-core/src/user/UserUISystem.tsx
@@ -39,6 +39,7 @@ import { PopoverState } from '../common/services/PopoverState'
 import { InviteService } from '../social/services/InviteService'
 import { ViewerMenuState } from '../util/ViewerMenuState'
 import EmbedFrame from './menus/avatar/EmbedFrame'
+import { LoadingUISystemState } from '../systems/LoadingUISystem'
 
 const IFrameReactor = () => {
   const entity = useEntityContext()
@@ -136,7 +137,9 @@ export const UserUISystem = defineSystem({
   insert: { after: PresentationSystemGroup },
   reactor: () => {
     const userID = useHookstate(getMutableState(EngineState)).userID.value
-    if (!userID) return null
+    const ready = useHookstate(getMutableState(LoadingUISystemState)).ready
+
+    if (!userID || !ready.value) return null
 
     return <UserSystemReactor />
   }

--- a/packages/client-core/src/user/UserUISystem.tsx
+++ b/packages/client-core/src/user/UserUISystem.tsx
@@ -37,9 +37,9 @@ import { IFrameComponent } from '@ir-engine/engine/src/scene/components/IFrameCo
 import { NetworkState } from '@ir-engine/network'
 import { PopoverState } from '../common/services/PopoverState'
 import { InviteService } from '../social/services/InviteService'
+import { LoadingUISystemState } from '../systems/LoadingUISystem'
 import { ViewerMenuState } from '../util/ViewerMenuState'
 import EmbedFrame from './menus/avatar/EmbedFrame'
-import { LoadingUISystemState } from '../systems/LoadingUISystem'
 
 const IFrameReactor = () => {
   const entity = useEntityContext()


### PR DESCRIPTION
## Summary

Hide user menu (profile, share, emote) until location is ready
![Screen Recording 2025-01-28 at 11 05 58 a m](https://github.com/user-attachments/assets/f3c6b82d-2c8d-4229-a4e5-212ae67a251f)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

Open a publish scene and make sure buttons are not displayed until location is ready.