### PR TITLE
move the EditorState.markModifiedScene to above the delete so SourceC…

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -468,8 +468,8 @@ const removeObject = (entities: Entity[]) => {
 
   for (const entity of entities) {
     if (hasComponent(entity, SceneComponent)) continue
-    removeEntityNodeRecursively(entity)
     EditorState.markModifiedScene(entity)
+    removeEntityNodeRecursively(entity)
   }
 }
 


### PR DESCRIPTION
…omponent will still exist when checked so the the scene will be marked as modified

## Summary
https://tsu.atlassian.net/browse/IR-7109
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
