### PR TITLE
Fix color for dock panel button

### DIFF
--- a/packages/editor/src/components/EditorContainer.css
+++ b/packages/editor/src/components/EditorContainer.css
@@ -9,6 +9,10 @@
   border: none;
 }
 
+.dock-panel-max-btn::before {
+  border-color: var(--text-primary) !important;
+}
+
 .dock.dock-top {
   background: var(--surface-0);
 }


### PR DESCRIPTION
Update the border color for the dock panel max button to ensure it matches the primary text color.