### PR TITLE
truncate overflowing DropdownItem labels

### DIFF
--- a/packages/ui/src/primitives/tailwind/Dropdown/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Dropdown/index.tsx
@@ -41,6 +41,8 @@ export interface DropdownItemProps extends Omit<React.HTMLAttributes<HTMLDivElem
    * Whether the item is hovered (or navigated through arrow keys)
    */
   active?: boolean
+  /** truncate overflowing label text with an ellipsis */
+  truncate?: boolean
 }
 
 export function DropdownItem({
@@ -51,6 +53,7 @@ export function DropdownItem({
   selected,
   secondaryText,
   className,
+  truncate = true,
   ...props
 }: DropdownItemProps) {
   return (
@@ -68,9 +71,9 @@ export function DropdownItem({
       )}
       {...props}
     >
-      <span className="flex items-center gap-2">
+      <span className="flex min-w-0 flex-1 items-center gap-2">
         {Icon && <Icon className="h-3 w-3" />}
-        {label}
+        <span className={truncate ? 'truncate' : ''}>{label}</span>
       </span>
       {secondaryText && <span className="ml-auto">{secondaryText}</span>}
       {selected && <HiCheck className="ml-auto h-3 w-3 stroke-2" />}


### PR DESCRIPTION
## Summary
fixes issue with DropdownItem label overflow
https://github.com/user-attachments/assets/2ddac643-ce8b-46ff-a251-5a361fbb1872

before:
![image](https://github.com/user-attachments/assets/526e2bd8-d138-4247-891c-8104ff182f75)

after: 
![image](https://github.com/user-attachments/assets/6de03b6c-7038-4ea0-b048-cd475a840cb1)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
