### PR TITLE
Fix collider visibility in some GLTF files

### DIFF
--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -1448,6 +1448,9 @@ const loadNode = async (options: GLTFParserOptions, nodeIndex: number) => {
     for (const extension in nodeDef.extensions) {
       const Component = ComponentJSONIDMap.get(extension) as any // todo
       if (!Component) continue
+      if (Component === ColliderComponent) {
+        removeComponent(nodeEntity, VisibleComponent)
+      }
       deserializeComponent(nodeEntity, Component, nodeDef.extensions[extension])
       if (typeof Component.loadNode === 'function') {
         extensionPending.push(Component.loadNode(options, nodeIndex))


### PR DESCRIPTION
make colliders invisible when loading collider component from nodeDef.extensions