### PR TITLE
fix default value to match schema; list

### DIFF
--- a/packages/server-core/src/cluster/logs-api/analytics-logger.ts
+++ b/packages/server-core/src/cluster/logs-api/analytics-logger.ts
@@ -66,7 +66,7 @@ export const logToBigQuery = async (event: LogParamsObject) => {
     event_name: event.event_name,
     event_id: event.event_id || uuidv4(),
     event_value: event.event_value || '',
-    event_properties: event.event_properties || {},
+    event_properties: event.event_properties || [],
     event_time: Date.now(),
     tenant: event.tenant,
     project: event.project,


### PR DESCRIPTION
## Summary
the default value event_properties needs to be a list to match the schema.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
