### PR TITLE
TALK ABOUT: the sliders we show in our components shouldn't be resized to the exact width of their parent

### DIFF
--- a/packages/ui/src/components/editor/Slider/index.tsx
+++ b/packages/ui/src/components/editor/Slider/index.tsx
@@ -81,7 +81,7 @@ const Slider = ({
 
   useEffect(() => {
     const observer = new ResizeObserver(() => {
-      if (parentRef.current) setWidth(parentRef.current?.offsetWidth)
+      if (parentRef.current) setWidth(Math.floor((parentRef.current?.offsetWidth * 3) / 5))
     })
     observer.observe(parentRef.current as Element)
     return () => observer.disconnect()


### PR DESCRIPTION
This commit sizes sliders in panels to be 3/5 the reported current width of their parent, rounded down to the nearest pixel. Even this is a bad solution to the problem of sizing sliders; their width contributes to their parents' reported width, which can cause runaway reactive loops that expand slider widths indefinitely.

We need a better solution— probably something CSS based.