### PR TITLE
only trigger onPublishSuccess if newly published

### DIFF
--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -423,10 +423,10 @@ export default function AddEditLocationModal(props: {
   const anchorEvent = useHookstate<null | React.MouseEvent<HTMLElement>>(null)
 
   useEffect(() => {
-    if (location && props.onPublishSuccess) {
+    if (isNewPublished.value && location && props.onPublishSuccess) {
       props.onPublishSuccess(location)
     }
-  }, [location, props.onPublishSuccess])
+  }, [location, props.onPublishSuccess, isNewPublished.value])
 
   return (
     <div className="absolute z-50 bg-surface-2 px-8 pt-6">


### PR DESCRIPTION
## Summary
onPublishSuccess should only run immediately after onPublish is successful
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
