### PR TITLE
Fix model transfrom when handling textures from 1st party assets

### DIFF
--- a/packages/common/src/model/ModelTransformFunctions.ts
+++ b/packages/common/src/model/ModelTransformFunctions.ts
@@ -609,7 +609,7 @@ const createTextureOperations = (
   return operations
 }
 
-const transformTexture = async (resultCache: Map<string, Texture>, operation: TextureOperation) => {
+const transformTexture = async (resultCache: Map<string, Texture>, operation: TextureOperation, index: number) => {
   const { shouldResize, shouldConvertToKTX, texture, params } = operation
 
   const hash = hashTextureOperation(operation)
@@ -661,6 +661,15 @@ const transformTexture = async (resultCache: Map<string, Texture>, operation: Te
     texture.setImage(new Uint8Array(compressedData))
     texture.setMimeType('image/ktx2')
     texture.setURI(texture.getURI().replace(/\.[^.]+$/, '.ktx2'))
+  }
+
+  if (shouldResize || shouldConvertToKTX) {
+    //wipe relative path from URI
+    const uri = texture.getURI()
+    let newURI = uri.split('/').at(-1)!
+    const [_, fileName, extension] = /(.*)\.([^.]+)$/.exec(newURI)!
+    newURI = `${fileName}-${index}.${extension}`
+    texture.setURI(newURI)
   }
   resultCache.set(hash, texture)
 }
@@ -864,7 +873,7 @@ export const transformModel = async (
   const resultCache = new Map<string, Texture>()
   for (let i = 0; i < numTextureOperations; i++) {
     onProgress?.((i + 1) / totalProgressSteps, Status.ProcessingTexture, i, numTextureOperations)
-    await transformTexture(resultCache, textureOperations[i])
+    await transformTexture(resultCache, textureOperations[i], i)
   }
 
   const results: string[] = []


### PR DESCRIPTION
if an asset is being compressed which references images in a read-only project, the resulting compressed images should be saved in the project that compression is taking place within