### PR TITLE
Fixed bug with projects deleting similarly-named projects

### DIFF
--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1578,7 +1578,7 @@ export const deleteProjectFilesInStorageProvider = async (
 ) => {
   const storageProvider = getStorageProvider(storageProviderName)
   try {
-    const existingFiles = await getFileKeysRecursive(`projects/${projectName}`)
+    const existingFiles = await getFileKeysRecursive(`projects/${projectName}/`)
     if (existingFiles.length) {
       await storageProvider.deleteResources(existingFiles)
       if (config.server.edgeCachingEnabled)


### PR DESCRIPTION
If one project matched the start of the name of another project, such as irpro-ecomm and irpro-ecommerce-tools, adding/updating/removing the former would match when calling deleteProjectFilesInStorageProvider, and erroneously remove the latter's files as well. Added a slash to the end of the getFileKeysRecursive call in there to specifically match just that project.

Resolves IR-7143

## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
