### PR TITLE
fixed prefab instantiation issue with node ID and uuid

### DIFF
--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -164,6 +164,7 @@ export async function addMediaNode(
           const newSource = GLTFComponent.getInstanceID(rootEntity)
           for (const entity of entities) {
             setComponent(entity, SourceComponent, newSource)
+            setComponent(entity, NodeIDComponent, NodeIDComponent.generate())
             setComponent(
               entity,
               UUIDComponent,


### PR DESCRIPTION
updated the prefab instantiation to update the node id with a newly generated node id to prevent the prefabs instances from all having the same UUIDs, which causes issues with selecting individual ones

## Summary
https://tsu.atlassian.net/browse/IR-7519
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
