### PR TITLE
fix(locations): display the correct scenes by user access [IR-7035]

### DIFF
--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -107,16 +107,19 @@ const locationTypeOptions = [
 
 const LOCATION_MAX = 10
 
-export default function AddEditLocationModal(props: {
+type AddEditLocationModalProps = Readonly<{
   action: string
   location?: LocationType
   sceneID?: string | null
   sceneModified?: boolean
   inStudio?: boolean
+  projectFullName?: string
 
   onPublish?: () => Promise<void>
   onPublishSuccess?: (location: LocationType) => void
-}) {
+}>
+
+export default function AddEditLocationModal(props: AddEditLocationModalProps) {
   const { t } = useTranslation()
   const compressionLoading = useHookstate(false)
   const locationID = useHookstate(props.location?.id || null)
@@ -165,12 +168,16 @@ export default function AddEditLocationModal(props: {
     }
   }, [location])
 
+  const projectQueryParam = props.action === 'studio' && !props.inStudio ? props.projectFullName : undefined
+
   const scenes = useFind(staticResourcePath, {
     query: {
       paginate: false,
-      type: 'scene'
+      type: 'scene',
+      project: projectQueryParam
     }
   })
+
   const handlePublishFolder = async () => {
     PopoverState.showPopupover(<CompressedPublishConfirmation />)
     const { projectName, sceneName, rootEntity, sceneAssetID, scenePath } = getState(EditorState)

--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -18,7 +18,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import React, { lazy, useEffect } from 'react'
+import React, { lazy, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
@@ -177,6 +177,26 @@ export default function AddEditLocationModal(props: AddEditLocationModalProps) {
       project: projectQueryParam
     }
   })
+
+  const scenesOptions = useMemo(() => {
+    if (scenes.status === 'pending') {
+      return [{ value: '', label: t('common:select.fetching') }]
+    }
+    if (scenes.status === 'success' && scenes.data.length) {
+      return [
+        { value: '', label: t('admin:components.location.selectScene'), disabled: true },
+        ...scenes.data.map((scene) => {
+          const project = scene.project
+          const name = scene.key.split('/').pop()!.split('.').at(0)!
+          return {
+            label: `${name} (${project})`,
+            value: scene.id
+          }
+        })
+      ]
+    }
+    return []
+  }, [scenes])
 
   const handlePublishFolder = async () => {
     PopoverState.showPopupover(<CompressedPublishConfirmation />)
@@ -490,21 +510,7 @@ export default function AddEditLocationModal(props: AddEditLocationModalProps) {
               value={scene.value}
               onChange={(value: string) => scene.set(value)}
               disabled={!!props.sceneID || scenes.status !== 'success' || isLoading}
-              options={
-                scenes.status === 'pending'
-                  ? [{ value: '', label: t('common:select.fetching') }]
-                  : [
-                      { value: '', label: t('admin:components.location.selectScene'), disabled: true },
-                      ...scenes.data.map((scene) => {
-                        const project = scene.project
-                        const name = scene.key.split('/').pop()!.split('.').at(0)!
-                        return {
-                          label: `${name} (${project})`,
-                          value: scene.id
-                        }
-                      })
-                    ]
-              }
+              options={scenesOptions}
               state={errors.scene.value ? 'error' : undefined}
               helperText={errors.scene.value}
               width="full"

--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -180,11 +180,13 @@ const Select = ({
   }, [value, localValue, selectedOptionIndex, filteredOptions])
 
   useEffect(() => {
-    const index = filteredOptions.findIndex((option) => option.value === localValue.value)
-    if (index !== -1) {
-      setDisplayText(filteredOptions[index].label)
+    if (filteredOptions.length) {
+      const index = filteredOptions.findIndex((option) => option.value === localValue.value)
+      if (index !== -1) {
+        setDisplayText(filteredOptions[index].label)
+      }
     }
-  }, [localValue])
+  }, [localValue, filteredOptions])
 
   useEffect(() => {
     if (searchString === '') {


### PR DESCRIPTION
## Summary
- Display the scenes by account access

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
- Open Studio
- Navigate to My Locations on the Dashboard
- Click Edit button for any published location
- Click the 'Scene' drop down
- Check if available scenes belongs to the current account
- 
## Evidence
<img width="890" alt="Screenshot 2025-03-05 at 11 10 32 p m" src="https://github.com/user-attachments/assets/28f0998a-b6cb-47bd-a92b-a13dedcbc8a2" />

## Jira
[IR-7035](https://tsu.atlassian.net/browse/IR-7035)

## Related
https://github.com/theinfinitereality/irpro-multitenancy/pull/779


[IR-7035]: https://tsu.atlassian.net/browse/IR-7035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ