### PR TITLE
do not show instance chat close button when age verified on mobile

### DIFF
--- a/packages/client-core/src/user/InstanceChat.tsx
+++ b/packages/client-core/src/user/InstanceChat.tsx
@@ -262,8 +262,6 @@ function MessagesWrapper() {
     isChatOpen.set(false)
   })
 
-  console.log('debug1 condition', ageVerified, isMobile)
-
   return (
     <div className="flex items-end">
       <div className="relative max-w-16">

--- a/packages/client-core/src/user/InstanceChat.tsx
+++ b/packages/client-core/src/user/InstanceChat.tsx
@@ -262,6 +262,8 @@ function MessagesWrapper() {
     isChatOpen.set(false)
   })
 
+  console.log('debug1 condition', ageVerified, isMobile)
+
   return (
     <div className="flex items-end">
       <div className="relative max-w-16">
@@ -270,20 +272,19 @@ function MessagesWrapper() {
         )}
         {isChatOpen.value && (
           <LocationIconButton
-            icon={isChatOpen.value ? XCloseLg : MessageTextSquare01Lg}
+            icon={XCloseLg}
             onClick={() => isChatOpen.set(!isChatOpen.value)}
-            className="h-[20px] w-[20px] lg:h-[24px] lg:w-[24px]"
+            className={twMerge(ageVerified && isMobile && 'hidden')}
           />
         )}
         {!isChatOpen.value && (
           <LocationIconButton
-            icon={MessageTextSquare01Md}
+            icon={isMobile ? MessageTextSquare01Md : MessageTextSquare01Lg}
             onClick={() => isChatOpen.set(!isChatOpen.value)}
-            className="h-[20px] w-[20px] lg:h-[24px] lg:w-[24px]"
           />
         )}
       </div>
-      {isChatOpen.value && (!ageVerified as any) ? (
+      {isChatOpen.value && !ageVerified ? (
         <div className="ml-[13px] rounded-lg bg-surface-4 p-4">
           <div className="mx-auto text-center font-semibold text-[#3B3A3A]">{t('user:instanceChat.wantToChat')}</div>
           <Button

--- a/packages/client-core/src/user/components/LocationIconButton.tsx
+++ b/packages/client-core/src/user/components/LocationIconButton.tsx
@@ -45,7 +45,7 @@ function LocationIconButton({
   ...props
 }: LocationIconButtonProps) {
   const Button = () => {
-    const { ref, className, ...restIconProps } = iconProps || {}
+    const { ref, className: iconClassName, ...restIconProps } = iconProps || {}
 
     return (
       <button
@@ -59,7 +59,7 @@ function LocationIconButton({
         {(loadingState && <LoadingView className="h-6 w-6" />) || (
           <Icon
             ref={() => ref}
-            className={twMerge('h-[20px] w-[20px] text-[#080808] lg:h-[24px] lg:w-[24px]', className)}
+            className={twMerge('h-[20px] w-[20px] text-[#080808] lg:h-[24px] lg:w-[24px]', iconClassName)}
             {...restIconProps}
           />
         )}


### PR DESCRIPTION
## Summary

on mobile devices, the close should not appear when the user has already age verified. it should only be shown to guest users.

## References
closes https://tsu.atlassian.net/browse/IR-7938

## QA Steps

on mobile, the close button is not visible when user is age verified
![image](https://github.com/user-attachments/assets/18bdd653-2f7c-41c5-bbb2-85b6fd97ee2f)

on mobile, the close button is visible when the user has NOT age verified
![image](https://github.com/user-attachments/assets/4c38d547-a2bc-4570-bbb4-b2bf5c7c138f)
