### PR TITLE
Clearing guest identity providers on successful login

### DIFF
--- a/packages/server-core/src/user/strategies/apple.ts
+++ b/packages/server-core/src/user/strategies/apple.ts
@@ -110,6 +110,12 @@ export class AppleStrategy extends CustomOAuthStrategy {
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
       await this.app.service(identityProviderPath).remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: entity.userId
+        }
+      })
       await this.userLoginEntry(entity, params)
       return super.updateEntity(entity, profile, params)
     }
@@ -152,9 +158,21 @@ export class AppleStrategy extends CustomOAuthStrategy {
         }
         await this.app.service(identityProviderPath).remove(entity.id)
       }
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(existingEntity, params)
       return existingEntity
     } else {

--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -109,6 +109,12 @@ export class DiscordStrategy extends CustomOAuthStrategy {
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
       await this.app.service(identityProviderPath).remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: entity.userId
+        }
+      })
       await this.userLoginEntry(entity, params)
       return super.updateEntity(entity, profile, params)
     }
@@ -151,9 +157,21 @@ export class DiscordStrategy extends CustomOAuthStrategy {
         }
         await this.app.service(identityProviderPath).remove(entity.id)
       }
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(existingEntity, params)
       return existingEntity
     } else {

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -109,6 +109,12 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
       await this.app.service(identityProviderPath).remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: entity.userId
+        }
+      })
       await this.userLoginEntry(entity, params)
       return super.updateEntity(entity, profile, params)
     }
@@ -151,9 +157,21 @@ export class FacebookStrategy extends CustomOAuthStrategy {
         }
         await this.app.service(identityProviderPath).remove(entity.id)
       }
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(existingEntity, params)
       return existingEntity
     } else {

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -31,10 +31,9 @@ import { githubRepoAccessRefreshPath } from '@ir-engine/common/src/schemas/user/
 import { identityProviderPath } from '@ir-engine/common/src/schemas/user/identity-provider.schema'
 import { userApiKeyPath, UserApiKeyType } from '@ir-engine/common/src/schemas/user/user-api-key.schema'
 import { InviteCode, UserName, userPath } from '@ir-engine/common/src/schemas/user/user.schema'
-import { getDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import { getDateTimeSql, toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
 
 import { loginTokenPath } from '@ir-engine/common/src/schemas/user/login-token.schema'
-import { toDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
 import moment from 'moment/moment'
 import { Octokit } from 'octokit'
 import { Application } from '../../../declarations'
@@ -147,11 +146,18 @@ export class GithubStrategy extends CustomOAuthStrategy {
         userId: entity.userId
       })
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
+      const existingUser = await this.app.service(userPath).get(entity.userId)
       await this.app.service(identityProviderPath)._remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
       if (!config.kubernetes.enabled)
-        await this.app.service(githubRepoAccessRefreshPath).find(Object.assign({}, params, { user }))
-      else await this.createRefreshJob(user.id)
+        await this.app.service(githubRepoAccessRefreshPath).find(Object.assign({}, params, { user: existingUser }))
+      else await this.createRefreshJob(existingUser.id)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: entity.userId
+        }
+      })
       await this.userLoginEntry(entity, params)
 
       return super.updateEntity(entity, profile, params)
@@ -200,12 +206,24 @@ export class GithubStrategy extends CustomOAuthStrategy {
       if (!config.kubernetes.enabled)
         await this.app.service(githubRepoAccessRefreshPath).find(Object.assign({}, params, { user }))
       else await this.createRefreshJob(user.id)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
       if (!config.kubernetes.enabled)
         await this.app.service(githubRepoAccessRefreshPath).find(Object.assign({}, params, { user }))
       else await this.createRefreshJob(user.id)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(existingEntity, params)
       return existingEntity
     } else {

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -110,6 +110,12 @@ export class Googlestrategy extends CustomOAuthStrategy {
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
       await this.app.service(identityProviderPath).remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: entity.userId
+        }
+      })
       await this.userLoginEntry(entity, params)
       return super.updateEntity(entity, profile, params)
     }
@@ -152,9 +158,21 @@ export class Googlestrategy extends CustomOAuthStrategy {
         }
         await this.app.service(identityProviderPath).remove(entity.id)
       }
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(existingEntity, params)
       return existingEntity
     } else {

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -109,6 +109,12 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
       await this.app.service(identityProviderPath).remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: entity.userId
+        }
+      })
       await this.userLoginEntry(entity, params)
       return super.updateEntity(entity, profile, params)
     }
@@ -151,9 +157,21 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
         }
         await this.app.service(identityProviderPath).remove(entity.id)
       }
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(existingEntity, params)
       return existingEntity
     } else {

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -109,6 +109,12 @@ export class TwitterStrategy extends CustomOAuthStrategy {
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
       await this.app.service(identityProviderPath).remove(identityProvider.id)
       await this.app.service(userPath).remove(identityProvider.userId)
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: entity.userId
+        }
+      })
       await this.userLoginEntry(entity, params)
       return super.updateEntity(entity, profile, params)
     }
@@ -151,9 +157,21 @@ export class TwitterStrategy extends CustomOAuthStrategy {
         }
         await this.app.service(identityProviderPath).remove(entity.id)
       }
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(newIP, params)
       return newIP
     } else if (existingEntity.userId === identityProvider.userId) {
+      await this.app.service(identityProviderPath).remove(null, {
+        query: {
+          type: 'guest',
+          userId: existingEntity.userId
+        }
+      })
       await this.userLoginEntry(existingEntity, params)
       return existingEntity
     } else {


### PR DESCRIPTION
## Summary

Certain bugs in OAuth login flow were not removing guest identity providers. This caused issues in multitenancy project, where the existence of a guest IP led the login pages to think the user was a guest, even though they had non-guest identity providers. They would always be redirected back to the welcome page by mistake instead of being sent to the rest of the signup flow or to the dashboard.

Resolves IR-6436

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
