### PR TITLE
copy tailscale key and crt in macos

### DIFF
--- a/scripts/tailscalecerts.sh
+++ b/scripts/tailscalecerts.sh
@@ -28,10 +28,12 @@ case "$(uname -s)" in
         exit 1
     fi
     domain=$(/Applications/Tailscale.app/Contents/MacOS/Tailscale cert 2>&1 | grep -o '".*"' | sed 's/"//g')
+    cp ~/Library/Containers/io.tailscale.ipn.macos/Data/$domain.key ./
+    cp ~/Library/Containers/io.tailscale.ipn.macos/Data/$domain.crt ./
     mkdir -p ./certs/tailscale && chmod a+r ./certs/tailscale
     /Applications/Tailscale.app/Contents/MacOS/Tailscale cert $domain 2>&1>/dev/null
-    sudo cp ./$domain.crt ./certs/tailscale/cert.pem
-    sudo cp ./$domain.key ./certs/tailscale/key.pem
+    sudo mv ./$domain.crt ./certs/tailscale/cert.pem
+    sudo mv ./$domain.key ./certs/tailscale/key.pem
     instructions
      ;;
    Linux)


### PR DESCRIPTION
## Summary

the tailscale key and crt were missing when copying them using the tailscalecerts.sh script

now it copies them from the correct location where present

