### PR TITLE
IR-7596: added project name to created project event in history

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -796,7 +796,8 @@
       "createdThumbnail": "created a thumbnail: ",
       "updatedThumbnail": "updated the thumbnail of the resource: ",
       "removedThumbnail": "removed the thumbnail for the resource: ",
-      "updatePermission": "updated the permission of the user"
+      "updatePermission": "updated the permission of the user",
+      "createdProject": "created project: "
     },
     "moderation": {
       "columns": {

--- a/packages/client-core/src/admin/components/project/ProjectHistory.tsx
+++ b/packages/client-core/src/admin/components/project/ProjectHistory.tsx
@@ -157,7 +157,12 @@ function HistoryLog({ projectHistory, projectName }: { projectHistory: ProjectHi
         </>
       )
     } else if (projectHistory.action === 'PROJECT_CREATED') {
-      return <Text>created the project</Text>
+      return (
+        <>
+          <Text>{t('admin:components.history.createdProject')}</Text>
+          <Text fontWeight="semibold">{projectName}</Text>
+        </>
+      )
     } else if (
       projectHistory.action === 'RESOURCE_CREATED' ||
       projectHistory.action === 'RESOURCE_REMOVED' ||


### PR DESCRIPTION
## Summary

Added project name to PROJECT_CREATED event in project history

![image](https://github.com/user-attachments/assets/f1feacab-e6c7-4b0d-bb6f-d20a699b4605)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
