### PR TITLE
Fix incorrect splicing for rendering entities

### DIFF
--- a/packages/engine/src/gltf/GLTFState.tsx
+++ b/packages/engine/src/gltf/GLTFState.tsx
@@ -82,7 +82,7 @@ export const SceneState = defineState({
     return () => {
       if (viewerEntity) {
         getMutableComponent(viewerEntity, RendererComponent).scenes.set((current) =>
-          current.splice(current.indexOf(simulationEntity), 1)
+          current.filter((scene) => scene !== simulationEntity)
         )
       }
       AssetState.unload(gltfEntity)

--- a/packages/engine/src/scene/systems/ShadowSystem.tsx
+++ b/packages/engine/src/scene/systems/ShadowSystem.tsx
@@ -156,7 +156,8 @@ const EntityCSMReactor = (props: { entity: Entity; rendererEntity: Entity; rende
   /** Must run after scene object system to ensure source light is not lit */
   useExecute(
     () => {
-      if (!directionalLight || !directionalLightComponent.castShadow.value) return
+      if (!directionalLight) return
+      if (!getOptionalComponent(entity, DirectionalLightComponent)?.castShadow) return
       directionalLight.visible = false
     },
     { after: SceneObjectSystem }


### PR DESCRIPTION
Replace incorrect splicing logic with filtering to correctly manage scene entities and improve shadow casting checks for directional lights.