### PR TITLE
fix(locations): don't display options when the select is disabled [IR-7035]

### DIFF
--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -25,7 +25,6 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { ChevronDownSm, HelpIconSm, XCloseSm } from '@ir-engine/ui/src/icons'
 import Fuse from 'fuse.js'
-import { isEmpty } from 'lodash'
 import React, { useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
 import Popup from 'reactjs-popup'
 import { PopupActions } from 'reactjs-popup/dist/types'
@@ -397,7 +396,7 @@ const Select = ({
           }
         }}
       >
-        {!isEmpty(filteredOptions) &&
+        {filteredOptions.length > 0 &&
           !disabled &&
           filteredOptions.map(({ value: currentValue, ...optionProps }, index) => (
             <DropdownItem
@@ -432,7 +431,7 @@ const Select = ({
             />
           ))}
 
-        {!isEmpty(filteredOptions) && !disabled && (
+        {filteredOptions.length === 0 && !disabled && (
           <div className="flex h-12 items-center justify-center bg-ui-background text-text-secondary">
             No options available
           </div>

--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -25,6 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { ChevronDownSm, HelpIconSm, XCloseSm } from '@ir-engine/ui/src/icons'
 import Fuse from 'fuse.js'
+import { isEmpty } from 'lodash'
 import React, { useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
 import Popup from 'reactjs-popup'
 import { PopupActions } from 'reactjs-popup/dist/types'
@@ -309,7 +310,7 @@ const Select = ({
                   }}
                   type="text"
                   className={twMerge(
-                    'w-full bg-inherit focus:outline-none',
+                    'focus:outline-non w-full bg-inherit text-text-secondary',
                     searchMode === undefined ? 'cursor-pointer' : 'cursor-text',
                     disabled ? 'cursor-not-allowed' : ''
                   )}
@@ -321,12 +322,12 @@ const Select = ({
                   }}
                 />
 
-                {showClearButton && (
+                {showClearButton && !disabled && (
                   <XCloseSm
                     onClick={() => {
                       onChange('')
                     }}
-                    className="cursor-pointer"
+                    className="cursor-pointer text-text-secondary"
                   />
                 )}
 
@@ -336,7 +337,7 @@ const Select = ({
                       togglePopup()
                     }
                   }}
-                  className={`cursor-pointer ${isOpen && 'rotate-180'} duration-300`}
+                  className={`cursor-pointer ${isOpen && !disabled && 'rotate-180'} text-text-secondary duration-300`}
                 />
               </div>
             </div>
@@ -396,7 +397,8 @@ const Select = ({
           }
         }}
       >
-        {filteredOptions.length > 0 ? (
+        {!isEmpty(filteredOptions) &&
+          !disabled &&
           filteredOptions.map(({ value: currentValue, ...optionProps }, index) => (
             <DropdownItem
               key={index}
@@ -428,8 +430,9 @@ const Select = ({
                 }
               }}
             />
-          ))
-        ) : (
+          ))}
+
+        {!isEmpty(filteredOptions) && !disabled && (
           <div className="flex h-12 items-center justify-center bg-ui-background text-text-secondary">
             No options available
           </div>


### PR DESCRIPTION
## Summary
- hide select options when the select is disabled
- display the correct color depending on the theme in the input of the select field

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
- [Admin] Select a project and go to the studio
- [Admin] click on Publish
- [Console] go to locations
- Edit a location 

## Evidence
### Studio
https://github.com/user-attachments/assets/cd9b15e9-b452-4526-801a-aa85eff3951f

### Console
<img width="832" alt="Screenshot 2025-02-28 at 8 18 27 p m" src="https://github.com/user-attachments/assets/b4915f00-c535-43ee-8681-5f45c0aba598" />

## Jira 
[IR-7035](https://tsu.atlassian.net/browse/IR-7035)


[IR-7035]: https://tsu.atlassian.net/browse/IR-7035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ