### PR TITLE
IR-5342: prevent tooltips from displaying while the screen is opaque

### DIFF
--- a/packages/client-core/src/components/ViewerInteractions/index.tsx
+++ b/packages/client-core/src/components/ViewerInteractions/index.tsx
@@ -33,6 +33,7 @@ import { EngineState } from '@ir-engine/ecs'
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { useTranslation } from 'react-i18next'
 import { PopoverState } from '../../common/services/PopoverState'
+import { twMerge } from 'tailwind-merge'
 import { LoadingSystemState } from '../../systems/state/LoadingState'
 import LocationIconButton from '../../user/components/LocationIconButton'
 import InstanceChat from '../../user/InstanceChat'
@@ -78,6 +79,7 @@ export const ViewerInteractions = () => {
   }
 
   const externalInjectedMenus = useMutableState(ViewerMenuState).externalInjectedMenus.get(NO_PROXY)
+  const isScreenOpaque = loadingScreenOpacity.value > 0
 
   return (
     <div style={{ opacity: 1 - loadingScreenOpacity.value }} className="relative h-dvh w-full p-6">
@@ -89,7 +91,12 @@ export const ViewerInteractions = () => {
         <VideoWindows />
       </div>
 
-      <div className="pointer-events-auto absolute bottom-0 left-0 h-fit w-full pb-[inherit]">
+      <div
+        className={twMerge(
+          'absolute bottom-0 left-0 h-fit w-full pb-[inherit]',
+          isScreenOpaque ? 'pointer-events-none' : 'pointer-events-auto '
+        )}
+      >
         <UserMenus />
       </div>
 

--- a/packages/client-core/src/components/ViewerInteractions/index.tsx
+++ b/packages/client-core/src/components/ViewerInteractions/index.tsx
@@ -79,6 +79,7 @@ export const ViewerInteractions = () => {
   }
 
   const externalInjectedMenus = useMutableState(ViewerMenuState).externalInjectedMenus.get(NO_PROXY)
+  
   const isScreenOpaque = loadingScreenOpacity.value > 0
 
   return (

--- a/packages/client-core/src/components/ViewerInteractions/index.tsx
+++ b/packages/client-core/src/components/ViewerInteractions/index.tsx
@@ -32,8 +32,8 @@ import { getMutableState, NO_PROXY, useHookstate, useMutableState } from '@ir-en
 import { EngineState } from '@ir-engine/ecs'
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { useTranslation } from 'react-i18next'
-import { PopoverState } from '../../common/services/PopoverState'
 import { twMerge } from 'tailwind-merge'
+import { PopoverState } from '../../common/services/PopoverState'
 import { LoadingSystemState } from '../../systems/state/LoadingState'
 import LocationIconButton from '../../user/components/LocationIconButton'
 import InstanceChat from '../../user/InstanceChat'
@@ -79,7 +79,7 @@ export const ViewerInteractions = () => {
   }
 
   const externalInjectedMenus = useMutableState(ViewerMenuState).externalInjectedMenus.get(NO_PROXY)
-  
+
   const isScreenOpaque = loadingScreenOpacity.value > 0
 
   return (


### PR DESCRIPTION
## Summary

Currently while the viewer is still loading a scene you can hover over the bottom of the screen when the screen is opaque
and tooltips for the user menu will be displaying, with this change pointer events are disabled 
while the screen is still opaque. 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Enter a location
- While it's still loading hover over where the buttons are displayed at the bottom 

**Expected result**: tooltips should not be visible while the screen is opaque 