### PR TITLE
IR-5235 fix for saving new entities to prefabs

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.test.tsx
+++ b/packages/editor/src/functions/EditorControlFunctions.test.tsx
@@ -44,14 +44,15 @@ import { createEngine, destroyEngine } from '@ir-engine/ecs/src/Engine'
 import { Entity, UndefinedEntity } from '@ir-engine/ecs/src/Entity'
 import { AssetState } from '@ir-engine/engine/src/gltf/GLTFState'
 import { SplineComponent } from '@ir-engine/engine/src/scene/components/SplineComponent'
-import { getMutableState } from '@ir-engine/hyperflux'
+import { getMutableState, getState } from '@ir-engine/hyperflux'
 import { HemisphereLightComponent, TransformComponent } from '@ir-engine/spatial'
 import { VisibleComponent } from '@ir-engine/spatial/src/renderer/components/VisibleComponent'
 
 import { EntityTreeComponent } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { NodeFunctions } from '@ir-engine/engine/src/gltf/NodeFunctions'
-import { NodeID, NodeIDComponent } from '@ir-engine/engine/src/gltf/NodeIDComponent'
+import { NodeID, NodeIDComponent, NodesBySourceState } from '@ir-engine/engine/src/gltf/NodeIDComponent'
+import { SourceComponent } from '@ir-engine/engine/src/scene/components/SourceComponent'
 import { startEngineReactor } from '@ir-engine/engine/tests/startEngineReactor'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
 import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics'
@@ -895,6 +896,89 @@ describe('EditorControlFunctions', () => {
       const newEntity = getComponent(rootEntity, EntityTreeComponent).children[2]
       assert.equal(newEntity, authoringNode4Entity)
       assert.equal(getComponent(newEntity, NodeIDComponent), node4ID)
+    })
+
+    it('should reparent to another source', async () => {
+      const node1ID = NodeIDComponent.generate()
+      const node2ID = NodeIDComponent.generate()
+      const node3ID = NodeIDComponent.generate()
+
+      const gltf: GLTF.IGLTF = {
+        asset: {
+          version: '2.0'
+        },
+        scenes: [{ nodes: [0, 1] }],
+        scene: 0,
+        nodes: [
+          {
+            name: 'node1',
+            extensions: {
+              [NodeIDComponent.jsonID]: node1ID,
+              [GLTFComponent.jsonID]: {
+                src: '/sub-asset.gltf'
+              }
+            }
+          },
+          {
+            name: 'node2',
+            extensions: {
+              [NodeIDComponent.jsonID]: node2ID
+            }
+          }
+        ]
+      }
+
+      const subAssetGLTF: GLTF.IGLTF = {
+        asset: {
+          version: '2.0'
+        },
+        scenes: [{ nodes: [0] }],
+        scene: 0,
+        nodes: [
+          {
+            name: 'node3',
+            extensions: {
+              [NodeIDComponent.jsonID]: node3ID
+            }
+          }
+        ]
+      }
+
+      Cache.add('/test.gltf', gltf)
+      Cache.add('/sub-asset.gltf', subAssetGLTF)
+      const rootEntity = AssetState.load('/test.gltf', undefined, physicsWorldEntity, Layers.Authoring)
+      getMutableState(EditorState).rootEntity.set(rootEntity)
+      await waitForScene(rootEntity)
+
+      const simulationNode1Entity = NodeFunctions.getEntityFromNodeID(rootEntity, node1ID)!
+      const authoringNode1Entity = LayerFunctions.getAuthoringCounterpart(simulationNode1Entity)
+
+      const simulationNode2Entity = NodeFunctions.getEntityFromNodeID(rootEntity, node2ID)!
+      const authoringNode2Entity = LayerFunctions.getAuthoringCounterpart(simulationNode2Entity)
+
+      const subAssetSourceID = GLTFComponent.getInstanceID(simulationNode1Entity)
+
+      const simulationNode3Entity = UUIDComponent.getEntityByUUID(
+        NodeIDComponent.getUUIDBySourceAndNodeID(subAssetSourceID, node3ID)!
+      )
+      const authoringNode3Entity = LayerFunctions.getAuthoringCounterpart(simulationNode3Entity)
+
+      EditorControlFunctions.reparentObject([authoringNode2Entity], null, null, authoringNode3Entity)
+
+      await vi.waitUntil(() => getState(NodesBySourceState)[subAssetSourceID][node3ID])
+
+      const reparentedSimulationNode2Entity = NodeFunctions.getEntityFromNodeID(authoringNode1Entity, node2ID)!
+      const reparentedAuthoringNode2Entity = LayerFunctions.getAuthoringCounterpart(reparentedSimulationNode2Entity)
+
+      assert.equal(reparentedAuthoringNode2Entity, authoringNode2Entity)
+      assert.equal(getComponent(reparentedAuthoringNode2Entity, NodeIDComponent), node2ID)
+      assert.equal(
+        getComponent(reparentedAuthoringNode2Entity, SourceComponent),
+        getComponent(authoringNode3Entity, SourceComponent)
+      )
+      assert.equal(getComponent(reparentedAuthoringNode2Entity, EntityTreeComponent).parentEntity, authoringNode3Entity)
+      const expectedUUID = NodeIDComponent.getUUIDBySourceAndNodeID(subAssetSourceID, node2ID)
+      assert.equal(getComponent(reparentedAuthoringNode2Entity, UUIDComponent), expectedUUID)
     })
   })
 

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -33,7 +33,6 @@ import {
   getAncestorWithComponents,
   getChildrenWithComponents,
   iterateEntityNode,
-  UndefinedEntity,
   UUIDComponent
 } from '@ir-engine/ecs'
 import {
@@ -520,17 +519,11 @@ const reparentObject = (
     EditorControlFunctions.rotateObject([entity], [worldRotation], TransformSpace.world)
     worldScaleObject([entity], [worldScale])
 
-    /** @todo handle the entity changing sources */
+    const newSourceID = hasComponent(parent, GLTFComponent)
+      ? GLTFComponent.getInstanceID(parent)
+      : getComponent(parent, SourceComponent)
+    setComponent(entity, SourceComponent, newSourceID)
     EditorState.markModifiedScene(entity)
-
-    const gltfAncestor = getAncestorWithComponents(entity, [GLTFComponent])
-    if (gltfAncestor !== UndefinedEntity) {
-      const sourceID = GLTFComponent.getInstanceID(gltfAncestor)
-      if (sourceID) {
-        const modifiedState = getMutableState(AssetModifiedState)
-        modifiedState[sourceID].set(true)
-      }
-    }
   }
 }
 

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -523,6 +523,12 @@ const reparentObject = (
       ? GLTFComponent.getInstanceID(parent)
       : getComponent(parent, SourceComponent)
     setComponent(entity, SourceComponent, newSourceID)
+    setComponent(
+      entity,
+      UUIDComponent,
+      NodeIDComponent.getUUIDBySourceAndNodeID(newSourceID, getComponent(entity, NodeIDComponent))
+    )
+
     EditorState.markModifiedScene(entity)
   }
 }

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -33,6 +33,7 @@ import {
   getAncestorWithComponents,
   getChildrenWithComponents,
   iterateEntityNode,
+  UndefinedEntity,
   UUIDComponent
 } from '@ir-engine/ecs'
 import {
@@ -521,6 +522,15 @@ const reparentObject = (
 
     /** @todo handle the entity changing sources */
     EditorState.markModifiedScene(entity)
+
+    const gltfAncestor = getAncestorWithComponents(entity, [GLTFComponent])
+    if (gltfAncestor !== UndefinedEntity) {
+      const sourceID = GLTFComponent.getInstanceID(gltfAncestor)
+      if (sourceID) {
+        const modifiedState = getMutableState(AssetModifiedState)
+        modifiedState[sourceID].set(true)
+      }
+    }
   }
 }
 

--- a/packages/editor/src/services/EditorHistoryState.tsx
+++ b/packages/editor/src/services/EditorHistoryState.tsx
@@ -325,7 +325,10 @@ export const applyCommandsToECS = (sourceID: SourceID, currentState: SourceData,
       // entity does not exist, remove entity
       const uuid = NodeIDComponent.getUUIDBySourceAndNodeID(sourceID, nodeID)
       const entity = UUIDComponent.getEntityByUUID(uuid, Layers.Authoring)
-      removeEntity(entity)
+      // ensure the entity has actually been removed, and not moved to another source
+      if (getComponent(entity, SourceComponent) === sourceID) {
+        removeEntity(entity)
+      }
     }
   }
 }

--- a/packages/engine/src/gltf/exportGLTFScene.ts
+++ b/packages/engine/src/gltf/exportGLTFScene.ts
@@ -876,9 +876,9 @@ const exportGLTFSceneNode = async (
 
   const children = getOptionalComponent(entity, EntityTreeComponent)?.children
   const childrenIndicies = [] as number[]
-  //instead of comparing source, just skip recursive support of the children of prefab entities that are THEMSELVES nested prefabs
-  if (!hasComponent(entity, GLTFComponent) && children && children.length > 0) {
+  if (children && children.length > 0) {
     for (const child of children) {
+      if (getComponent(child, SourceComponent) !== context.sourceID) continue
       const childIndex = await exportGLTFSceneNode(child, gltf, context)
       if (typeof childIndex === 'number') childrenIndicies.push(childIndex)
     }

--- a/packages/engine/src/gltf/exportGLTFScene.ts
+++ b/packages/engine/src/gltf/exportGLTFScene.ts
@@ -876,9 +876,9 @@ const exportGLTFSceneNode = async (
 
   const children = getOptionalComponent(entity, EntityTreeComponent)?.children
   const childrenIndicies = [] as number[]
-  if (children && children.length > 0) {
+  //instead of comparing source, just skip recursive support of the children of prefab entities that are THEMSELVES nested prefabs
+  if (!hasComponent(entity, GLTFComponent) && children && children.length > 0) {
     for (const child of children) {
-      if (getComponent(child, SourceComponent) !== context.sourceID) continue
       const childIndex = await exportGLTFSceneNode(child, gltf, context)
       if (typeof childIndex === 'number') childrenIndicies.push(childIndex)
     }


### PR DESCRIPTION
## Summary
fix for saving new entities to prefabs (bad condition check when crawling prefab children)- marks the ancestor gltf as modified as well

## References
[https://tsu.atlassian.net/browse/IR-5235](https://tsu.atlassian.net/browse/IR-5235)

## QA Steps
drag a new entity into the prefab hierarchy (not the root of it, but somewhere under it's child or grandchildren etc)
observe the save icon in the hierarchy on the prefab root
save the prefab with the icon or the right click
go to files tab in the assets view
navigate up to your project root, then down to assets/custom-prefabs (or wherever you saved it)
drag in your updated prefab
observe it has the new entity included
