### PR TITLE
Fix Lookdev Prefabs & Add Error and Suspense Boundary to Studio Dock Tabs

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.test.tsx
+++ b/packages/editor/src/functions/EditorControlFunctions.test.tsx
@@ -918,4 +918,67 @@ describe('EditorControlFunctions', () => {
       assert.equal(UUIDComponent.getEntityByUUID(childUUID, Layers.Authoring), UndefinedEntity)
     })
   })
+
+  describe('overwriteLookdevObject', () => {
+    it('should overwrite a lookdev object with new components', async () => {
+      const nodeUUID = 'nodeUUID' as EntityUUID
+      const childUUID = 'childUUID' as EntityUUID
+
+      const gltf: GLTF.IGLTF = {
+        asset: {
+          version: '2.0'
+        },
+        scenes: [{ nodes: [0] }],
+        scene: 0,
+        nodes: [
+          {
+            name: 'node',
+            children: [1],
+            extensions: {
+              [UUIDComponent.jsonID]: nodeUUID
+            }
+          },
+          {
+            name: 'child',
+            extensions: {
+              [UUIDComponent.jsonID]: childUUID,
+              [HemisphereLightComponent.jsonID]: {
+                skyColor: new Color('purple').getHex(),
+                groundColor: new Color('green').getHex(),
+                intensity: 0.5
+              }
+            }
+          }
+        ]
+      }
+
+      Cache.add('/test.gltf', gltf)
+      const rootEntity = AssetState.load('/test.gltf', undefined, physicsWorldEntity, Layers.Authoring)
+      getMutableState(EditorState).rootEntity.set(rootEntity)
+      await waitForScene(rootEntity)
+
+      const nodeEntity = UUIDComponent.getEntityByUUID(nodeUUID, Layers.Authoring)
+
+      EditorControlFunctions.overwriteLookdevObject(
+        [
+          {
+            name: HemisphereLightComponent.jsonID,
+            props: {
+              skyColor: new Color('blue').getHex(),
+              groundColor: new Color('red').getHex(),
+              intensity: 0.7
+            }
+          }
+        ],
+        rootEntity
+      )
+
+      const childEntity = getComponent(nodeEntity, EntityTreeComponent).children[0]
+
+      const hemisphereLightComponent = getComponent(childEntity, HemisphereLightComponent)
+      assert.deepEqual(hemisphereLightComponent.skyColor, new Color('blue'))
+      assert.deepEqual(hemisphereLightComponent.groundColor, new Color('red'))
+      assert.equal(hemisphereLightComponent.intensity, 0.7)
+    })
+  })
 })

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -162,7 +162,6 @@ const lookDevComponent: Component[] = [
 ]
 
 const overwriteLookdevObject = (
-  beforeComponentJson: ComponentJsonType[] = [],
   componentJson: ComponentJsonType[] = [],
   parentEntity = getState(EditorState).rootEntity,
   beforeEntity?: Entity
@@ -173,7 +172,7 @@ const overwriteLookdevObject = (
     if (!lookDevComp) continue
     const sceneEntitiesWithComponent = getChildrenWithComponents(parentEntity, [lookDevComp])
     if (sceneEntitiesWithComponent.length) {
-      setComponent(sceneEntitiesWithComponent[0], lookDevComp, componentJson)
+      deserializeComponent(sceneEntitiesWithComponent[0], lookDevComp, props)
       EditorState.markModifiedScene(parentEntity)
     } else {
       createObjectFromSceneElement(componentJson, parentEntity, beforeEntity)

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -130,12 +130,7 @@ export async function addMediaNode(
         (entity) => {
           const firstChild = getComponent(entity, EntityTreeComponent).children[0]
           const json = serializeEntity(firstChild)
-          EditorControlFunctions.overwriteLookdevObject(
-            [{ name: GLTFComponent.jsonID, props: { src: url } }, ...extraComponentJson],
-            json,
-            parent!,
-            before
-          )
+          EditorControlFunctions.overwriteLookdevObject([...json, ...extraComponentJson], parent!, before)
           removeEntity(entity)
         }
       )

--- a/packages/editor/src/panels/hierarchy/index.tsx
+++ b/packages/editor/src/panels/hierarchy/index.tsx
@@ -52,7 +52,7 @@ export const HierarchyPanelTab: TabData = {
   title: <HierarchyPanelTitle />,
   content: (
     <ErrorBoundary fallback={<div>Error occured with the Hierarchy tab</div>}>
-      <Suspense >
+      <Suspense>
         <HierarchyPanelWrapper />
       </Suspense>
     </ErrorBoundary>

--- a/packages/editor/src/panels/hierarchy/index.tsx
+++ b/packages/editor/src/panels/hierarchy/index.tsx
@@ -25,10 +25,10 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { EditorState } from '@ir-engine/editor/src/services/EditorServices'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
-import { useMutableState } from '@ir-engine/hyperflux'
+import { ErrorBoundary, useMutableState } from '@ir-engine/hyperflux'
 import { PanelDragContainer, PanelTitle } from '@ir-engine/ui/src/components/editor/layout/Panel'
 import { TabData } from 'rc-dock'
-import React from 'react'
+import React, { Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import HierarchyTreeContextMenu from './contextmenu'
 import { Contents, Topbar } from './hierarchytree'
@@ -50,7 +50,13 @@ export const HierarchyPanelTab: TabData = {
   id: 'hierarchyPanel',
   closable: true,
   title: <HierarchyPanelTitle />,
-  content: <HierarchyPanelWrapper />
+  content: (
+    <ErrorBoundary fallback={<div>Error occured with the Hierarchy tab</div>}>
+      <Suspense >
+        <HierarchyPanelWrapper />
+      </Suspense>
+    </ErrorBoundary>
+  )
 }
 
 function HierarchyPanelWrapper() {

--- a/packages/editor/src/panels/materials/index.tsx
+++ b/packages/editor/src/panels/materials/index.tsx
@@ -36,12 +36,12 @@ import {
 } from '@ir-engine/ecs'
 import { SourceComponent } from '@ir-engine/engine/src/scene/components/SourceComponent'
 import { getMaterialsFromScene } from '@ir-engine/engine/src/scene/materials/functions/materialSourcingFunctions'
-import { getMutableState } from '@ir-engine/hyperflux'
+import { ErrorBoundary, getMutableState } from '@ir-engine/hyperflux'
 import { MaterialStateComponent } from '@ir-engine/spatial/src/renderer/materials/MaterialComponent'
 import { Button, Input } from '@ir-engine/ui'
 import { PanelDragContainer, PanelTitle } from '@ir-engine/ui/src/components/editor/layout/Panel'
 import { TabData } from 'rc-dock'
-import React, { useEffect } from 'react'
+import React, { Suspense, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiFilter, HiGlobeAlt } from 'react-icons/hi'
 import { SelectionState } from '../../services/SelectionServices'
@@ -66,7 +66,13 @@ export const MaterialsPanelTab: TabData = {
   id: MATERIALS_PANEL_ID,
   closable: true,
   title: <MaterialsPanelTitle />,
-  content: <MaterialsLibrary />
+  content: (
+    <ErrorBoundary fallback={<div>Error occured with the Materials tab</div>}>
+      <Suspense>
+        <MaterialsLibrary />
+      </Suspense>
+    </ErrorBoundary>
+  )
 }
 
 function MaterialsLibrary() {

--- a/packages/editor/src/panels/properties/index.tsx
+++ b/packages/editor/src/panels/properties/index.tsx
@@ -23,10 +23,11 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+import { ErrorBoundary } from '@ir-engine/hyperflux'
 import { Tooltip } from '@ir-engine/ui'
 import { PanelDragContainer, PanelTitle } from '@ir-engine/ui/src/components/editor/layout/Panel'
 import { TabData } from 'rc-dock'
-import React from 'react'
+import React, { Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import PropertiesEditor from './propertyeditor'
 
@@ -49,5 +50,11 @@ export const PropertiesPanelTab: TabData = {
   closable: true,
   cached: true,
   title: <PropertiesPanelTitle />,
-  content: <PropertiesEditor />
+  content: (
+    <ErrorBoundary fallback={<div>Error occured with the properties tab</div>}>
+      <Suspense>
+        <PropertiesEditor />
+      </Suspense>
+    </ErrorBoundary>
+  )
 }

--- a/packages/editor/src/panels/viewport/index.tsx
+++ b/packages/editor/src/panels/viewport/index.tsx
@@ -197,7 +197,7 @@ export const ViewportPanelTab: TabData = {
   closable: true,
   title: <ViewportPanelTitle />,
   content: (
-    <ErrorBoundary  fallback={<div>Error occured with the Viewport tab</div>}>
+    <ErrorBoundary fallback={<div>Error occured with the Viewport tab</div>}>
       <Suspense>
         <ViewportContainer />
       </Suspense>

--- a/packages/editor/src/panels/viewport/index.tsx
+++ b/packages/editor/src/panels/viewport/index.tsx
@@ -33,14 +33,14 @@ import { cleanFileNameString } from '@ir-engine/common/src/utils/cleanFileName'
 import { useComponent, useQuery } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { ResourcePendingComponent } from '@ir-engine/engine/src/gltf/ResourcePendingComponent'
-import { useMutableState } from '@ir-engine/hyperflux'
+import { ErrorBoundary, useMutableState } from '@ir-engine/hyperflux'
 import { TransformComponent } from '@ir-engine/spatial'
 import { useEngineCanvas } from '@ir-engine/spatial/src/renderer/functions/useEngineCanvas'
 import { PanelDragContainer, PanelTitle } from '@ir-engine/ui/src/components/editor/layout/Panel'
 import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import { TabData } from 'rc-dock'
-import React from 'react'
+import React, { Suspense } from 'react'
 import { useDrop } from 'react-dnd'
 import { useTranslation } from 'react-i18next'
 import { twMerge } from 'tailwind-merge'
@@ -196,5 +196,11 @@ export const ViewportPanelTab: TabData = {
   id: 'viewPanel',
   closable: true,
   title: <ViewportPanelTitle />,
-  content: <ViewportContainer />
+  content: (
+    <ErrorBoundary  fallback={<div>Error occured with the Viewport tab</div>}>
+      <Suspense>
+        <ViewportContainer />
+      </Suspense>
+    </ErrorBoundary>
+  )
 }

--- a/packages/hyperflux/src/functions/ReactorFunctions.tsx
+++ b/packages/hyperflux/src/functions/ReactorFunctions.tsx
@@ -130,13 +130,17 @@ export const ReactorErrorBoundary = createErrorBoundary<{ children: React.ReactN
   }
 )
 
-export const ErrorBoundary = createErrorBoundary(function error(props, error?: Error) {
-  if (error) {
-    return null
-  } else {
-    return <React.Fragment>{props.children}</React.Fragment>
+export const ErrorBoundary = createErrorBoundary<{ children: React.ReactNode; fallback?: React.ReactNode }>(
+  function error(props, error?: Error) {
+    if (error) {
+      console.error(error)
+      if (props.fallback) return <>{props.fallback}</>
+      return null
+    } else {
+      return <React.Fragment>{props.children}</React.Fragment>
+    }
   }
-})
+)
 
 const ReactorRootContext = React.createContext<ReactorRoot>(undefined as any)
 


### PR DESCRIPTION
## Summary

- add suspense and error boundaries to studio panels
- fix overwrite lookdev bug
- add regression test for overwrite lookdev

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
