### PR TITLE
Fix removal of loaded gltf entities

### DIFF
--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -145,8 +145,9 @@ export async function addMediaNode(
        */
       AssetState.loadAsync(url, false, UUIDComponent.generateUUID(), UndefinedEntity, Layers.Authoring as LayerID).then(
         (entity) => {
-          const entities = SourceComponent.getEntitiesBySource(entity)
           const rootEntity = getState(EditorState).rootEntity
+          const currentSource = GLTFComponent.getInstanceID(rootEntity)
+          const entities = SourceComponent.getEntitiesBySource(currentSource)
           const newSource = GLTFComponent.getInstanceID(rootEntity)
           for (const entity of entities) {
             setComponent(entity, SourceComponent, newSource)

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -236,7 +236,7 @@ export const GLTFComponentReactor = () => {
       if (loadedEntities) {
         // only remove entities that are still children of the root entity
         const immediateChildren = loadedEntities.filter(
-          (child) => getComponent(child, EntityTreeComponent).parentEntity === entity
+          (child) => getOptionalComponent(child, EntityTreeComponent)?.parentEntity === entity
         )
         // parent entity may no longer exist, so get immediate children and remove recursively
         for (const entity of immediateChildren) removeEntityNodeRecursively(entity)

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -31,16 +31,16 @@ import {
   ComponentJSONIDMap,
   defineComponent,
   Entity,
+  EntityTreeComponent,
   EntityUUID,
   generateEntityUUID,
   getComponent,
   getMutableComponent,
   getOptionalComponent,
   hasComponent,
-  isAncestor,
   Layers,
   removeComponent,
-  removeEntity,
+  removeEntityNodeRecursively,
   setComponent,
   UndefinedEntity,
   useComponent,
@@ -235,8 +235,11 @@ export const GLTFComponentReactor = () => {
     const unloadEntities = () => {
       if (loadedEntities) {
         // only remove entities that are still children of the root entity
-        const loadedAndStillChildEntities = loadedEntities.filter((child) => isAncestor(entity, child, false))
-        for (const entity of loadedAndStillChildEntities) removeEntity(entity)
+        const immediateChildren = loadedEntities.filter(
+          (child) => getComponent(child, EntityTreeComponent).parentEntity === entity
+        )
+        // parent entity may no longer exist, so get immediate children and remove recursively
+        for (const entity of immediateChildren) removeEntityNodeRecursively(entity)
       }
     }
 

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -31,7 +31,6 @@ import {
   ComponentJSONIDMap,
   defineComponent,
   Entity,
-  EntityTreeComponent,
   EntityUUID,
   generateEntityUUID,
   getComponent,
@@ -40,7 +39,7 @@ import {
   hasComponent,
   Layers,
   removeComponent,
-  removeEntityNodeRecursively,
+  removeEntity,
   setComponent,
   UndefinedEntity,
   useComponent,
@@ -229,23 +228,18 @@ export const GLTFComponentReactor = () => {
 
     const sceneIndex = options.document.scene || 0
     let aborted = false
-    let loadedEntities = null as Entity[] | null
     removeComponent(entity, AnimationComponent)
 
+    const sourceID = GLTFComponent.getInstanceID(entity)
+
     const unloadEntities = () => {
-      if (loadedEntities) {
-        // only remove entities that are still children of the root entity
-        const immediateChildren = loadedEntities.filter(
-          (child) => getOptionalComponent(child, EntityTreeComponent)?.parentEntity === entity
-        )
-        // parent entity may no longer exist, so get immediate children and remove recursively
-        for (const entity of immediateChildren) removeEntityNodeRecursively(entity)
-      }
+      // only remove entities that are still children of the gltf entity and were loaded as part of the model
+      const loadedEntities = SourceComponent.getEntitiesBySource(sourceID)
+      for (const entity of loadedEntities) removeEntity(entity)
     }
 
     GLTFLoaderFunctions.loadScene(options, sceneIndex).then(() => {
       documentLoaded.set(true)
-      loadedEntities = SourceComponent.getEntitiesBySource(entity)
 
       // force transform update for all entities in the model.
       // required to propagate dirty update auth to sim layers

--- a/packages/engine/src/scene/components/SourceComponent.ts
+++ b/packages/engine/src/scene/components/SourceComponent.ts
@@ -23,13 +23,11 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { iterateEntityNode } from '@ir-engine/ecs'
-import { defineComponent, getOptionalComponent } from '@ir-engine/ecs/src/ComponentFunctions'
+import { defineComponent } from '@ir-engine/ecs/src/ComponentFunctions'
 import { Entity } from '@ir-engine/ecs/src/Entity'
 import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
 import { hookstate, none, useHookstate } from '@ir-engine/hyperflux'
 import { NonEmptyString } from '@ir-engine/spatial/src/schema/schemaFunctions'
-import { GLTFComponent } from '../../gltf/GLTFComponent'
 
 const entitiesBySource = {} as Record<string, Entity[]>
 
@@ -70,21 +68,12 @@ export const SourceComponent = defineComponent({
     }
   },
 
-  useEntitiesBySource: (rootEntity: Entity) => {
-    const source = GLTFComponent.useInstanceID(rootEntity)
+  useEntitiesBySource: (source: string) => {
     return useHookstate(SourceComponent.entitiesBySourceState[source]).value as Entity[]
   },
 
-  getEntitiesBySource: (rootEntity: Entity) => {
-    const source = GLTFComponent.getInstanceID(rootEntity)
-    const entities = [] as Entity[]
-    iterateEntityNode(rootEntity, (childEntity) => {
-      if (rootEntity === childEntity) return
-      const src = getOptionalComponent(childEntity, SourceComponent)
-      if (src !== source) return
-      entities.push(childEntity)
-    })
-    return entities
+  getEntitiesBySource: (source: string) => {
+    return SourceComponent.entitiesBySourceState[source].value as Entity[]
   },
 
   entitiesBySourceState: hookstate(entitiesBySource),


### PR DESCRIPTION
## Summary
Currently, loaded gltf entities are never cleaned up when the gltf component entity is removed because the isAncestor check will always return false if the entity its being checked with no longer exists. This fix is a workaround that instead checks for any loaded entities that are still children, then calls removeEntityNodeRecursively for a postorder traversal removal of entities. The idea being to ensure that of the gltf component hierarchy, only loaded entities that are still children will be removed.

## Subtasks Checklist

## Breaking Changes

## References
May fix https://tsu.atlassian.net/browse/IR-7111 - only reproduceable on deploys at the moment, will need to merge in this fix to test.

## QA Steps
