### PR TITLE
IR-6833: Unsupported file uploads are blocked

### DIFF
--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -122,7 +122,6 @@ export function sanitizeFiles(files: FileList | File[]): File[] {
         i18n.t('editor:errors.fileNotSupported', { file: file.name, errorMessage: errorMessage || '' }) as string,
         { variant: 'warning' }
       )
-      continue
     }
     newFiles.push(newFile)
   }


### PR DESCRIPTION
## Summary

This change allows users to upload unsupported files to a project. QA requested that users be warned about unsupported files, but the upload should proceed.

![Screen Recording 2025-01-31 at 10 26 28 a m](https://github.com/user-attachments/assets/50386b4b-2ed1-4d7e-93ac-8c74deb94366)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
