### PR TITLE
add touch events to select

### DIFF
--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -100,6 +100,7 @@ const Select = ({
   const [filteredOptions, setFilteredOptions] = useState(options)
   const [searchString, setSearchString] = useState('')
   const fuseRef = useRef<Fuse<OptionType> | null>(null)
+  const [touchMoved, setTouchedMoved] = useState(false)
   const localValue = useHookstate(value)
   const id = useId()
   const [triggerWidth, setTriggerWidth] = useState(0)
@@ -440,6 +441,21 @@ const Select = ({
               }}
               onMouseLeave={() => {
                 setActiveIndex(-1)
+              }}
+              onTouchStart={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+              }}
+              onTouchMove={() => setTouchedMoved(true)}
+              onTouchEnd={() => {
+                if (!touchMoved) {
+                  closePopup()
+                  localValue.set(currentValue)
+                  setSelectedOptionIndex(index)
+                  setDisplayText(optionProps.label)
+                  onChange(currentValue)
+                }
+                setTouchedMoved(false)
               }}
               onKeyUp={(e) => {
                 if (e.code === 'Enter') {


### PR DESCRIPTION
## Summary

previously, touch events on select used to have event propagated which closed the modal
now, touch events work properly with browsing the menu and selecting an item

`touchmove` is added to not close the dropdown items when the select menu items are browsed using touch

## References
closes #_insert number here_

## QA Steps

use browser's touch system to check this