### PR TITLE
Adding QOL updates to hide children of GLB files for better UX

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1530,6 +1530,11 @@
       "title": "Save Changes",
       "text": "Are you sure you want to save changes to this file?"
     },
+    "savePrefab": {
+      "title": "Save Prefab",
+      "lbl-save-path": "Save Path",
+      "warn-save-path": "Name must be between 4 and 64 characters (with only letters, numbers, underscores, dashes and periods allowed)"
+    },
     "revertModel": {
       "lbl-name": "Revert",
       "title": "Revert Changes",

--- a/packages/common/src/constants/FeatureFlags.ts
+++ b/packages/common/src/constants/FeatureFlags.ts
@@ -56,7 +56,7 @@ export const FeatureFlags = {
       SceneComplexityNotification: 'ir.editor.ui.sceneComplexityNotification',
       TransformPivot: 'ir.editor.ui.transformPivot',
       Hierarchy: {
-        ShowModelChildren: 'ir.editor.ui.hierarchy.showModelChildren'
+        HideGlbChildren: 'ir.editor.ui.hierarchy.showModelChildren'
       },
       PointClick: 'ir.editor.ui.pointClick'
     }

--- a/packages/common/src/constants/FeatureFlags.ts
+++ b/packages/common/src/constants/FeatureFlags.ts
@@ -56,7 +56,7 @@ export const FeatureFlags = {
       SceneComplexityNotification: 'ir.editor.ui.sceneComplexityNotification',
       TransformPivot: 'ir.editor.ui.transformPivot',
       Hierarchy: {
-        HideGlbChildren: 'ir.editor.ui.hierarchy.showModelChildren'
+        HideGlbChildren: 'ir.editor.ui.hierarchy.hideGlbChildren' //@todo hook this up when ready
       },
       PointClick: 'ir.editor.ui.pointClick'
     }

--- a/packages/common/src/constants/FeatureFlags.ts
+++ b/packages/common/src/constants/FeatureFlags.ts
@@ -56,7 +56,7 @@ export const FeatureFlags = {
       SceneComplexityNotification: 'ir.editor.ui.sceneComplexityNotification',
       TransformPivot: 'ir.editor.ui.transformPivot',
       Hierarchy: {
-        HideGlbChildren: 'ir.editor.ui.hierarchy.hideGlbChildren' //@todo hook this up when ready
+        HideGlbChildren: 'ir.editor.ui.hierarchy.hideGlbChildren' //@todo hook this up when ready (hierarchyNode:135 &&
       },
       PointClick: 'ir.editor.ui.pointClick'
     }

--- a/packages/editor/src/components/dialogs/SavePrefabDialog.tsx
+++ b/packages/editor/src/components/dialogs/SavePrefabDialog.tsx
@@ -24,21 +24,26 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { cleanFileNameString } from '@ir-engine/common/src/utils/cleanFileName.ts'
 import { getComponent, hasComponent } from '@ir-engine/ecs'
 import { STATIC_ASSET_REGEX } from '@ir-engine/engine/src/assets/functions/pathResolver'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { getState, useHookstate } from '@ir-engine/hyperflux'
 import { Input } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
+import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { exportRelativeGLTF } from '../../functions/exportGLTF'
 import { EditorState } from '../../services/EditorServices'
 
 export default function SavePrefabPanel({ entity }) {
+  const { t } = useTranslation()
   if (!hasComponent(entity, GLTFComponent))
     throw new Error('Cannot save a prefab that has no GLTF Component on root entity')
   const gltfComponent = getComponent(entity, GLTFComponent)
   const srcPath = useHookstate(STATIC_ASSET_REGEX.exec(gltfComponent.src)?.[3].replace(/\.[^.]*$/, ''))
+  const pathIssues = cleanFileNameString(srcPath.value ?? '') !== srcPath.value
 
   const onSavePrefab = async () => {
     const isGLTF = gltfComponent.src.endsWith('gltf')
@@ -49,19 +54,23 @@ export default function SavePrefabPanel({ entity }) {
 
   return (
     <Modal
-      title="Save Prefab"
+      title={t('editor:dialog.savePrefab.title')}
       onSubmit={onSavePrefab}
+      submitButtonDisabled={pathIssues}
       className="w-[50vw] max-w-2xl"
       onClose={PopoverState.hidePopupover}
     >
       <Input
         value={srcPath.value}
-        onChange={(event) => srcPath.set(event.target.value)}
+        onChange={(event) => {
+          srcPath.set(event.target.value)
+        }}
         labelProps={{
-          text: 'Save Path',
+          text: t('editor:dialog.savePrefab.lbl-save-path'),
           position: 'top'
         }}
       />
+      {pathIssues && <Text className="ml-5 text-red-400">{t('editor:dialog.savePrefab.warn-save-path')}</Text>}
     </Modal>
   )
 }

--- a/packages/editor/src/functions/utils.ts
+++ b/packages/editor/src/functions/utils.ts
@@ -23,6 +23,15 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 import { isApple } from '@ir-engine/common/src/utils/getDeviceStats'
+import { Entity, getOptionalComponent } from '@ir-engine/ecs'
+import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent.tsx'
+
+export function isEntityGlb(entity: Entity): boolean {
+  const gltfComponent = getOptionalComponent(entity, GLTFComponent)
+  if (!gltfComponent) return false
+  const trimmedFilename = gltfComponent?.src.split('?')[0]
+  return trimmedFilename !== undefined && trimmedFilename.endsWith('.glb')
+}
 
 export function getStepSize(event, smallStep, mediumStep, largeStep) {
   if (event.altKey) {

--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -40,6 +40,7 @@ import { getState } from '@ir-engine/hyperflux'
 import { t } from 'i18next'
 import { CopyPasteFunctions, EntityCopyDataType } from '../../functions/CopyPasteFunctions'
 import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
+import { isEntityGlb } from '../../functions/utils'
 import { HierarchyTreeState } from '../../services/HierarchyNodeState'
 import { SelectionState } from '../../services/SelectionServices'
 
@@ -127,13 +128,6 @@ type WalkerEntry = {
   depth: number
   lastChild: boolean
   isRendered: boolean
-}
-
-function isEntityGlb(entity: Entity): boolean {
-  const gltfComponent = getOptionalComponent(entity, GLTFComponent)
-  if (!gltfComponent) return false
-  const trimmedFilename = gltfComponent?.src.split('?')[0]
-  return trimmedFilename !== undefined && trimmedFilename.endsWith('.glb')
 }
 
 export function ecsHierarchyTreeWalker(rootEntity: Entity, enableHideGlbChildren: boolean): HierarchyTreeNodeType[] {

--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -129,17 +129,31 @@ type WalkerEntry = {
   isRendered: boolean
 }
 
-export function ecsHierarchyTreeWalker(rootEntity: Entity): HierarchyTreeNodeType[] {
+function isEntityGlb(entity: Entity): boolean {
+  const gltfComponent = getOptionalComponent(entity, GLTFComponent)
+  if (!gltfComponent) return false
+  const trimmedFilename = gltfComponent?.src.split('?')[0]
+  return trimmedFilename !== undefined && trimmedFilename.endsWith('.glb')
+}
+
+export function ecsHierarchyTreeWalker(rootEntity: Entity, enableHideGlbChildren: boolean): HierarchyTreeNodeType[] {
   const result: HierarchyTreeNodeType[] = []
   const frontier: WalkerEntry[] = [{ entity: rootEntity, depth: 0, lastChild: true, isRendered: true }]
   while (frontier.length > 0) {
     const { entity, depth, lastChild, isRendered: originalIsRendered } = frontier.pop()!
     const eTree = getOptionalComponent(entity, EntityTreeComponent)
-    const valid = hasComponent(entity, GLTFComponent) || hasComponent(entity, SourceComponent)
+
+    const hasGLTFComponent = hasComponent(entity, GLTFComponent)
+    const hasSourceComponent = hasComponent(entity, SourceComponent)
+
+    const valid = hasGLTFComponent || hasSourceComponent
     if (!eTree || !valid) continue
     const childIndex = eTree.childIndex ?? 0
     const children = eTree.children
-    const isLeaf = !children || children.length === 0
+
+    //@todo temporary check for glb so we don't display children we can't save edits to
+    const hideChildren = isEntityGlb(entity) && enableHideGlbChildren
+    const isLeaf = !children || children.length === 0 || hideChildren //check glb here to hide expansion chevron
     const sourceID = GLTFComponent.getInstanceID(rootEntity)
     const isCollapsed = !getState(HierarchyTreeState).expandedNodes[sourceID]?.[entity]
     const isRendered = originalIsRendered && !isCollapsed
@@ -152,7 +166,8 @@ export function ecsHierarchyTreeWalker(rootEntity: Entity): HierarchyTreeNodeTyp
       isCollapsed,
       isRendered: originalIsRendered
     })
-    if (children) {
+    if (children && !hideChildren) {
+      //do not push children of glb
       for (let i = children.length - 1; i >= 0; i--) {
         frontier.push({ entity: children[i], depth: depth + 1, lastChild: i === 0, isRendered })
       }

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -129,6 +129,9 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
   const canSaveNodeChanges = useState(false)
   const permissionToChangeNodeVerified = useState(false)
 
+  //@todo when this feature flag is added, remove the hardcoded value
+  const hideGlbChildrenFeatureFlag = [true] //useFeatureFlags([FeatureFlags.Studio.UI.Hierarchy.HideGlbChildren])
+
   const handleRenameOpen = () => {
     if (!isRenameOpen.value) {
       isRenameOpen.set(true)
@@ -400,7 +403,8 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         'bg-ui-background',
         !visible ? 'text-text-inactive' : '',
         selected ? 'rounded-sm border border-ui-select-outline bg-ui-select-background text-text-primary' : '',
-        isOverOn && canDropOn ? 'border border-dotted' : ''
+        isOverOn && canDropOn ? 'border border-dotted' : '',
+        hideGlbChildrenFeatureFlag[0] && isOverOn && !canDropOn ? 'border border-dotted bg-ui-hover-error' : ''
       )}
       data-testid="hierarchy-panel-scene-item"
     >

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -336,7 +336,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
     const [_, orgName, projectName, fileName] = STATIC_ASSET_REGEX.exec(gltfComponent.src)!
     const fullProjectName = `${orgName}/${projectName}`
     const parsedName = fileName.split('?')[0]
-    exportRelativeGLTF(node.entity, fullProjectName, parsedName).then((newSRC) => {
+    exportRelativeGLTF(node.entity, fullProjectName, parsedName, false).then((newSRC) => {
       EditorControlFunctions.modifyProperty([node.entity], GLTFComponent, { src: newSRC })
       getMutableState(AssetModifiedState)[GLTFComponent.getInstanceID(entity)].set(none)
     })
@@ -361,11 +361,16 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
     permissionToChangeNodeVerified.set(true)
 
     const gltfComponent = getComponent(node.entity, GLTFComponent)
-    const [, orgName, projectName] = STATIC_ASSET_REGEX.exec(gltfComponent.src)!
+    const [, orgName, projectName, fileName] = STATIC_ASSET_REGEX.exec(gltfComponent.src)!
     const fullProjectName = `${orgName}/${projectName}`
 
     const { projectName: stateProjectName } = getState(EditorState)
 
+    const trimmedFilename = fileName.split('?')[0]
+    if (trimmedFilename && trimmedFilename.endsWith('.glb')) {
+      canSaveNodeChanges.set(false)
+      return
+    }
     if (stateProjectName === fullProjectName) {
       canSaveNodeChanges.set(true)
       return

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -97,7 +97,7 @@ const HierarchySnapshotReactor = (props: { children?: ReactNode; rootEntity: Ent
   const { children, rootEntity, sourceID } = props
   const selectionState = useMutableState(SelectionState)
   const hierarchyTreeState = useMutableState(HierarchyTreeState)
-  const [showModelChildren] = useFeatureFlags([FeatureFlags.Studio.UI.Hierarchy.ShowModelChildren])
+  const [hideGlbChildren] = useFeatureFlags([FeatureFlags.Studio.UI.Hierarchy.HideGlbChildren])
   const renamingEntity = useHookstate<Entity | null>(null)
   const contextMenu = useHookstate({ entity: UndefinedEntity, anchorEvent: undefined as React.MouseEvent | undefined })
   const entities = useQuery([SourceComponent], Layers.Authoring)
@@ -121,11 +121,11 @@ const HierarchySnapshotReactor = (props: { children?: ReactNode; rootEntity: Ent
   }
 
   const hierarchyNodes = useMemo(
-    () => ecsHierarchyTreeWalker(rootEntity),
+    () => ecsHierarchyTreeWalker(rootEntity, hideGlbChildren),
     [
       hierarchyTreeState.expandedNodes[sourceID],
       selectionState.selectedEntities,
-      showModelChildren,
+      hideGlbChildren,
       entities,
       childEntities,
       reparentRefresh

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -49,7 +49,7 @@ import useUpload from '../../components/assets/useUpload'
 import { DnDFileType, FileDataType, ItemTypes, SupportedFileTypes } from '../../constants/AssetTypes'
 import { addMediaNode } from '../../functions/addMediaNode'
 import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
-import { cmdOrCtrlString } from '../../functions/utils'
+import { cmdOrCtrlString, isEntityGlb } from '../../functions/utils'
 import { EditorState } from '../../services/EditorServices'
 import { HierarchyTreeState } from '../../services/HierarchyNodeState'
 import { SelectionState } from '../../services/SelectionServices'
@@ -240,6 +240,7 @@ export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' 
     if (item.type === ItemTypes.Node) {
       if (node?.entity) {
         const entityTreeComponent = getComponent(node.entity, EntityTreeComponent)
+        if (place === 'On' && isEntityGlb(node.entity)) return false
         if (place === 'On' || !!entityTreeComponent.parentEntity) return true
       }
 

--- a/packages/editor/src/systems/EditorControlSystem.ts
+++ b/packages/editor/src/systems/EditorControlSystem.ts
@@ -438,7 +438,7 @@ const updateSelection = (clickedEntity: Entity, control: boolean, shift: boolean
 const reactor = () => {
   const editorHelperState = useMutableState(EditorHelperState)
   const rendererState = useMutableState(RendererState)
-  const flag = useFeatureFlags([FeatureFlags.Studio.UI.Hierarchy.ShowModelChildren])
+  const flag = useFeatureFlags([FeatureFlags.Studio.UI.Hierarchy.HideGlbChildren])
 
   useEffect(() => {
     // todo figure out how to do these with our input system

--- a/packages/editor/src/systems/EditorControlSystem.ts
+++ b/packages/editor/src/systems/EditorControlSystem.ts
@@ -72,13 +72,11 @@ import { EditorErrorState } from '../services/EditorErrorServices'
 
 import { EditorHelperState, PlacementMode } from '../services/EditorHelperState'
 
-import useFeatureFlags from '@ir-engine/client-core/src/hooks/useFeatureFlags'
-import { FeatureFlags } from '@ir-engine/common/src/constants/FeatureFlags'
 import { usesCtrlKey } from '@ir-engine/common/src/utils/OperatingSystemFunctions'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { ReferenceSpaceState } from '@ir-engine/spatial'
-import { SceneComponent } from '@ir-engine/spatial/src/renderer/components/SceneComponents'
 import { TransformGizmoControlledComponent } from '../classes/gizmo/transform/TransformGizmoControlledComponent'
+import { isEntityGlb } from '../functions/utils.ts'
 import { EditorState } from '../services/EditorServices'
 import { SelectionState } from '../services/SelectionServices'
 import { ClickPlacementState } from './ClickPlacementSystem'
@@ -344,10 +342,10 @@ const execute = () => {
       const selectedEntity =
         selectedParentEntity === clickStartEntity ? closestIntersection.entity : selectedParentEntity
 
-      // If not showing model children in hierarchy don't allow those objects to be selected
-      if (!hierarchyFeatureFlagEnabled) {
-        const inCurrentScene = hasComponent(selectedParentEntity, SceneComponent)
-        clickStartEntity = inCurrentScene ? selectedEntity : clickStartEntity
+      // If hiding children of GLB, don't allow those children to be selected (clicking in scene view)
+      if (hierarchyFeatureFlagEnabled && selectedParentEntity) {
+        const forceSelectGlbParent = isEntityGlb(selectedParentEntity) // && hasComponent(selectedParentEntity, SceneComponent)
+        clickStartEntity = forceSelectGlbParent ? selectedParentEntity : selectedEntity //selectedEntity vs clickStartEntity so that we allow closest intersection drill down above to work
       } else {
         clickStartEntity = selectedEntity
       }
@@ -438,7 +436,9 @@ const updateSelection = (clickedEntity: Entity, control: boolean, shift: boolean
 const reactor = () => {
   const editorHelperState = useMutableState(EditorHelperState)
   const rendererState = useMutableState(RendererState)
-  const flag = useFeatureFlags([FeatureFlags.Studio.UI.Hierarchy.HideGlbChildren])
+
+  //@todo remove hardcoded value once feature flag is added to MT
+  const hideGlbChildrenFeatureFlag = [true] // useFeatureFlags([FeatureFlags.Studio.UI.Hierarchy.HideGlbChildren])
 
   useEffect(() => {
     // todo figure out how to do these with our input system
@@ -473,8 +473,8 @@ const reactor = () => {
   }, [viewerEntity])
 
   useEffect(() => {
-    hierarchyFeatureFlagEnabled = flag[0]
-  }, [flag])
+    hierarchyFeatureFlagEnabled = hideGlbChildrenFeatureFlag[0]
+  }, [hideGlbChildrenFeatureFlag])
 
   return null
 }

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -35,6 +35,7 @@ import {
   getComponent,
   getMutableComponent,
   getOptionalComponent,
+  getSimulationCounterpart,
   hasComponent,
   Layers,
   removeComponent,
@@ -284,7 +285,8 @@ const ResourceReactor = (props: { documentID: string; entity: Entity; documentLo
   const dependenciesLoaded = GLTFComponent.useDependenciesLoaded(props.entity)
   const resourceQuery = useQuery([SourceComponent, ResourcePendingComponent])
 
-  useApplyCollidersToChildMeshesEffect(props.entity)
+  const simulationEntity = getSimulationCounterpart(props.entity)
+  useApplyCollidersToChildMeshesEffect(simulationEntity)
 
   useEffect(() => {
     if (!hasComponent(props.entity, GLTFComponent) || !props.documentLoaded) return


### PR DESCRIPTION
## Summary
branch name might be wrong, will sort out the tickets
adding QOL updates to hide children of GLB files for better UX with model files (and by extension prefabs)

- fixing prefab save icon in hierarchy panel (the added param exportRoot must be false or you get infinitely recursive model references)

hiding children of GLB files in hierarchy:
- renamed and repurposed the no longer used feature flag "ShowModelChildren" to "HideGlbChildren" - this is currently not used, as it will require a separate PR to MT, so this feature is enabled with a @todo to hook it up to the flag by uncommenting 2 lines of code for all hiding of glb related work
- disabled dropping entities onto glb files (would make them a child that is also hidden) and gave it a red highlight when hovering over to drop
- disabled save icon for GLB files (as we do not support saving changes to GLB currently - this all still works for GLTF)
- NOTE: you can still persist changes to the GLB entity components by saving scene

- added prefab name validation in save prefab modal, as well as i18n for the modal text
- also fixed issue with applyColliders on GLTFComponent
