### PR TITLE
Fix envmap reactors getting suspended and broken envmap bake entity lookup

### DIFF
--- a/packages/engine/src/scene/systems/EnvironmentSystem.tsx
+++ b/packages/engine/src/scene/systems/EnvironmentSystem.tsx
@@ -96,10 +96,13 @@ const EnvMapReactor = () => {
 const IntensityReactor = (props: { rootEntity: Entity; entity: Entity }) => {
   const { rootEntity, entity } = props
   const envMapComponent = useComponent(rootEntity, EnvMapComponent)
-  const material = useComponent(entity, MaterialStateComponent).material as State<MeshStandardMaterial>
+  const material = useOptionalComponent(entity, MaterialStateComponent)?.material as
+    | State<MeshStandardMaterial>
+    | undefined
   useEffect(() => {
+    if (!material) return
     material.envMapIntensity.set(envMapComponent.envMapIntensity.value)
-  }, [envMapComponent.envMapIntensity.value, material.uuid.value])
+  }, [envMapComponent.envMapIntensity?.value, material?.uuid.value])
   return null
 }
 
@@ -109,8 +112,9 @@ const disallowedMaterials = new Set(['MeshMatcapMaterial', 'MeshToonMaterial'])
 const EnvMapSkyboxReactor = (props: { entity: Entity; rootEntity: Entity }) => {
   const { entity, rootEntity } = props
   const backgroundQuery = useQuery([BackgroundComponent])
-  const materialComponent = useComponent(entity, MaterialStateComponent)
+  const materialComponent = useOptionalComponent(entity, MaterialStateComponent)
   useEffect(() => {
+    if (!materialComponent) return
     let i = 0
     for (i; i < backgroundQuery.length; i++) if (haveCommonAncestor(entity, backgroundQuery[i])) break
     const backgroundComponent = getOptionalComponent(backgroundQuery[i], BackgroundComponent)
@@ -120,23 +124,24 @@ const EnvMapSkyboxReactor = (props: { entity: Entity; rootEntity: Entity }) => {
     if (disallowedMaterials.has(material.type.value)) return
 
     material.envMap.set(backgroundComponent as any)
-  }, [backgroundQuery, materialComponent.material.uuid.value])
+  }, [backgroundQuery, materialComponent?.material.uuid.value])
 
   return <IntensityReactor entity={entity} rootEntity={rootEntity} />
 }
 
 const EnvMapCubemapReactor = (props: { entity: Entity; rootEntity: Entity }) => {
   const { entity, rootEntity } = props
-  const materialComponent = useComponent(entity, MaterialStateComponent)
+  const materialComponent = useOptionalComponent(entity, MaterialStateComponent)
   const envMapComponent = useComponent(rootEntity, EnvMapComponent)
   useEffect(() => {
     return () => {
+      if (!materialComponent) return
       ;(materialComponent.material as State<MeshStandardMaterial>).envMap.set(null)
     }
   }, [])
 
   useEffect(() => {
-    if (disallowedMaterials.has(materialComponent.material.type.value)) return
+    if (!materialComponent || disallowedMaterials.has(materialComponent.material.type.value)) return
     loadCubeMapTexture(
       envMapComponent.envMapCubemapURL.value,
       (texture: CubeTexture | undefined) => {
@@ -160,18 +165,19 @@ const EnvMapCubemapReactor = (props: { entity: Entity; rootEntity: Entity }) => 
 
 const EnvmapProbesReactor = (props: { entity: Entity; rootEntity: Entity }) => {
   const { entity, rootEntity } = props
-  const materialComponent = useComponent(entity, MaterialStateComponent)
+  const materialComponent = useOptionalComponent(entity, MaterialStateComponent)
 
   const probeQuery = useQuery([ReflectionProbeComponent])
 
   useEffect(() => {
     return () => {
+      if (!materialComponent) return
       ;(materialComponent.material as State<MeshStandardMaterial>).envMap.set(null)
     }
   }, [])
 
   useEffect(() => {
-    if (disallowedMaterials.has(materialComponent.material.type.value)) return
+    if (!materialComponent || disallowedMaterials.has(materialComponent.material.type.value)) return
 
     const [renderTexture, unload] = createReflectionProbeRenderTarget(entity, probeQuery)
     ;(materialComponent.material as State<MeshStandardMaterial>).envMap.set(renderTexture)
@@ -186,7 +192,8 @@ const EnvmapProbesReactor = (props: { entity: Entity; rootEntity: Entity }) => {
 const EnvMapEquirectangularReactor = (props: { entity: Entity; rootEntity: Entity }) => {
   const { entity, rootEntity } = props
   const envMapComponent = useComponent(rootEntity, EnvMapComponent)
-  const materialComponent = useComponent(entity, MaterialStateComponent).material as State<MeshStandardMaterial>
+  const materialComponent = useOptionalComponent(entity, MaterialStateComponent)
+    ?.material as State<MeshStandardMaterial>
   const [envMapTexture, error] = useTexture(envMapComponent.envMapSourceURL.value, entity)
 
   useEffect(() => {
@@ -214,7 +221,7 @@ const EnvMapEquirectangularReactor = (props: { entity: Entity; rootEntity: Entit
 
 const EnvMapBakeReactor = (props: { entity: Entity; rootEntity: Entity }) => {
   const { entity, rootEntity } = props
-  const materialComponent = useComponent(entity, MaterialStateComponent)
+  const materialComponent = useOptionalComponent(entity, MaterialStateComponent)
   const envMapComponent = useComponent(rootEntity, EnvMapComponent)
 
   const bakeEntity =
@@ -224,7 +231,7 @@ const EnvMapBakeReactor = (props: { entity: Entity; rootEntity: Entity }) => {
   const [envMaptexture, error] = useTexture(bakeComponent?.envMapOrigin.value ?? '', bakeEntity)
 
   useEffect(() => {
-    if (disallowedMaterials.has(materialComponent.material.type.value)) return
+    if (!materialComponent || disallowedMaterials.has(materialComponent.material.type.value)) return
 
     const texture = envMaptexture
     if (!texture) return
@@ -255,17 +262,18 @@ const EnvMapBakeReactor = (props: { entity: Entity; rootEntity: Entity }) => {
 const tempColor = new Color(0, 0, 1)
 const EnvMapColorReactor = (props: { entity: Entity; rootEntity: Entity }) => {
   const { entity, rootEntity } = props
-  const materialComponent = useComponent(entity, MaterialStateComponent)
+  const materialComponent = useOptionalComponent(entity, MaterialStateComponent)
   const envMapComponent = useComponent(rootEntity, EnvMapComponent)
 
   useEffect(() => {
     return () => {
+      if (!materialComponent) return
       ;(materialComponent.material as State<MeshStandardMaterial>).envMap.set(null)
     }
   }, [])
 
   useEffect(() => {
-    if (disallowedMaterials.has(materialComponent.material.type.value)) return
+    if (!materialComponent || disallowedMaterials.has(materialComponent.material.type.value)) return
 
     const color = envMapComponent.envMapSourceColor.value ?? tempColor
     const resolution = 64 // Min value required
@@ -278,7 +286,7 @@ const EnvMapColorReactor = (props: { entity: Entity; rootEntity: Entity }) => {
     return () => {
       texture.dispose()
     }
-  }, [envMapComponent.envMapSourceColor, materialComponent.material.uuid.value, envMapComponent.type])
+  }, [envMapComponent.envMapSourceColor, materialComponent?.material.uuid.value, envMapComponent.type])
 
   return <IntensityReactor entity={entity} rootEntity={rootEntity} />
 }

--- a/packages/engine/src/scene/systems/EnvironmentSystem.tsx
+++ b/packages/engine/src/scene/systems/EnvironmentSystem.tsx
@@ -223,9 +223,8 @@ const EnvMapBakeReactor = (props: { entity: Entity; rootEntity: Entity }) => {
   const { entity, rootEntity } = props
   const materialComponent = useOptionalComponent(entity, MaterialStateComponent)
   const envMapComponent = useComponent(rootEntity, EnvMapComponent)
-
   const bakeEntity =
-    NodeFunctions.useEntityFromNodeID(props.entity, envMapComponent.envMapSourceEntityUUID.value) ?? UndefinedEntity
+    NodeFunctions.useEntityFromNodeID(props.rootEntity, envMapComponent.envMapSourceEntityUUID.value) ?? UndefinedEntity
   const bakeComponent = useOptionalComponent(bakeEntity, EnvMapBakeComponent)
 
   const [envMaptexture, error] = useTexture(bakeComponent?.envMapOrigin.value ?? '', bakeEntity)


### PR DESCRIPTION
## Summary
Fix envmap reactors getting suspended by treating the material component as potentially undefined. 

I don't know why this would happen for subreactors mapped to a component that is being retrieved by useChildrenWithComponents. Need to look into that function returning undefined.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-7546 and https://tsu.atlassian.net/browse/IR-7240

## QA Steps
