### PR TITLE
Fix IR-6953: Improve Context and Error messages and validation in the studio at upload files and folders

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -69,7 +69,7 @@
     "sceneCreationFail": "Scene creation failed. {{reason}}",
     "uploadAborted": "Upload aborted",
     "uploadFailed": "Upload failed {{reason}}",
-    "fileUploadFailed": "File upload failed",
+    "fileUploadFailed": "File upload failed; {{reason}}",
     "assetDeletionFail": "Asset deletion failed. {{reason}}",
     "projectAssetDeletionFail": "Project Asset deletion failed. {{reason}}",
     "networkError": "Network Error: {{status}}. {{text}}",

--- a/packages/client-core/src/common/services/NotificationService.tsx
+++ b/packages/client-core/src/common/services/NotificationService.tsx
@@ -47,6 +47,7 @@ export type NotificationOptions = {
   persist?: boolean
   style?: CSSProperties
   hideIconVariant?: boolean
+  autoHideDuration?: number
 }
 
 export const defaultAction = (key: SnackbarKey, content?: React.ReactNode) => {
@@ -85,7 +86,8 @@ export const NotificationService = {
       action: NotificationActions[options.actionType ?? 'default'],
       persist: options.persist,
       style: options.style,
-      hideIconVariant: options.hideIconVariant
+      hideIconVariant: options.hideIconVariant,
+      autoHideDuration: options.autoHideDuration ?? 5000
     })
   },
   closeNotification(key: SnackbarKey) {

--- a/packages/client-core/src/util/upload.tsx
+++ b/packages/client-core/src/util/upload.tsx
@@ -143,7 +143,7 @@ export const uploadToFeathersService = (
           } else {
             if (aborted) return
             console.error('Oh no! There has been an error with the request!', request, e)
-            if (status === 403) {
+            if (status === 403 || status === 400) {
               const errorResponse = JSON.parse(request.responseText)
               reject(new Error(errorResponse.message))
             } else {

--- a/packages/common/src/regex/index.ts
+++ b/packages/common/src/regex/index.ts
@@ -25,20 +25,31 @@ Infinite Reality Engine. All Rights Reserved.
 
 // Add unit tests for new patterns in packages/common/tests/regex.test.ts
 
-/*
-A filename is valid if:
-  - it has 4 to 64 characters
-  - its first and last character are alphanumeric
-  - any other characters are either alphanumeric, '_', '-', or '.'
-*/
-
-// eslint-disable-next-line no-control-regex
-export const VALID_FILENAME_REGEX = /^([^_\W])([\w\-_.]{2,126})([^_\W])$/
+/**
+ * Regular expression for validating filenames with the following rules:
+ * - Must start with an alphanumeric character [a-zA-Z0-9]
+ * - Must end with an alphanumeric character [a-zA-Z0-9]
+ * - Middle characters (2-62 chars) can contain:
+ *   - Alphanumeric characters [a-zA-Z0-9]
+ *   - Underscores (_)
+ *   - Hyphens (-)
+ *   - Spaces
+ *   - Dots (.)
+ * - Total length must be between 4-64 characters (2 for ends + 2-62 for middle)
+ *
+ * @example
+ * // Valid filenames:
+ * "hello-world.txt"     // true
+ * "Screenshot 2023 1"    // true
+ * "my_file_v1.0"        // true
+ *
+ * // Invalid filenames:
+ * "_hello.txt"          // false (starts with underscore)
+ * "file."               // false (ends with dot)
+ * "a.b"                 // false (too short)
+ */
+export const VALID_FILENAME_REGEX = /^[a-zA-Z0-9][\w\-\s.]{2,62}[a-zA-Z0-9]$/
 export const VALID_EXTENSION_REGEX = /^(\w{2,4})$/
-export const SANITIZE_FILENAME_REGEX = /[^a-zA-Z0-9._-]+/g
-export const START_WITH_ALPHANUMERIC_REGEX = /^[^a-zA-Z0-9]+/
-export const END_WITH_ALPHANUMERIC_REGEX = /[^a-zA-Z0-9]+$/
-// eslint-disable-next-line no-control-regex
 export const WINDOWS_RESERVED_NAME_REGEX = /^(con|prn|aux|nul|com\d|lpt\d)$/i
 export const VALID_SCENE_NAME_REGEX = VALID_FILENAME_REGEX
 export const VALID_HEIRARCHY_SEARCH_REGEX = /[.*+?^${}()|[\]\\]/g

--- a/packages/common/src/utils/cleanFileName.test.ts
+++ b/packages/common/src/utils/cleanFileName.test.ts
@@ -25,86 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import assert from 'assert'
 import { describe, it } from 'vitest'
-import { cleanFileNameString, getDecodedFileName, getEncodedFileName } from './cleanFileName'
-
-describe('getEncodedFileName', () => {
-  it('should handle normal text without special characters', () => {
-    assert.equal(getEncodedFileName('hello'), 'hello')
-    assert.equal(getEncodedFileName('hello world'), 'hello-world')
-  })
-
-  it('should preserve hyphens by doubling them', () => {
-    assert.equal(getEncodedFileName('hello-world'), 'hello--world')
-    assert.equal(getEncodedFileName('test-file-name'), 'test--file--name')
-  })
-
-  it('should handle parentheses', () => {
-    assert.equal(getEncodedFileName('(test)'), 'x__test--y')
-    assert.equal(getEncodedFileName('(2)'), 'x__2--y')
-  })
-
-  it('should handle spaces and special characters', () => {
-    assert.equal(getEncodedFileName('test - file'), 'test----file')
-    assert.equal(getEncodedFileName(' space '), 'x-space-y')
-  })
-
-  it('should handle folder names with numbers in parentheses', () => {
-    assert.equal(getEncodedFileName('New Folder (1)'), 'New-Folder__1--y')
-    assert.equal(getEncodedFileName('New Folder (2)'), 'New-Folder__2--y')
-    assert.equal(getEncodedFileName('folder (10)'), 'folder__10--y')
-    assert.equal(getEncodedFileName('test folder (1) '), 'test-folder__1--y')
-  })
-
-  it('should handle folder names with hyphens and numbers in parentheses', () => {
-    assert.equal(getEncodedFileName('my-folder (1)'), 'my--folder__1--y')
-    assert.equal(getEncodedFileName('test-folder (2)'), 'test--folder__2--y')
-  })
-})
-
-describe('getDecodedFileName', () => {
-  it('should handle normal text without special characters', () => {
-    assert.equal(getDecodedFileName('hello'), 'hello')
-    assert.equal(getDecodedFileName('hello-world'), 'hello world')
-  })
-
-  it('should decode double hyphens back to single hyphen', () => {
-    assert.equal(getDecodedFileName('hello--world'), 'hello-world')
-    assert.equal(getDecodedFileName('test--file--name'), 'test-file-name')
-  })
-
-  it('should decode encoded parentheses', () => {
-    assert.equal(getDecodedFileName('folder-_1-y'), 'folder (1)')
-    assert.equal(getDecodedFileName('x_2-y'), '(2)')
-  })
-
-  it('should handle numbers correctly', () => {
-    assert.equal(getDecodedFileName('version-2'), 'version 2')
-    assert.equal(getDecodedFileName('v2-test'), 'v2 test')
-    assert.equal(getDecodedFileName('test-2-v3'), 'test 2 v3')
-  })
-
-  it('should properly decode folder names with numbers', () => {
-    assert.equal(getDecodedFileName('New-Folder_1-'), 'New Folder (1)')
-    assert.equal(getDecodedFileName('folder_10-'), 'folder (10)')
-    assert.equal(getDecodedFileName('test-folder_1-'), 'test folder (1)')
-    assert.equal(getDecodedFileName('my--folder_1-'), 'my-folder (1)')
-  })
-
-  it('should maintain proper spacing around parentheses', () => {
-    assert.equal(getDecodedFileName('New-Folder_1-'), 'New Folder (1)')
-    assert.equal(getDecodedFileName('test--new-folder_2-'), 'test-new folder (2)')
-  })
-
-  it('should handle round-trip encoding and decoding', () => {
-    const testCases = ['New Folder (1)', 'test-folder (2)', 'my folder (10)', 'hello-world (1)', 'New Folder (1)']
-
-    testCases.forEach((original) => {
-      const encoded = getEncodedFileName(original)
-      const decoded = getDecodedFileName(encoded)
-      assert.equal(decoded, original.trim())
-    })
-  })
-})
+import { cleanFileNameString } from './cleanFileName'
 
 describe('cleanFileNameString', () => {
   it('should return a cleaned version of the filename', () => {
@@ -128,6 +49,6 @@ describe('cleanFileNameString', () => {
   it('should respect multiple spaces in the file name', () => {
     const fullFileName = 'path/to/file/file name with spaces.txt'
     const result = cleanFileNameString(fullFileName)
-    assert.equal(result, 'path/to/file/file-name-with-spaces.txt')
+    assert.equal(result, 'path/to/file/file name with spaces.txt')
   })
 })

--- a/packages/common/src/utils/cleanFileName.ts
+++ b/packages/common/src/utils/cleanFileName.ts
@@ -23,96 +23,6 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { END_WITH_ALPHANUMERIC_REGEX, SANITIZE_FILENAME_REGEX, START_WITH_ALPHANUMERIC_REGEX } from '../regex'
-
-/**
- * Encodes a filename by replacing special characters with a safe format:
- * 1. Converts parentheses to underscores/hyphens: '(' -> '_', ')' -> '-'
- * 2. Preserves existing hyphens by doubling them: '-' -> '--'
- * 3. Converts spaces to single hyphens
- * 4. Adds 'x' prefix if filename starts with special chars
- * 5. Adds 'y' suffix if filename ends with special chars
- *
- * @param displayName - The original filename to encode
- * @returns The encoded filename safe for storage/transmission
- *
- * @example
- * // Returns "hello--world"
- * getEncodedFileName("hello-world")
- *
- * // Returns "x_test-y"
- * getEncodedFileName("(test)")
- *
- * // Returns "my-file-name"
- * getEncodedFileName("my file name")
- */
-export const getEncodedFileName = (displayName: string) => {
-  let encoded = displayName
-    .replace(/\s*\(\s*(\d+)\s*\)\s*/g, '_$1-') // handle (number) pattern with any spaces
-    .replace(/\(/g, '_') // remaining opening parenthesis to underscore
-    .replace(/\)/g, '-') // remaining closing parenthesis to hyphen
-    .replace(/--/g, '§') // temporarily store double hyphens
-    .replace(/__/g, '¤') // temporarily store double underscores
-    .replace(/-/g, '--') // double all single hyphens
-    .replace(/_/g, '__') // double all single underscores
-    .replace(/§/g, '--') // restore original double hyphens
-    .replace(/¤/g, '__') // restore original double underscores
-    .replace(/\s+/g, '-') // convert spaces to single hyphens
-
-  // Add 'x' at the beginning if it starts with special characters
-  if (/^[-_]/.test(encoded)) {
-    encoded = 'x' + encoded
-  }
-  // Add 'y' at the end if it ends with special characters
-  if (/[-_]$/.test(encoded)) {
-    encoded = encoded + 'y'
-  }
-  return encoded
-}
-
-/**
- * Decodes a filename that was previously encoded by getEncodedFileName by:
- * 1. Removing 'x' prefix and 'y' suffix if they were added during encoding
- * 2. Converting underscores back to opening parentheses '(' in specific positions
- * 3. Converting hyphens back to closing parentheses ')' when appropriate
- * 4. Restoring original hyphens that were doubled during encoding
- * 5. Converting remaining single hyphens back to spaces
- *
- * @param encodedName - The encoded filename to decode
- * @returns The original filename with special characters restored
- *
- * @example
- * // Returns "hello-world"
- * getDecodedFileName("hello--world")
- *
- * // Returns "(test)"
- * getDecodedFileName("x_test-y")
- *
- * // Returns "my file name"
- * getDecodedFileName("my-file-name")
- */
-export const getDecodedFileName = (encodedName: string) => {
-  let decoded = encodedName
-  // Remove added characters if they were added during encoding
-  if (decoded.startsWith('x') && /^x[-_]/.test(decoded)) {
-    decoded = decoded.slice(1)
-  }
-  if (decoded.endsWith('y') && /[-_]y$/.test(decoded)) {
-    decoded = decoded.slice(0, -1)
-  }
-
-  return decoded
-    .replace(/_(\d+)-/g, ' ($1)') // handle _number- pattern with proper spacing
-    .replace(/--/g, '§') // temporarily store double hyphens
-    .replace(/__/g, '¤') // temporarily store double underscores
-    .replace(/-/g, ' ') // convert single hyphens to spaces
-    .replace(/_/g, ' ') // convert single underscores to spaces
-    .replace(/§/g, '-') // restore original hyphens
-    .replace(/¤/g, '_') // restore original underscores
-    .replace(/\s+/g, ' ') // normalize multiple spaces to single space
-    .trim() // remove any leading/trailing spaces
-}
-
 /**
  * This method takes a filename (with or without included path) and returns a cleaned version of it.
  * Ensures toLower file extension, truncates a file name if too long, and sanitizes special characters
@@ -139,11 +49,6 @@ export const cleanFileNameString = (fullFileName: string, useStorageProviderLeng
     if (useStorageProviderLengthRestrictions) {
       if (nameWithoutExtension.length > 1024) nameWithoutExtension = nameWithoutExtension.slice(0, 1024)
     } else {
-      // Sanitize the name part and skiped if needed in the server
-      nameWithoutExtension = nameWithoutExtension
-        .replace(SANITIZE_FILENAME_REGEX, '-')
-        .replace(START_WITH_ALPHANUMERIC_REGEX, '')
-        .replace(END_WITH_ALPHANUMERIC_REGEX, '')
       // Truncate or concat the name if it is too long or too short
       if (nameWithoutExtension.length > 64) {
         nameWithoutExtension = nameWithoutExtension.slice(0, 64)

--- a/packages/common/src/utils/validateFileName.ts
+++ b/packages/common/src/utils/validateFileName.ts
@@ -30,14 +30,40 @@ import {
   WINDOWS_RESERVED_NAME_REGEX
 } from '@ir-engine/common/src/regex'
 
-export function isValidFileName(fileName: string) {
-  return VALID_FILENAME_REGEX.test(fileName) && !WINDOWS_RESERVED_NAME_REGEX.test(fileName)
+export function isValidFileName(fileName: string): { isValid: boolean; error?: string } {
+  if (!VALID_FILENAME_REGEX.test(fileName)) {
+    return {
+      isValid: false,
+      error: `Invalid name: ${fileName}; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.`
+    }
+  }
+
+  if (WINDOWS_RESERVED_NAME_REGEX.test(fileName)) {
+    return {
+      isValid: false,
+      error: 'Name cannot be a Windows reserved name'
+    }
+  }
+
+  return { isValid: true }
 }
 
-export function isValidFilePath(path: string) {
-  return PATH_REGEX.test(path)
+export function isValidFilePath(path: string): { isValid: boolean; error?: string } {
+  if (!PATH_REGEX.test(path)) {
+    return {
+      isValid: false,
+      error: `Invalid path: ${path}; directories can only contain alphanumeric characters, dashes, underscores, dots, and @`
+    }
+  }
+  return { isValid: true }
 }
 
-export function isValidFileExtension(extension: string) {
-  return VALID_EXTENSION_REGEX.test(extension)
+export function isValidFileExtension(extension: string): { isValid: boolean; error?: string } {
+  if (!VALID_EXTENSION_REGEX.test(extension)) {
+    return {
+      isValid: false,
+      error: `Invalid file extension: ${extension}; file extension must be 2-4 alphanumeric characters`
+    }
+  }
+  return { isValid: true }
 }

--- a/packages/common/tests/regex.test.ts
+++ b/packages/common/tests/regex.test.ts
@@ -61,8 +61,6 @@ describe('regex.test', () => {
         'question?mark',
         'asterisk*char',
         'control\0char',
-        'another\ncontrol',
-        'file name',
         '< tag >',
         'key : value',
         'quote " example',

--- a/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
@@ -27,6 +27,7 @@ import { PopoverState } from '@ir-engine/client-core/src/common/services/Popover
 import { API } from '@ir-engine/common'
 import config from '@ir-engine/common/src/config'
 import { staticResourcePath } from '@ir-engine/common/src/schema.type.module'
+import { isValidFileName } from '@ir-engine/common/src/utils/validateFileName'
 import {
   Component,
   Entity,
@@ -62,6 +63,7 @@ import { SelectionState } from '../../services/SelectionServices'
 export default function CreatePrefabPanel({ entity, isExportLookDev }: { entity?: Entity; isExportLookDev?: boolean }) {
   const defaultPrefabFolder = useHookstate<string>('assets/custom-prefabs')
   const prefabName = useHookstate<string>('prefab')
+  const resultFileName = useHookstate(isValidFileName(prefabName.value))
   const prefabTag = useHookstate<string[]>(['prefab'])
   const { t } = useTranslation()
   const isOverwriteModalVisible = useHookstate(false)
@@ -210,6 +212,7 @@ export default function CreatePrefabPanel({ entity, isExportLookDev }: { entity?
           onSubmit={onExportPrefab}
           className="w-[50vw] max-w-2xl"
           onClose={PopoverState.hidePopupover}
+          submitButtonDisabled={!resultFileName.value.isValid}
         >
           <Input
             value={defaultPrefabFolder.value}
@@ -221,12 +224,18 @@ export default function CreatePrefabPanel({ entity, isExportLookDev }: { entity?
           />
           <Input
             value={prefabName.value}
-            onChange={(event) => prefabName.set(event.target.value)}
+            onChange={(event) => {
+              resultFileName.set(isValidFileName(event.target.value))
+              prefabName.set(event.target.value)
+            }}
             labelProps={{
               text: 'Name',
               position: 'top'
             }}
+            minLength={4}
             maxLength={64}
+            state={!resultFileName.value.isValid ? 'error' : undefined}
+            helperText={!resultFileName.value.isValid ? resultFileName.value.error : undefined}
           />
           {!isExportLookDev && (
             <div>

--- a/packages/editor/src/components/dialogs/SavePrefabDialog.tsx
+++ b/packages/editor/src/components/dialogs/SavePrefabDialog.tsx
@@ -24,14 +24,13 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
-import { cleanFileNameString } from '@ir-engine/common/src/utils/cleanFileName.ts'
+import { isValidFileName } from '@ir-engine/common/src/utils/validateFileName'
 import { getComponent, hasComponent } from '@ir-engine/ecs'
 import { STATIC_ASSET_REGEX } from '@ir-engine/engine/src/assets/functions/pathResolver'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { getState, useHookstate } from '@ir-engine/hyperflux'
 import { Input } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
-import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { exportRelativeGLTF } from '../../functions/exportGLTF'
@@ -43,10 +42,10 @@ export default function SavePrefabPanel({ entity }) {
     throw new Error('Cannot save a prefab that has no GLTF Component on root entity')
   const gltfComponent = getComponent(entity, GLTFComponent)
   const srcPath = useHookstate(STATIC_ASSET_REGEX.exec(gltfComponent.src)?.[3].replace(/\.[^.]*$/, ''))
-  const pathIssues = cleanFileNameString(srcPath.value ?? '') !== srcPath.value
+  const fileName = (srcPath.value ?? '').split('/').pop() ?? ''
+  const resultFileName = useHookstate(isValidFileName(fileName))
 
   const onSavePrefab = async () => {
-    const isGLTF = gltfComponent.src.endsWith('gltf')
     const saveName = srcPath.value + '.gltf'
     await exportRelativeGLTF(entity, getState(EditorState).projectName!, saveName, false)
     PopoverState.hidePopupover()
@@ -56,21 +55,24 @@ export default function SavePrefabPanel({ entity }) {
     <Modal
       title={t('editor:dialog.savePrefab.title')}
       onSubmit={onSavePrefab}
-      submitButtonDisabled={pathIssues}
+      submitButtonDisabled={!resultFileName.isValid.value}
       className="w-[50vw] max-w-2xl"
       onClose={PopoverState.hidePopupover}
     >
       <Input
         value={srcPath.value}
         onChange={(event) => {
+          const fileName = (event.target.value ?? '').split('/').pop() ?? ''
+          resultFileName.set(isValidFileName(fileName))
           srcPath.set(event.target.value)
         }}
         labelProps={{
           text: t('editor:dialog.savePrefab.lbl-save-path'),
           position: 'top'
         }}
+        state={!resultFileName.value.isValid ? 'error' : undefined}
+        helperText={!resultFileName.value.isValid ? resultFileName.value.error : undefined}
       />
-      {pathIssues && <Text className="ml-5 text-red-400">{t('editor:dialog.savePrefab.warn-save-path')}</Text>}
     </Modal>
   )
 }

--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -243,7 +243,6 @@ export const handleUploadFiles = (
       })
         .promise.then((response) => {
           //get the static resource record for this file, so we can make it's thumbnail null, since it was oerwritten
-
           const checkStaticResourceThumbnail = async (path) => {
             await API.instance
               .service(staticResourcePath)
@@ -271,9 +270,11 @@ export const handleUploadFiles = (
           removeFromFileThumbnailsSeen([file])
           return checkStaticResourceThumbnail(file)
         })
-        .catch(() => {
-          NotificationService.dispatchNotify(i18n.t('editor:errors.fileUploadFailed') as string, { variant: 'error' })
-          throw new Error('Upload failed')
+        .catch((e) => {
+          NotificationService.dispatchNotify(i18n.t('editor:errors.fileUploadFailed', { reason: e }) as string, {
+            variant: 'error',
+            autoHideDuration: 20000
+          })
         })
     })
   )

--- a/packages/editor/src/panels/assets/categories.tsx
+++ b/packages/editor/src/panels/assets/categories.tsx
@@ -24,7 +24,6 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import capitalizeFirstLetter from '@ir-engine/common/src/utils/capitalizeFirstLetter'
-import { getDecodedFileName } from '@ir-engine/common/src/utils/cleanFileName'
 import { useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import EditorDropdownItem from '@ir-engine/ui/src/components/editor/DropdownItem'
 import { CubeOutlineLg, File04Lg, Folder, Pin02Lg } from '@ir-engine/ui/src/icons'
@@ -53,7 +52,7 @@ function NodeHierarchyItem({ node, onClick }: { node: AssetCategoryNode; onClick
   return (
     <>
       <EditorDropdownItem
-        label={getDecodedFileName(node.name)}
+        label={node.name}
         ItemIcon={({ className }: { className: string }) => <Folder className={className} />}
         collapsed={!isOpen}
         onClick={handleClick}

--- a/packages/editor/src/panels/files/fileitem.tsx
+++ b/packages/editor/src/panels/files/fileitem.tsx
@@ -23,7 +23,6 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { getDecodedFileName } from '@ir-engine/common/src/utils/cleanFileName'
 import { usesCtrlKey } from '@ir-engine/common/src/utils/OperatingSystemFunctions'
 import {
   FilesState,
@@ -112,7 +111,7 @@ function FileItemRow({
       >
         {file.isFolder ? <IoIosArrowForward /> : <VscBlank />}
         <FileIcon isMinified={true} thumbnailURL={thumbnailURL} type={file?.type} isFolder={file?.isFolder} />
-        <span className="text-ellipsis text-nowrap">{getDecodedFileName(file?.fullName)}</span>
+        <span className="text-ellipsis text-nowrap">{file?.fullName}</span>
       </span>
     ),
     type: file?.type.toUpperCase(),
@@ -177,7 +176,7 @@ function FileItemCard({
     >
       <FileCard
         item={file}
-        name={getDecodedFileName(file?.fullName)}
+        name={file?.fullName}
         onClick={onClick}
         onDoubleClick={file?.isFolder ? onDoubleClick : undefined}
         onLoad={undefined}

--- a/packages/editor/src/panels/files/modals/DeleteFileModal.tsx
+++ b/packages/editor/src/panels/files/modals/DeleteFileModal.tsx
@@ -30,7 +30,6 @@ import { NotificationService } from '@ir-engine/client-core/src/common/services/
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { useMutation } from '@ir-engine/common'
 import { fileBrowserPath } from '@ir-engine/common/src/schema.type.module'
-import { getDecodedFileName } from '@ir-engine/common/src/utils/cleanFileName'
 import { useHookstate } from '@ir-engine/hyperflux'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
@@ -71,9 +70,9 @@ export default function DeleteFileModal({
     >
       <Text className="w-full text-center">
         {files.length === 1
-          ? t('editor:dialog.delete.confirm-content', { content: getDecodedFileName(files[0].fullName) })
+          ? t('editor:dialog.delete.confirm-content', { content: files[0].fullName })
           : t('editor:dialog.delete.confirm-multiple', {
-              first: getDecodedFileName(files[0].fullName),
+              first: files[0].fullName,
               count: files.length - 1
             })}
       </Text>

--- a/packages/editor/src/panels/files/modals/RenameFileModal.tsx
+++ b/packages/editor/src/panels/files/modals/RenameFileModal.tsx
@@ -29,7 +29,6 @@ import { useTranslation } from 'react-i18next'
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { useMutation } from '@ir-engine/common'
 import { fileBrowserPath } from '@ir-engine/common/src/schema.type.module'
-import { getDecodedFileName, getEncodedFileName } from '@ir-engine/common/src/utils/cleanFileName'
 import { isValidFileName } from '@ir-engine/common/src/utils/validateFileName'
 import { useHookstate } from '@ir-engine/hyperflux'
 import { Input } from '@ir-engine/ui'
@@ -38,19 +37,17 @@ import { FileDataType } from '../../../constants/AssetTypes'
 
 export default function RenameFileModal({ projectName, file }: { projectName: string; file: FileDataType }) {
   const { t } = useTranslation()
-  const newFileName = useHookstate(getDecodedFileName(file.name))
+  const newFileName = useHookstate(file.name)
   const fileService = useMutation(fileBrowserPath)
-  const isValid = isValidFileName(getEncodedFileName(newFileName.value))
+  const resultFileName = isValidFileName(newFileName.value)
 
   const handleSubmit = async () => {
-    const encodedName = getEncodedFileName(newFileName.value)
-
-    if (isValidFileName(encodedName)) {
+    if (resultFileName.isValid) {
       fileService.update(null, {
         oldProject: projectName,
         newProject: projectName,
         oldName: file.fullName,
-        newName: file.isFolder ? encodedName : `${encodedName}.${file.type}`,
+        newName: file.isFolder ? newFileName.value : `${newFileName.value}.${file.type}`,
         oldPath: file.path,
         newPath: file.path,
         isCopy: false
@@ -65,14 +62,14 @@ export default function RenameFileModal({ projectName, file }: { projectName: st
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
       onClose={PopoverState.hidePopupover}
-      submitButtonDisabled={!isValid}
+      submitButtonDisabled={!resultFileName.isValid}
     >
       <Input
         value={newFileName.value}
         data-testid="rename-file-input"
         onChange={(event) => newFileName.set(event.target.value)}
-        state={!isValid ? 'error' : undefined}
-        helperText={!isValid ? t('editor:layout.filebrowser.renameFileError') : undefined}
+        state={!resultFileName.isValid ? 'error' : undefined}
+        helperText={!resultFileName.isValid ? resultFileName.error : undefined}
       />
     </Modal>
   )

--- a/packages/editor/src/panels/files/toolbar.tsx
+++ b/packages/editor/src/panels/files/toolbar.tsx
@@ -26,7 +26,6 @@ Infinite Reality Engine. All Rights Reserved.
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { REMOVE_EDGE_SLASH_REGEX } from '@ir-engine/common/src/regex'
-import { getDecodedFileName } from '@ir-engine/common/src/utils/cleanFileName'
 import { NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
 import { Button, Checkbox, Input, Tooltip } from '@ir-engine/ui'
 import { Slider, ViewportButton } from '@ir-engine/ui/editor'
@@ -125,7 +124,7 @@ function BreadcrumbItems() {
               className="cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap text-base text-text-secondary hover:underline"
               data-testid={'files-panel-breadcrumb-current-directory'}
             >
-              {getDecodedFileName(file)}
+              {file}
             </span>
           ) : (
             <a
@@ -134,7 +133,7 @@ function BreadcrumbItems() {
               data-testid={`files-panel-breadcrumb-nested-level-${index}`}
             >
               <span className="cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap text-base text-text-secondary hover:underline">
-                {getDecodedFileName(file)}
+                {file}
               </span>
             </a>
           )}

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -79,12 +79,10 @@ const ensureProjectPermissionAndPublicOrAssetsDirectory = async (
   const fileNameSplit = pathSplit[pathSplit.length - 1].split('.')
   const isDirectory = fileNameSplit.length === 1
   const filePath = path.join(...pathSplit.slice(0, isDirectory ? pathSplit.length : pathSplit.length - 1))
-  if (!isValidFilePath(filePath))
-    throw new BadRequest(
-      'Invalid path: ' +
-        filePath +
-        '; directories can only contain alphanumeric characters, dashes, underscores, dots, and @'
-    )
+
+  const resultFilePath = isValidFilePath(filePath)
+
+  if (!resultFilePath.isValid) throw new BadRequest(resultFilePath.error)
   if (!isDirectory) {
     let fileName = '',
       extension = ''
@@ -95,16 +93,11 @@ const ensureProjectPermissionAndPublicOrAssetsDirectory = async (
       fileName = fileNameSplit[0]
       extension = ''
     }
-    if (!isValidFileName(fileName))
-      throw new BadRequest(
-        'Invalid file name: ' +
-          fileName +
-          '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
-      )
-    if (!isValidFileExtension(extension))
-      throw new BadRequest(
-        'Invalid file extension: ' + extension + '; file extension must be 2-4 alphanumeric characters'
-      )
+    const resultFileName = isValidFileName(fileName)
+    if (!resultFileName.isValid) throw new BadRequest(resultFileName.error)
+
+    const resultFileExtension = isValidFileExtension(extension)
+    if (!resultFileExtension.isValid) throw new BadRequest(resultFileExtension.error)
   }
 
   await verifyProjectPermission(['owner', 'editor'])({
@@ -270,12 +263,8 @@ export class FileBrowserService
 
     await ensureProjectPermissionAndPublicOrAssetsDirectory(directory, projectName, this.app, params!)
 
-    if (!isValidFilePath(joinedDirectory))
-      throw new BadRequest(
-        'Invalid directory: ' +
-          joinedDirectory +
-          '; directories can only contain alphanumeric characters, dashes, underscores, dots, and @'
-      )
+    const resultFilePath = isValidFilePath(joinedDirectory)
+    if (!resultFilePath.isValid) throw new BadRequest(resultFilePath.error)
 
     const parentPath = path.dirname(directory)
     const key = await getIncrementalName(path.basename(directory), parentPath, storageProvider, true)

--- a/packages/server-core/src/media/file-browser/file-browser.test.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.test.ts
@@ -541,9 +541,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             invalidFileFullName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
     })
@@ -565,9 +565,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             longFileFullName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
     })
@@ -589,9 +589,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             shortFileFullName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
     })
@@ -3298,9 +3298,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             invalidFileName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
 
@@ -3330,9 +3330,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             invalidFileName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
 
@@ -3362,9 +3362,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             shortFileName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
 
@@ -3392,9 +3392,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             shortFileName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
 
@@ -3422,9 +3422,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             longFileName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
 
@@ -3452,9 +3452,9 @@ describe('file-browser.test', () => {
           ),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             longFileName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
 
@@ -4076,9 +4076,9 @@ describe('file-browser.test', () => {
           }),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             shortFileName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
     })
@@ -4091,9 +4091,9 @@ describe('file-browser.test', () => {
           }),
         {
           message:
-            'Invalid file name: ' +
+            'Invalid name: ' +
             longFileName.split('.')[0] +
-            '; file names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots'
+            '; file or folder names must be 4-64 characters, start and end with an alphanumeric, and contain only alphanumerics, dashes, underscores, and dots.'
         }
       )
     })


### PR DESCRIPTION
Fix IR-6953: Improve Context and Error messages and validation in the studio at upload files and folders

Remove Encode/Decode Filename Logic and Add and improve Errors and Validation for Upload File and folders

This PR addresses the issue described in IR-6953 by removing the problematic encode/decode logic for filenames and introducing strict validation rules for uploaded filenames. The goal is to ensure filenames comply with the following requirements before upload and show up the correct context in the message errors

    Length: Must be between 4 and 64 characters.
    Format: Must start and end with an alphanumeric character (a-z, A-Z, 0-9).
    Allowed Characters: Only alphanumerics, dashes (-), underscores (_), and dots (.) are permitted.

Changes:

- Removed the encode/decode logic for filenames as it was causing unnecessary complexity and potential issues.
- Added validation to ensure filenames meet the specified criteria before allowing uploads.
- Improved error messaging to provide clear feedback when a filename fails validation.

Testing:

- Manually tested various filename scenarios to ensure compliance with the rules.

Example of Valid Filenames:

    my_file_123.txt

    document-v2.pdf

    image.01.png

Example of Invalid Filenames:

    file (too short)

    -invalid-.txt (starts/ends with a dash)

    file@name.exe (contains invalid character @)

The same validation applies to rename of the Folders

https://github.com/user-attachments/assets/58a906c5-c79b-4160-b6b4-049803a72fe5


## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
