### PR TITLE
Stop onBeforeCompile plugins from being erroneously removed

### DIFF
--- a/packages/editor/src/panels/properties/materialeditor.tsx
+++ b/packages/editor/src/panels/properties/materialeditor.tsx
@@ -186,7 +186,7 @@ export function MaterialEditor(props: { materialUUID: EntityUUID }) {
         )
       )
     )
-  }, [currentSelectedMaterial])
+  }, [currentSelectedMaterial, material.type])
 
   //for each parameter type, default values
   const pluginParameters = useHookstate({})

--- a/packages/spatial/src/common/functions/OnBeforeCompilePlugin.ts
+++ b/packages/spatial/src/common/functions/OnBeforeCompilePlugin.ts
@@ -118,16 +118,11 @@ const onBeforeCompile = {
     return this._onBeforeCompile
   },
   set: function (this: Material, plugins: PluginType | PluginType[]) {
-    if (plugins === null) {
-      if (this.plugins) {
-        while (this.plugins.length) removeOBCPlugin(this, this.plugins[0])
-      }
-    } else if (plugins instanceof Array) {
+    if (plugins instanceof Array) {
       for (let i = 0, l = plugins.length; i < l; i++) (this as any).onBeforeCompile = plugins[i]
     } else if (plugins instanceof Function || plugins instanceof Object) {
       const plugin = plugins
 
-      if (hasOBCPlugin(this, plugin)) return
       if (!this.plugins) this.plugins = []
       ;(plugin as PluginObjectType).priority =
         typeof (plugin as PluginObjectType).priority === 'undefined' ? 1 : (plugin as PluginObjectType).priority
@@ -143,8 +138,6 @@ const onBeforeCompile = {
           if (typeof pluginObj.compile === 'function') result += pluginObj.compile.toString()
           else result += plugin.toString()
         }
-        // if (typeof this._onBeforeCompile.toString === 'function') return this._onBeforeCompile.toString()
-        // else return this.onBeforeCompile.toString()
         return result
       }
     } else {

--- a/packages/spatial/src/common/functions/OnBeforeCompilePlugin.ts
+++ b/packages/spatial/src/common/functions/OnBeforeCompilePlugin.ts
@@ -118,6 +118,7 @@ const onBeforeCompile = {
     return this._onBeforeCompile
   },
   set: function (this: Material, plugins: PluginType | PluginType[]) {
+    if (plugins === null) return
     if (plugins instanceof Array) {
       for (let i = 0, l = plugins.length; i < l; i++) (this as any).onBeforeCompile = plugins[i]
     } else if (plugins instanceof Function || plugins instanceof Object) {

--- a/packages/spatial/src/renderer/materials/materialFunctions.ts
+++ b/packages/spatial/src/renderer/materials/materialFunctions.ts
@@ -100,7 +100,7 @@ export const hasPlugin = (material: Material, callback) =>
 
 export const removePlugin = (material: Material, callback) => {
   const pluginIndex = material.plugins?.findIndex((plugin) => plugin === callback)
-  if (pluginIndex !== undefined) material.plugins?.splice(pluginIndex, 1)
+  if (pluginIndex !== undefined && pluginIndex >= 0) material.plugins?.splice(pluginIndex, 1)
 }
 
 export function MaterialNotFoundError(message: string) {


### PR DESCRIPTION
## Summary
Stops obc plugins being lost on selection change, and sometimes immediately on set by fixing logic in the removePlugin function and disabling the use of the deprecated obc functions used within the obc plugin patch. I also threw in a quick fix for properties not updating on prototype change.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-7238
## QA Steps
