### PR TITLE
IR-7168: update default scene thumbnail

### DIFF
--- a/packages/client-core/src/world/SceneAPI.ts
+++ b/packages/client-core/src/world/SceneAPI.ts
@@ -78,7 +78,6 @@ export const createScene = async (
     type: 'scene',
     body: templateURL,
     path: 'public/scenes/New-Scene.gltf',
-    thumbnailKey: templateURL.replace(`${config.client.fileServer}/`, '').replace('.gltf', '.thumbnail.jpg'),
     unique: true
   })
   return sceneData

--- a/packages/editor/src/panels/scenes/SceneItem.tsx
+++ b/packages/editor/src/panels/scenes/SceneItem.tsx
@@ -23,11 +23,12 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ThemeState } from '@ir-engine/client-core/src/common/services/ThemeService'
 import { deleteScene } from '@ir-engine/client-core/src/world/SceneAPI'
-import { config } from '@ir-engine/common/src/config'
 import { StaticResourceType } from '@ir-engine/common/src/schema.type.module'
 import { timeAgo } from '@ir-engine/common/src/utils/datetime-sql'
 import RenameSceneModal from '@ir-engine/editor/src/panels/scenes/RenameSceneModal'
+import { useMutableState } from '@ir-engine/hyperflux'
 import { Tooltip } from '@ir-engine/ui'
 import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 import MoreOptionsMenu from '@ir-engine/ui/src/components/tailwind/MoreOptionsMenu'
@@ -35,6 +36,7 @@ import { Edit01Sm, Trash04Sm } from '@ir-engine/ui/src/icons'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import { default as React } from 'react'
 import { useTranslation } from 'react-i18next'
+import { twMerge } from 'tailwind-merge'
 
 type SceneItemProps = {
   scene: StaticResourceType
@@ -44,8 +46,6 @@ type SceneItemProps = {
   onDeleteScene?: (scene: StaticResourceType) => void
   disableDeleteScene: boolean
 }
-
-const DEFAULT_SCENE_THUMBNAIL = `${config.client.fileServer}/projects/ir-engine/default-project/public/scenes/default.thumbnail.jpg`
 
 export default function SceneItem({
   scene,
@@ -58,6 +58,7 @@ export default function SceneItem({
   const { t } = useTranslation()
 
   const sceneName = scene.key.split('/').pop()!.replace('.gltf', '')
+  const theme = useMutableState(ThemeState).theme
 
   const deleteSelectedScene = async (scene: StaticResourceType) => {
     if (scene) {
@@ -72,16 +73,18 @@ export default function SceneItem({
     PopoverState.hidePopupover()
   }
 
+  const defaultThumbnail = theme?.value === 'dark' ? '/iR-logo-Modal-light.png' : 'iR-logo-Modal-dark.png'
+
   return (
     <div
       data-testid="scene-container"
       className="col-span-2 inline-flex h-64 w-64 min-w-64 max-w-64 cursor-pointer flex-col items-start justify-start gap-3 rounded-lg border border-ui-outline bg-ui-background p-3 lg:col-span-1"
     >
-      <div className="shrink grow basis-0 self-stretch">
+      <div className="flex max-h-40 shrink grow basis-0 items-center justify-center self-stretch rounded bg-surface-4">
         <img
-          className="rounded"
-          src={scene.thumbnailURL || DEFAULT_SCENE_THUMBNAIL}
-          alt={DEFAULT_SCENE_THUMBNAIL}
+          className={twMerge(scene.thumbnailURL ? 'rounded' : 'h-auto max-h-32 w-full max-w-32 ')}
+          src={scene.thumbnailURL || defaultThumbnail}
+          alt={defaultThumbnail}
           data-testid="scene-thumbnail"
           onClick={handleOpenScene}
         />

--- a/packages/editor/src/panels/scenes/SceneItem.tsx
+++ b/packages/editor/src/panels/scenes/SceneItem.tsx
@@ -73,7 +73,7 @@ export default function SceneItem({
     PopoverState.hidePopupover()
   }
 
-  const defaultThumbnail = theme?.value === 'dark' ? '/iR-logo-Modal-light.png' : 'iR-logo-Modal-dark.png'
+  const defaultThumbnail = theme?.value === 'dark' ? '/iR-logo-Modal-light.png' : '/iR-logo-Modal-dark.png'
 
   return (
     <div

--- a/packages/server-core/src/media/static-resource/migrations/20250227180446_remove_default_thumbnail_from_scenes.ts
+++ b/packages/server-core/src/media/static-resource/migrations/20250227180446_remove_default_thumbnail_from_scenes.ts
@@ -1,0 +1,54 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import type { Knex } from 'knex'
+
+export const staticResourcePath = 'static-resource'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw('SET FOREIGN_KEY_CHECKS=0')
+
+  const tableExists = await knex.schema.hasTable(staticResourcePath)
+
+  if (tableExists) {
+    await knex(staticResourcePath)
+      .whereNot('project', 'ir-engine/default-project')
+      .andWhere('type', 'scene')
+      .andWhere('thumbnailKey', 'projects/ir-engine/default-project/public/scenes/default.thumbnail.jpg')
+      .update({ thumbnailKey: null })
+  }
+
+  await knex.raw('SET FOREIGN_KEY_CHECKS=1')
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {}


### PR DESCRIPTION
## Summary

Remove thumbnail from scenes that use the default thumbnail, this is needed 
since the studio and dashboard will set a fallback image to the scene based on the theme applied 
which can only be achieved in the absence of thumbnail. 

This applies to scenes that have just been created and don't have any change since the save process 
will update the scene thumbnail. 

**Fallback image in dark mode**

![image](https://github.com/user-attachments/assets/e3e640c9-0c02-4cca-a724-97cc13c487fe)


**Fallback image in light mode**

![image](https://github.com/user-attachments/assets/19a38605-4583-422b-bb7f-a3844eb97435)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

1.- npm run migrate
2.- npm run dev 
3.- create a new scene 
3.- Change from dark mode to light mode and viceversa 

Expected result: fallback image should update based on theme applied
