### PR TITLE
GLTF Export: Allow image routing to projects outside of current one

### DIFF
--- a/packages/engine/src/gltf/exportGLTFScene.test.tsx
+++ b/packages/engine/src/gltf/exportGLTFScene.test.tsx
@@ -291,7 +291,7 @@ describe('exportGLTFScene', () => {
 
     assert.strictEqual(gltf.images?.length, 1)
     const image = gltf.images[0]
-    assert.strictEqual(image.uri, '../../../../ir-engine/dud-project/public/images/image.png')
+    assert.strictEqual(image.uri, '../../../ir-engine/dud-project/public/images/image.png')
   })
 
   it('export mesh with material texture map into new folder', async () => {
@@ -299,7 +299,7 @@ describe('exportGLTFScene', () => {
     const [gltf, ...files] = (await exportGLTFScene(meshEntity, 'dud-project', 'base/folder2/test.gltf')) as [
       GLTF.IGLTF
     ]
-    assert.strictEqual(gltf.images?.[0]?.uri, '../../../../ir-engine/dud-project/public/images/image.png')
+    assert.strictEqual(gltf.images?.[0]?.uri, '../../../ir-engine/dud-project/public/images/image.png')
   })
 
   it('export custom ECS data', async () => {

--- a/packages/engine/src/gltf/exportGLTFScene.test.tsx
+++ b/packages/engine/src/gltf/exportGLTFScene.test.tsx
@@ -291,7 +291,7 @@ describe('exportGLTFScene', () => {
 
     assert.strictEqual(gltf.images?.length, 1)
     const image = gltf.images[0]
-    assert.strictEqual(image.uri, '../../../ir-engine/dud-project/public/images/image.png')
+    assert.strictEqual(image.uri, '../../../../ir-engine/dud-project/public/images/image.png')
   })
 
   it('export mesh with material texture map into new folder', async () => {

--- a/packages/engine/src/gltf/exportGLTFScene.test.tsx
+++ b/packages/engine/src/gltf/exportGLTFScene.test.tsx
@@ -291,7 +291,7 @@ describe('exportGLTFScene', () => {
 
     assert.strictEqual(gltf.images?.length, 1)
     const image = gltf.images[0]
-    assert.strictEqual(image.uri, '../../../public/images/image.png')
+    assert.strictEqual(image.uri, '../../../../ir-engine/dud-project/public/images/image.png')
   })
 
   it('export mesh with material texture map into new folder', async () => {
@@ -299,7 +299,7 @@ describe('exportGLTFScene', () => {
     const [gltf, ...files] = (await exportGLTFScene(meshEntity, 'dud-project', 'base/folder2/test.gltf')) as [
       GLTF.IGLTF
     ]
-    assert.strictEqual(gltf.images?.[0]?.uri, '../../public/images/image.png')
+    assert.strictEqual(gltf.images?.[0]?.uri, '../../../../ir-engine/dud-project/public/images/image.png')
   })
 
   it('export custom ECS data', async () => {

--- a/packages/engine/src/gltf/exportGLTFScene.test.tsx
+++ b/packages/engine/src/gltf/exportGLTFScene.test.tsx
@@ -256,9 +256,11 @@ describe('exportGLTFScene', () => {
   it('export mesh with material texture map', async () => {
     const { meshEntity } = createDudMesh()
     // Export the scene. The first element is the GLTF JSON.
-    const [gltf, ...files] = (await exportGLTFScene(meshEntity, 'dud-project', 'assets/base/folder1/test.gltf')) as [
-      GLTF.IGLTF
-    ]
+    const [gltf, ...files] = (await exportGLTFScene(
+      meshEntity,
+      'ir-engine/dud-project',
+      'assets/base/folder1/test.gltf'
+    )) as [GLTF.IGLTF]
 
     // Validate that the GLTF contains a single node referencing mesh index 0.
     assert(Array.isArray(gltf.nodes))
@@ -291,15 +293,15 @@ describe('exportGLTFScene', () => {
 
     assert.strictEqual(gltf.images?.length, 1)
     const image = gltf.images[0]
-    assert.strictEqual(image.uri, '../../../../ir-engine/dud-project/public/images/image.png')
+    assert.strictEqual(image.uri, '../../../public/images/image.png')
   })
 
   it('export mesh with material texture map into new folder', async () => {
     const { meshEntity } = createDudMesh()
-    const [gltf, ...files] = (await exportGLTFScene(meshEntity, 'dud-project', 'base/folder2/test.gltf')) as [
+    const [gltf, ...files] = (await exportGLTFScene(meshEntity, 'ir-engine/dud-project', 'base/folder2/test.gltf')) as [
       GLTF.IGLTF
     ]
-    assert.strictEqual(gltf.images?.[0]?.uri, '../../../ir-engine/dud-project/public/images/image.png')
+    assert.strictEqual(gltf.images?.[0]?.uri, '../../public/images/image.png')
   })
 
   it('export custom ECS data', async () => {

--- a/packages/engine/src/gltf/exportGLTFScene.ts
+++ b/packages/engine/src/gltf/exportGLTFScene.ts
@@ -835,11 +835,14 @@ const exportImage = async (image: any, gltf: GLTF.IGLTF, context: GLTFSceneExpor
       bufferView: bufferViewIndex
     }
   } else {
-    const relativeSrc = STATIC_ASSET_REGEX.exec(image.src)![3]
-    const dstName = baseName(relativeSrc)
-    const srcName = baseName(context.relativePath)
-    const dstDir = LoaderUtils.extractUrlBase(relativeSrc)
-    const srcDir = LoaderUtils.extractUrlBase(context.relativePath)
+    const [, dstOrgName, dstProjectName, dstInternalPath] = STATIC_ASSET_REGEX.exec(image.src)!
+    const srcProjectName = context.projectName
+    const dstRelativePath = pathJoin(dstOrgName, dstProjectName, dstInternalPath)
+    const srcRelativePath = pathJoin(srcProjectName, context.relativePath)
+    const dstName = baseName(dstRelativePath)
+    const srcName = baseName(srcRelativePath)
+    const dstDir = LoaderUtils.extractUrlBase(dstRelativePath)
+    const srcDir = LoaderUtils.extractUrlBase(srcRelativePath)
 
     const uri = pathJoin(relativePathTo(srcDir, dstDir), dstName)
 


### PR DESCRIPTION
When saving a .gltf file, we are preserving references to the original images. This means rerouting the URIs within the gltf to point to the relative path between the original gltf's location and the new gltf's location. Previously we were not considering the case where the new gltf is being saved into a different project than the original, which is what happens when compressing + publishing 1st party assets. 
This change expands the image routing to take the org name and project name in the image URI into account, and allow relative URIs that can reference images in other projects and organizations