### PR TITLE
Fix GLTF entities deleting themselves

### DIFF
--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -233,9 +233,8 @@ export const GLTFComponentReactor = () => {
     let aborted = false
     removeComponent(entity, AnimationComponent)
 
-    const layer = LayerComponent.get(entity)
-    const unloadEntities = () => {
-      const loadedEntities = SourceComponent.getEntitiesBySource(sourceID, layer)
+    const unloadSimulationEntities = () => {
+      const loadedEntities = SourceComponent.getEntitiesBySource(sourceID)
       for (const entity of loadedEntities) removeEntity(entity)
     }
 
@@ -247,14 +246,14 @@ export const GLTFComponentReactor = () => {
       TransformComponent.dirty[entity] = 1
 
       if (aborted) {
-        unloadEntities()
+        unloadSimulationEntities()
       }
     })
     return () => {
       documentLoaded.set(false)
       GLTFLoaderFunctions.unloadScene(url, entity)
       aborted = true
-      unloadEntities()
+      unloadSimulationEntities()
       if (hasComponent(entity, GLTFComponent)) {
         getMutableComponent(entity, GLTFComponent).progress.set(0)
       }

--- a/packages/engine/src/gltf/GLTFState.tsx
+++ b/packages/engine/src/gltf/GLTFState.tsx
@@ -55,6 +55,7 @@ import { SceneComponent } from '@ir-engine/spatial/src/renderer/components/Scene
 import { VisibleComponent } from '@ir-engine/spatial/src/renderer/components/VisibleComponent'
 import { RendererComponent } from '@ir-engine/spatial/src/renderer/WebGLRendererSystem'
 import { TransformComponent } from '@ir-engine/spatial/src/transform/components/TransformComponent'
+import { SourceComponent } from '../scene/components/SourceComponent'
 import { GLTFComponent, GLTFComponentReactor } from './GLTFComponent'
 import './MeshExtensionComponents'
 
@@ -86,6 +87,9 @@ export const SceneState = defineState({
           current.filter((scene) => scene !== simulationEntity)
         )
       }
+      const sourceID = GLTFComponent.getInstanceID(gltfEntity)
+      const loadedEntities = SourceComponent.getEntitiesBySource(sourceID, Layers.Authoring)
+      for (const entity of loadedEntities) removeEntity(entity)
       AssetState.unload(gltfEntity)
       getMutableState(SceneState)[sceneURL].set(gltfEntity)
     }


### PR DESCRIPTION
## Summary
Since entities update their GLTF document occasionally this unload logic was deleting the authoring layer entities whenever they were triggering the use effect. Moved cleanup logic to scene switching logic.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
