### PR TITLE
Fix lint errors when trying to commit scss changes

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,7 +13,7 @@
     "at-rule-no-unknown": null,
     "no-descending-specificity": null,
     "indentation": 2,
-    "no-unexpected-multiline": 0,
+    "no-unexpected-multiline": 1,
     "number-leading-zero": null,
     "property-no-vendor-prefix": null,
     "font-family-no-missing-generic-family-keyword": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,7 +13,6 @@
     "at-rule-no-unknown": null,
     "no-descending-specificity": null,
     "indentation": 2,
-    "no-unexpected-multiline": 1,
     "number-leading-zero": null,
     "property-no-vendor-prefix": null,
     "font-family-no-missing-generic-family-keyword": null,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,7 +46,8 @@ export default [
       'no-useless-escape': 'off',
       '@typescript-eslint/no-extra-semi': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
-      'no-fallthrough': 'off'
+      'no-fallthrough': 'off',
+      "no-unexpected-multiline": "off"
     }
   }
 ]


### PR DESCRIPTION
## Summary
An eslint rule was put into stylelint causing an error when it detected SCSS file changes and ran. This moves the linting rule change to the right config.

Likely wasn't caught since the PR to change the rule didn't change any SCSS triggering the error.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
