### PR TITLE
fixed Collider-toggle prefab not working due to physicsWorld ref being undefined in callbacks

### DIFF
--- a/packages/spatial/src/physics/components/ColliderComponent.tsx
+++ b/packages/spatial/src/physics/components/ColliderComponent.tsx
@@ -148,6 +148,8 @@ const ColliderReactor = function () {
   }, [physicsWorld, triggerComponent, hasCollider])
 
   useEffect(() => {
+    if (!physicsWorld) return
+
     setCallback(entity, 'Disable Collision', () => {
       if (!physicsWorld) return
       Physics.setCollisionLayer(physicsWorld, entity, CollisionGroups.None)

--- a/packages/spatial/src/physics/components/ColliderComponent.tsx
+++ b/packages/spatial/src/physics/components/ColliderComponent.tsx
@@ -160,7 +160,7 @@ const ColliderReactor = function () {
       removeCallback(entity, 'Disable Collision')
       removeCallback(entity, 'Enable Collision')
     }
-  }, [])
+  }, [physicsWorld])
 
   return null
 }


### PR DESCRIPTION
updated the useEffect that sets up the collider callbacks to be updated if the physicsWorld dependency updates.

This updated the reference to the physicsWorld used inside the callback to the latest reference

## Summary
https://tsu.atlassian.net/browse/IR-7234

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
