### PR TITLE
Analytics for creating scenes

### DIFF
--- a/packages/editor/src/components/dialogs/CreateScenePanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/CreateScenePanelDialog.tsx
@@ -29,7 +29,7 @@ import { Button } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { onNewScene } from '../../functions/sceneFunctions'
+import { logNewScene, onNewScene } from '../../functions/sceneFunctions'
 import { UIAddonsState } from '../../services/UIAddonsState'
 
 export default function CreateSceneDialog() {
@@ -48,6 +48,7 @@ export default function CreateSceneDialog() {
           className="w-[10vw] break-keep"
           onClick={() => {
             onNewScene()
+            logNewScene('editor', 'editor')
             PopoverState.hidePopupover()
           }}
         >

--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -133,6 +133,26 @@ export const saveSceneGLTF = async (
   })
 }
 
+export const logNewScene = (authoringApp: string, entryPoint: string = 'editor') => {
+  logger.analytics({
+    app_name: 'editor',
+    project: getState(EditorState).projectName,
+    user_id: getState(EngineState).userID,
+    event_name: 'editor',
+    event_value: 'new-scene',
+    event_properties: [
+      {
+        key: 'authoring-app',
+        value: authoringApp
+      },
+      {
+        key: 'entry-point',
+        value: entryPoint
+      }
+    ]
+  })
+}
+
 export const onNewScene = async (
   templateURL = config.client.fileServer + '/projects/ir-engine/default-project/public/scenes/default.gltf'
 ) => {


### PR DESCRIPTION
Scenes can be created using different applications (ie. the editor and the wizard) from different UI entry points (ie the editor menus and the dashboard menu). This small method makes it easy to track these user events consistently across applications and entry points.

Supports [IR-6917](https://tsu.atlassian.net/browse/IR-6917)

[IR-6917]: https://tsu.atlassian.net/browse/IR-6917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ