### PR TITLE
Fix: Rigidbody Physics Desync in Editor

### DIFF
--- a/packages/ecs/src/ComponentFunctions.ts
+++ b/packages/ecs/src/ComponentFunctions.ts
@@ -856,7 +856,23 @@ function createLayerPropagationArgs<C extends Component>(entity: Entity, linkedL
         }
       }
       case 'Class': {
-        if ('clone' in obj && typeof obj.clone === 'function') {
+        if (
+          schema.options &&
+          'id' in schema.options &&
+          schema.options.id === 'SerializedClass' &&
+          typeof schema.options.default === 'function'
+        ) {
+          // when propagating a class, we don't want to clone it, we want to use whatever default initializer and copy functionality exists copy it
+          // this is a bit messy because the component initializer does this too
+          // @todo how can we make this cleaner?
+          const layerComponent = LayerComponents[layer]
+          const linkedEntity = getComponent(entity, layerComponent).relations[linkedLayer]
+          const val = schema.options.default(linkedEntity)
+          if ('copy' in obj && typeof obj.copy === 'function') {
+            val.copy(obj)
+          }
+          return val
+        } else if ('clone' in obj && typeof obj.clone === 'function') {
           return obj.clone()
         } else {
           try {

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -38,7 +38,6 @@ import {
   getOptionalComponent,
   hasComponent,
   isAncestor,
-  LayerFunctions,
   Layers,
   removeComponent,
   removeEntity,
@@ -245,10 +244,9 @@ export const GLTFComponentReactor = () => {
       documentLoaded.set(true)
       loadedEntities = SourceComponent.getEntitiesBySource(entity)
 
-      /** @todo dirty does not propagate, so force the whole tree to be dirty in simulation layer upon load */
-      const simulationEntity = LayerFunctions.getLayerRelationsEntities(entity)?.[0]?.[1]
-      if (simulationEntity) TransformComponent.dirty[simulationEntity] = 1
-      else TransformComponent.dirty[entity] = 1
+      // force transform update for all entities in the model.
+      // required to propagate dirty update auth to sim layers
+      TransformComponent.dirty[entity] = 1
 
       if (aborted) {
         unloadEntities()

--- a/packages/spatial/src/physics/systems/PhysicsPreTransformSystem.ts
+++ b/packages/spatial/src/physics/systems/PhysicsPreTransformSystem.ts
@@ -187,10 +187,10 @@ export const execute = () => {
   const dirtyRigidbodyEntities = allRigidbodyEntities.filter(isDirty)
   const dirtyColliderEntities = colliderQuery().filter(isDirty)
 
-  /** Ff rigidbody transforms have been dirtied, teleport the rigidbody to the transform */
+  /** If rigidbody transforms have been dirtied, teleport the rigidbody to the transform */
   for (const entity of dirtyRigidbodyEntities) copyTransformToRigidBody(entity)
 
-  /** Ff collider transforms have been dirtied, update them */
+  /** If collider transforms have been dirtied, update them */
   for (const entity of dirtyColliderEntities) copyTransformToCollider(entity)
 
   /** Lerp awake clean rigidbody entities (and make their transforms dirty) */

--- a/packages/spatial/src/transform/systems/TransformSystem.ts
+++ b/packages/spatial/src/transform/systems/TransformSystem.ts
@@ -33,7 +33,9 @@ import {
   Entity,
   getComponent,
   getOptionalComponent,
-  hasComponent
+  hasComponent,
+  LayerComponents,
+  Layers
 } from '@ir-engine/ecs'
 import { getMutableState, getState, none } from '@ir-engine/hyperflux'
 import { NetworkState } from '@ir-engine/network'
@@ -105,6 +107,8 @@ const compareReferenceDepth = (a: Entity, b: Entity) => {
   return aDepth - bDepth
 }
 
+const dirtyAuthoringTransformQuery = defineQuery([TransformComponent], Layers.Authoring)
+
 export const isDirty = (entity: Entity) => TransformComponent.dirty[entity] === 1
 
 const _sortedTransformEntities = [] as Entity[]
@@ -140,6 +144,15 @@ const sortAndMakeDirtyEntities = () => {
     for (const entity of _sortedTransformEntities) updateTransformDepth(entity)
     insertionSort(_sortedTransformEntities, compareReferenceDepth) // Insertion sort is speedy O(n) for mostly sorted arrays
     TransformComponent.transformsNeedSorting = false
+  }
+
+  /** Mark the corresponding simulation entity of any authoring layer entities as dirty */
+  const dirtyAuthoringEntities = dirtyAuthoringTransformQuery().filter(isDirty)
+  for (const entity of dirtyAuthoringEntities) {
+    const authoringComponent = getComponent(entity, LayerComponents[Layers.Authoring])
+    const linkedEntity = authoringComponent.relations[Layers.Simulation]
+    TransformComponent.dirty[entity] = 0
+    TransformComponent.dirty[linkedEntity] = 1
   }
 
   // entities with dirty parent or reference entities, or computed transforms, should also be dirty


### PR DESCRIPTION
## Summary

- Propagate authoring layer dirty transforms
- fix bug with maths classes de-proxifying upon propagation

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
