### PR TITLE
fix(accordion): display the chevron with the correct size [IR-7025]

### DIFF
--- a/packages/ui/src/primitives/tailwind/Accordion/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Accordion/index.tsx
@@ -71,7 +71,7 @@ const Accordion = forwardRef(
           }}
         >
           <div className="flex w-full items-center justify-between p-4">
-            <h2 className="truncate text-base font-semibold leading-4 text-text-primary">{title}</h2>
+            <h2 className="flex-1 truncate text-base font-semibold leading-4 text-text-primary">{title}</h2>
             <ChevronDownLg
               className={twMerge('h-5 w-5 text-text-primary duration-300', openState ? 'rotate-180' : '')}
             />


### PR DESCRIPTION
## Summary
- Display the chevron with the correct size in the profile section of the sidebar

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


## Evidence
<img width="1230" alt="Screenshot 2025-02-21 at 11 57 53 a m" src="https://github.com/user-attachments/assets/17fdd8ac-9c83-4d80-b500-78f08c97723e" />

## Jira
[IR-7025](https://tsu.atlassian.net/browse/IR-7025)

[IR-7025]: https://tsu.atlassian.net/browse/IR-7025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ