### PR TITLE
IR-7675: SSO signup error caused by undefined userId

### DIFF
--- a/packages/server-core/src/user/strategies/apple.ts
+++ b/packages/server-core/src/user/strategies/apple.ts
@@ -161,7 +161,7 @@ export class AppleStrategy extends CustomOAuthStrategy {
       await this.app.service(identityProviderPath).remove(null, {
         query: {
           type: 'guest',
-          userId: existingEntity.userId
+          userId: entity.userId
         }
       })
       await this.userLoginEntry(newIP, params)

--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -160,7 +160,7 @@ export class DiscordStrategy extends CustomOAuthStrategy {
       await this.app.service(identityProviderPath).remove(null, {
         query: {
           type: 'guest',
-          userId: existingEntity.userId
+          userId: entity.userId
         }
       })
       await this.userLoginEntry(newIP, params)

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -160,7 +160,7 @@ export class FacebookStrategy extends CustomOAuthStrategy {
       await this.app.service(identityProviderPath).remove(null, {
         query: {
           type: 'guest',
-          userId: existingEntity.userId
+          userId: entity.userId
         }
       })
       await this.userLoginEntry(newIP, params)

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -209,7 +209,7 @@ export class GithubStrategy extends CustomOAuthStrategy {
       await this.app.service(identityProviderPath).remove(null, {
         query: {
           type: 'guest',
-          userId: existingEntity.userId
+          userId: entity.userId
         }
       })
       await this.userLoginEntry(newIP, params)

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -161,7 +161,7 @@ export class Googlestrategy extends CustomOAuthStrategy {
       await this.app.service(identityProviderPath).remove(null, {
         query: {
           type: 'guest',
-          userId: existingEntity.userId
+          userId: entity.userId
         }
       })
       await this.userLoginEntry(newIP, params)

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -160,7 +160,7 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
       await this.app.service(identityProviderPath).remove(null, {
         query: {
           type: 'guest',
-          userId: existingEntity.userId
+          userId: entity.userId
         }
       })
       await this.userLoginEntry(newIP, params)

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -160,7 +160,7 @@ export class TwitterStrategy extends CustomOAuthStrategy {
       await this.app.service(identityProviderPath).remove(null, {
         query: {
           type: 'guest',
-          userId: existingEntity.userId
+          userId: entity.userId
         }
       })
       await this.userLoginEntry(newIP, params)


### PR DESCRIPTION
## Summary

The SSO signup process throws an error (as shown in the image below), which is usually resolved by signing up again using the same SSO provider.

This error occurs because the code attempts to access a property on an object within a code block that is only executed when the object doesn't exist. The solution is to use entity.userId instead of existingEntity.userId.

![image](https://github.com/user-attachments/assets/a4f86a42-5649-4145-ab69-8ea80f249454)

**Note:** This should solve IR-7675 & IR-7115

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Sign up using SSO with an account that has not been used or linked to any existing user
**Expected result:** SSO authentication doesn't throw an error and user can complete signup process. 

## Evidence
https://github.com/user-attachments/assets/c6c0b587-46ff-438e-af3b-58d5e0d4ffd0


## Jira
[IR-7675](https://tsu.atlassian.net/browse/IR-7675)

[IR-7675]: https://tsu.atlassian.net/browse/IR-7675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ