### PR TITLE
Material drag drop deltas

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -187,9 +187,14 @@ const updateMaterialPrototype = (materialEntity: Entity, newPrototype: string) =
 
   materialComponent.material.set(newMaterial)
   materialComponent.parameters.set({})
-  for (const key in prototype.arguments) materialComponent.parameters[key].set(prototype.arguments[key].default)
+  materialComponent.prototype.set(newPrototype)
+  // for (const key in prototype.arguments) materialComponent.parameters[key].set(prototype.arguments[key].default)
 
   EditorState.markModifiedScene(materialEntity)
+  if (!EditorState.isInActiveScene(materialEntity)) {
+    SceneDeltaState.registerMaterialDelta(materialEntity, undefined, newPrototype)
+  }
+
   return newMaterial
 }
 

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -188,7 +188,6 @@ const updateMaterialPrototype = (materialEntity: Entity, newPrototype: string) =
   materialComponent.material.set(newMaterial)
   materialComponent.parameters.set({})
   materialComponent.prototype.set(newPrototype)
-  // for (const key in prototype.arguments) materialComponent.parameters[key].set(prototype.arguments[key].default)
 
   EditorState.markModifiedScene(materialEntity)
   if (!EditorState.isInActiveScene(materialEntity)) {

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { Euler, Material, Matrix4, Quaternion, Vector3 } from 'three'
+import { Euler, Material, Matrix4, Quaternion, Texture, Vector3 } from 'three'
 
 import {
   EntityTreeComponent,
@@ -76,6 +76,7 @@ import {
 } from '@ir-engine/spatial/src/renderer/materials/MaterialComponent'
 import { extractDefaults } from '@ir-engine/spatial/src/renderer/materials/materialFunctions'
 import { computeTransformMatrix } from '@ir-engine/spatial/src/transform/systems/TransformSystem'
+import { Color } from 'three'
 import { EditorHelperState } from '../services/EditorHelperState'
 import { EditorState } from '../services/EditorServices'
 import { SelectionState } from '../services/SelectionServices'
@@ -204,31 +205,61 @@ const modifyMaterial = (nodes: string[], materialId: EntityUUID, properties: { [
     const materialEntity = UUIDComponent.getEntityByUUID(materialId, Layers.Authoring)
     const material = getComponent(materialEntity, MaterialStateComponent).material
     if (!material) return
+    if (!material) throw new Error('Updating properties on undefined material')
     const props = properties[i] ?? properties[0]
-    Object.entries(props).map(([k, v]) => {
-      if (!material) throw new Error('Updating properties on undefined material')
+    for (const [key, value] of Object.entries(props)) {
       if (
-        ![undefined, null].includes(v) &&
-        ![undefined, null].includes(material[k]) &&
-        typeof material[k] === 'object' &&
-        typeof material[k].set === 'function'
+        ![undefined, null].includes(value) &&
+        ![undefined, null].includes(material[key]) &&
+        typeof material[key] === 'object' &&
+        typeof material[key].set === 'function'
       ) {
-        material[k].set(v)
+        material[key].set(value)
       } else {
-        material[k] = v
+        material[key] = value
       }
-      getMutableComponent(materialEntity, MaterialStateComponent).parameters[k].set(v)
-    })
-    const sceneID = getComponent(materialEntity, SourceComponent)
+    }
+
+    setupMaterialParameters(materialEntity, props)
+
     getMutableComponent(
       LayerFunctions.getLayerRelationsEntities(materialEntity)![0][1],
       MaterialStateComponent
     ).material.plugins.set(material.plugins)
+
     EditorState.markModifiedScene(materialEntity)
     if (!EditorState.isInActiveScene(materialEntity)) {
-      SceneDeltaState.registerMaterialDelta(materialEntity, props)
+      SceneDeltaState.registerMaterialDelta(
+        materialEntity,
+        getComponent(materialEntity, MaterialStateComponent).parameters
+      )
     }
   }
+}
+
+/**sets up parameters for editing and serialization into a scene delta */
+const setupMaterialParameters = (entity: Entity, properties: { [_: string]: any }) => {
+  const materialComponent = getMutableComponent(entity, MaterialStateComponent)
+  const prototypeArgs = getState(MaterialPrototypeDefinitions)[materialComponent.material.type.value].arguments
+  Object.entries(properties).map(([k, v]) => {
+    if (!properties[k] || !prototypeArgs[k]?.type) return
+    console.log(properties[k], prototypeArgs[k].type)
+    switch (prototypeArgs[k].type) {
+      case 'texture': {
+        materialComponent.parameters[k].set((v as Texture).source.data.src)
+        console.log(v)
+        break
+      }
+      case 'color': {
+        materialComponent.parameters[k].set((v as Color).getHex())
+        break
+      }
+      default: {
+        materialComponent.parameters[k].set(v)
+        break
+      }
+    }
+  })
 }
 
 const lookDevComponent: Component[] = [
@@ -653,6 +684,7 @@ export const EditorControlFunctions = {
   modifyProperty,
   modifyName,
   modifyMaterial,
+  setupMaterialParameters,
   updateMaterialPrototype,
   createObjectFromSceneElement,
   duplicateObject,

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -247,7 +247,6 @@ const setupMaterialParameters = (entity: Entity, properties: { [_: string]: any 
     switch (prototypeArgs[k].type) {
       case 'texture': {
         materialComponent.parameters[k].set((v as Texture).source.data.src)
-        console.log(v)
         break
       }
       case 'color': {

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { Euler, Material, Matrix4, Quaternion, Texture, Vector3 } from 'three'
+import { Euler, Material, Matrix4, Quaternion, SRGBColorSpace, Vector3 } from 'three'
 
 import {
   EntityTreeComponent,
@@ -63,6 +63,7 @@ import { DirectionalLightComponent, HemisphereLightComponent } from '@ir-engine/
 import { VisibleComponent } from '@ir-engine/spatial/src/renderer/components/VisibleComponent'
 import { TransformComponent } from '@ir-engine/spatial/src/transform/components/TransformComponent'
 
+import { getTextureAsync } from '@ir-engine/engine/src/assets/functions/resourceLoaderHooks'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { NodeID, NodeIDComponent } from '@ir-engine/engine/src/gltf/NodeIDComponent'
 import { serializeEntity } from '@ir-engine/engine/src/scene/functions/serializeWorld'
@@ -74,7 +75,7 @@ import {
   MaterialPrototypeDefinitions,
   MaterialStateComponent
 } from '@ir-engine/spatial/src/renderer/materials/MaterialComponent'
-import { extractDefaults } from '@ir-engine/spatial/src/renderer/materials/materialFunctions'
+import { extractDefaults, setupMaterialParameters } from '@ir-engine/spatial/src/renderer/materials/materialFunctions'
 import { computeTransformMatrix } from '@ir-engine/spatial/src/transform/systems/TransformSystem'
 import { Color } from 'three'
 import { EditorHelperState } from '../services/EditorHelperState'
@@ -159,7 +160,7 @@ const updateMaterialPrototype = (materialEntity: Entity, newPrototype: string) =
   const materialComponent = getOptionalMutableComponent(materialEntity, MaterialStateComponent)
   if (!materialComponent) return
   const material = materialComponent.material.value
-
+  materialComponent.prototype.set(newPrototype)
   if (!material || newPrototype === material.type) return
   const prototype = getState(MaterialPrototypeDefinitions)[newPrototype]
   if (!prototype) return
@@ -188,11 +189,10 @@ const updateMaterialPrototype = (materialEntity: Entity, newPrototype: string) =
 
   materialComponent.material.set(newMaterial)
   materialComponent.parameters.set({})
-  materialComponent.prototype.set(newPrototype)
 
   EditorState.markModifiedScene(materialEntity)
   if (!EditorState.isInActiveScene(materialEntity)) {
-    SceneDeltaState.registerMaterialDelta(materialEntity, undefined, newPrototype)
+    SceneDeltaState.registerMaterialDelta(materialEntity, {}, newPrototype)
   }
 
   return newMaterial
@@ -207,60 +207,48 @@ const modifyMaterial = (nodes: string[], materialId: EntityUUID, properties: { [
     if (!material) return
     if (!material) throw new Error('Updating properties on undefined material')
     const props = properties[i] ?? properties[0]
+    const materialComponent = getMutableComponent(materialEntity, MaterialStateComponent)
+    const prototype = getState(MaterialPrototypeDefinitions)[materialComponent.prototype.value].arguments
+    const texturePromises = [] as Promise<void>[]
     for (const [key, value] of Object.entries(props)) {
-      if (
-        ![undefined, null].includes(value) &&
-        ![undefined, null].includes(material[key]) &&
-        typeof material[key] === 'object' &&
-        typeof material[key].set === 'function'
-      ) {
-        material[key].set(value)
-      } else {
-        material[key] = value
+      switch (prototype[key]?.type) {
+        case 'texture':
+          texturePromises.push(
+            new Promise<void>(async (resolve) => {
+              const texture = await getTextureAsync(value)
+              if (texture[0]) {
+                texture[0].colorSpace = SRGBColorSpace
+                material[key] = texture[0]
+              }
+              resolve()
+            })
+          )
+          break
+        case 'color':
+          material[key] = value.isColor ? value : new Color(value)
+          break
+        default:
+          material[key] = value
       }
     }
 
-    setupMaterialParameters(materialEntity, props)
+    Promise.all(texturePromises).then(() => {
+      setupMaterialParameters(materialEntity, getComponent(materialEntity, MaterialStateComponent).material)
+      EditorState.markModifiedScene(materialEntity)
+      if (!EditorState.isInActiveScene(materialEntity)) {
+        SceneDeltaState.registerMaterialDelta(
+          materialEntity,
+          getComponent(materialEntity, MaterialStateComponent).parameters,
+          material.userData?.type ?? material.type
+        )
+      }
+    })
 
     getMutableComponent(
       LayerFunctions.getLayerRelationsEntities(materialEntity)![0][1],
       MaterialStateComponent
     ).material.plugins.set(material.plugins)
-
-    EditorState.markModifiedScene(materialEntity)
-    if (!EditorState.isInActiveScene(materialEntity)) {
-      SceneDeltaState.registerMaterialDelta(
-        materialEntity,
-        getComponent(materialEntity, MaterialStateComponent).parameters
-      )
-    }
   }
-}
-
-/**sets up parameters for editing and serialization into a scene delta */
-const setupMaterialParameters = (entity: Entity, properties: { [_: string]: any }) => {
-  const materialComponent = getMutableComponent(entity, MaterialStateComponent)
-  const prototypeArgs = getState(MaterialPrototypeDefinitions)[materialComponent.material.type.value].arguments
-  Object.entries(properties).map(([k, v]) => {
-    if (!properties[k] || !prototypeArgs[k]?.type) return
-    console.log(properties[k], prototypeArgs[k].type)
-    switch (prototypeArgs[k].type) {
-      case 'texture': {
-        const src = (v as Texture).source.data?.src as string | undefined
-        if (!src) break
-        materialComponent.parameters[k].set(src?.startsWith('blob:') ? src.substring(5) : src)
-        break
-      }
-      case 'color': {
-        materialComponent.parameters[k].set((v as Color).getHex())
-        break
-      }
-      default: {
-        materialComponent.parameters[k].set(v)
-        break
-      }
-    }
-  })
 }
 
 const lookDevComponent: Component[] = [
@@ -685,7 +673,6 @@ export const EditorControlFunctions = {
   modifyProperty,
   modifyName,
   modifyMaterial,
-  setupMaterialParameters,
   updateMaterialPrototype,
   createObjectFromSceneElement,
   duplicateObject,

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -246,7 +246,9 @@ const setupMaterialParameters = (entity: Entity, properties: { [_: string]: any 
     console.log(properties[k], prototypeArgs[k].type)
     switch (prototypeArgs[k].type) {
       case 'texture': {
-        materialComponent.parameters[k].set((v as Texture).source.data.src)
+        const src = (v as Texture).source.data?.src as string | undefined
+        if (!src) break
+        materialComponent.parameters[k].set(src?.startsWith('blob:') ? src.substring(5) : src)
         break
       }
       case 'color': {

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -130,8 +130,19 @@ export async function addMediaNode(
                 }
               }
               const uuids = getComponent(entity, MaterialInstanceComponent).uuid
-              uuids[materialIndex] = getComponent(material, UUIDComponent)
-              setComponent(entity, MaterialInstanceComponent, { uuid: uuids })
+              const materialUUID = getComponent(material, UUIDComponent)
+              /**@todo we should be setting the uuid of the material instance component to the uuid of the new material */
+              //uuids[materialIndex] = materialUUID,
+              //setComponent(entity, MaterialInstanceComponent, { uuid: uuids })
+              /**scene deltas do not yet support this, so a temporary hackfix is to modify existing materials to match */
+              const materialComponent = getComponent(material, MaterialStateComponent)
+              EditorControlFunctions.updateMaterialPrototype(
+                UUIDComponent.getEntityByUUID(uuids[materialIndex], Layers.Authoring),
+                materialComponent.material.userData?.type
+              )
+              EditorControlFunctions.modifyMaterial([uuids[materialIndex]], uuids[materialIndex], [
+                getComponent(material, MaterialStateComponent).parameters
+              ])
               foundTarget = true
             })
             if (foundTarget) break

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -136,12 +136,13 @@ export async function addMediaNode(
               //setComponent(entity, MaterialInstanceComponent, { uuid: uuids })
               /**scene deltas do not yet support this, so a temporary hackfix is to modify existing materials to match */
               const materialComponent = getComponent(material, MaterialStateComponent)
+              const materialToMutate = UUIDComponent.getEntityByUUID(uuids[materialIndex], Layers.Authoring)
               EditorControlFunctions.updateMaterialPrototype(
-                UUIDComponent.getEntityByUUID(uuids[materialIndex], Layers.Authoring),
-                materialComponent.material.userData?.type
+                materialToMutate,
+                materialComponent.material.userData?.type ?? materialComponent.material.type
               )
               EditorControlFunctions.modifyMaterial([uuids[materialIndex]], uuids[materialIndex], [
-                getComponent(material, MaterialStateComponent).material
+                getComponent(material, MaterialStateComponent).parameters
               ])
               removeEntity(assetEntity)
               foundTarget = true

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -113,7 +113,6 @@ export async function addMediaNode(
 
       AssetState.loadAsync(url, false, UUIDComponent.generateUUID(), UndefinedEntity, Layers.Authoring as LayerID).then(
         (assetEntity) => {
-          /** @todo do we need to get rid of the gltf entity here? */
           const [material] = getChildrenWithComponents(assetEntity, [MaterialStateComponent])
           let foundTarget = false
           for (const intersection of intersections) {
@@ -130,8 +129,9 @@ export async function addMediaNode(
                 }
               }
               const uuids = getComponent(entity, MaterialInstanceComponent).uuid
-              const materialUUID = getComponent(material, UUIDComponent)
+
               /**@todo we should be setting the uuid of the material instance component to the uuid of the new material */
+              //const materialUUID = getComponent(material, UUIDComponent)
               //uuids[materialIndex] = materialUUID,
               //setComponent(entity, MaterialInstanceComponent, { uuid: uuids })
               /**scene deltas do not yet support this, so a temporary hackfix is to modify existing materials to match */
@@ -143,6 +143,7 @@ export async function addMediaNode(
               EditorControlFunctions.modifyMaterial([uuids[materialIndex]], uuids[materialIndex], [
                 getComponent(material, MaterialStateComponent).parameters
               ])
+              removeEntity(assetEntity)
               foundTarget = true
             })
             if (foundTarget) break

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -141,7 +141,7 @@ export async function addMediaNode(
                 materialComponent.material.userData?.type
               )
               EditorControlFunctions.modifyMaterial([uuids[materialIndex]], uuids[materialIndex], [
-                getComponent(material, MaterialStateComponent).parameters
+                getComponent(material, MaterialStateComponent).material
               ])
               removeEntity(assetEntity)
               foundTarget = true

--- a/packages/editor/src/panels/properties/materialeditor.tsx
+++ b/packages/editor/src/panels/properties/materialeditor.tsx
@@ -50,7 +50,11 @@ import {
   PrototypeArgument
 } from '@ir-engine/spatial/src/renderer/materials/MaterialComponent'
 import { getDefaultType } from '@ir-engine/spatial/src/renderer/materials/constants/DefaultArgs'
-import { extractValues, formatMaterialArgs } from '@ir-engine/spatial/src/renderer/materials/materialFunctions'
+import {
+  extractValues,
+  formatMaterialArgs,
+  setupMaterialParameters
+} from '@ir-engine/spatial/src/renderer/materials/materialFunctions'
 import { Button, Tooltip } from '@ir-engine/ui'
 import InputGroup from '@ir-engine/ui/src/components/editor/input/Group'
 import SelectInput from '@ir-engine/ui/src/components/editor/input/Select'
@@ -177,7 +181,7 @@ export function MaterialEditor(props: { materialUUID: EntityUUID }) {
 
   useEffect(() => {
     prototypeName.set(material.type)
-    EditorControlFunctions.setupMaterialParameters(entity, material)
+    setupMaterialParameters(entity, material)
 
     materialParameters.set(
       Object.fromEntries(

--- a/packages/editor/src/panels/properties/materialeditor.tsx
+++ b/packages/editor/src/panels/properties/materialeditor.tsx
@@ -173,11 +173,11 @@ export function MaterialEditor(props: { materialUUID: EntityUUID }) {
     }
     return prop
   }
-
   const materialParameters = useHookstate({})
 
   useEffect(() => {
     prototypeName.set(material.type)
+    EditorControlFunctions.setupMaterialParameters(entity, material)
 
     materialParameters.set(
       Object.fromEntries(

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -55,6 +55,7 @@ import { SkinnedMeshComponent } from '@ir-engine/spatial/src/renderer/components
 import { VisibleComponent } from '@ir-engine/spatial/src/renderer/components/VisibleComponent'
 import {
   MaterialInstanceComponent,
+  MaterialPrototypeDefinitions,
   MaterialStateComponent
 } from '@ir-engine/spatial/src/renderer/materials/MaterialComponent'
 import { ResourceType } from '@ir-engine/spatial/src/resources/ResourceState'
@@ -131,6 +132,7 @@ import { AnimationComponent } from '../avatar/components/AnimationComponent'
 import { SourceID } from '../scene/components/SourceComponent'
 import {
   MATERIAL_JSON_ID,
+  MATERIAL_PROTOTYPE_JSON_ID,
   SceneDeltaEntry,
   SceneDeltaRegistry,
   SceneDeltaState
@@ -791,6 +793,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
 
   await Promise.all(promises)
 
+  const userData = {}
   //apply deltas
   const deltaState = getState(SceneDeltaState)
   const sourceDelta = deltaState[GLTFComponent.removeHashes(options.documentID)]
@@ -799,8 +802,17 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
     const nodeDelta = sourceDelta[nodeID]
     if (nodeDelta) {
       const materialDelta = nodeDelta[MATERIAL_JSON_ID]
+      const materialPrototype = nodeDelta[MATERIAL_PROTOTYPE_JSON_ID]
       if (materialDelta) {
-        Object.assign(materialParams, materialDelta)
+        const prototype = getState(MaterialPrototypeDefinitions)[materialPrototype]
+        if (materialPrototype) materialConstructor = prototype.prototypeConstructor
+        for (const key in materialDelta) {
+          if (prototype.arguments[key]?.type === 'color') {
+            materialParams[key] = new Color(materialDelta[key])
+          } else {
+            materialParams[key] = materialDelta[key]
+          }
+        }
       }
     }
   }

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -795,6 +795,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
 
   await Promise.all(promises)
 
+  const deltaPromises = [] as Promise<void>[]
   //apply deltas
   const deltaState = getState(SceneDeltaState)
   const sourceDelta = deltaState[GLTFComponent.removeHashes(options.documentID)]
@@ -816,9 +817,16 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
               materialConstructorParameters[key] = new Color(materialDelta[key])
               break
             case 'texture':
-              getTextureAsync(materialDelta[key]).then((texture) => {
-                materialConstructorParameters[key] = texture
-              })
+              deltaPromises.push(
+                new Promise<void>(async (resolve) => {
+                  const texture = getTextureAsync(materialDelta[key])
+
+                  if (texture) {
+                    materialConstructorParameters[key] = texture
+                  }
+                  resolve()
+                })
+              )
               break
           }
         }
@@ -826,7 +834,10 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
     }
   }
 
+  await Promise.all(deltaPromises)
+
   const material = new materialConstructor(materialConstructorParameters)
+  console.log(materialConstructorParameters, materialDef.name)
   const uuid = getComponent(materialEntity, UUIDComponent)
   material.uuid = uuid
   material.name = materialDef.name || 'Material-' + materialIndex

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -58,6 +58,7 @@ import {
   MaterialPrototypeDefinitions,
   MaterialStateComponent
 } from '@ir-engine/spatial/src/renderer/materials/MaterialComponent'
+import { setupMaterialParameters } from '@ir-engine/spatial/src/renderer/materials/materialFunctions'
 import { ResourceType } from '@ir-engine/spatial/src/resources/ResourceState'
 import { computeTransformMatrix } from '@ir-engine/spatial/src/transform/systems/TransformSystem'
 import {
@@ -819,14 +820,16 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
             case 'texture':
               deltaPromises.push(
                 new Promise<void>(async (resolve) => {
-                  const texture = getTextureAsync(materialDelta[key])
-
-                  if (texture) {
-                    materialConstructorParameters[key] = texture
+                  const texture = await getTextureAsync(materialDelta[key])
+                  if (texture[0]) {
+                    texture[0].colorSpace = SRGBColorSpace
+                    materialConstructorParameters[key] = texture[0]
                   }
                   resolve()
                 })
               )
+            default:
+              materialConstructorParameters[key] = materialDelta[key]
               break
           }
         }
@@ -837,12 +840,12 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
   await Promise.all(deltaPromises)
 
   const material = new materialConstructor(materialConstructorParameters)
-  console.log(materialConstructorParameters, materialDef.name)
   const uuid = getComponent(materialEntity, UUIDComponent)
   material.uuid = uuid
   material.name = materialDef.name || 'Material-' + materialIndex
 
   setComponent(materialEntity, MaterialStateComponent, { material })
+  setupMaterialParameters(materialEntity, materialConstructorParameters)
 
   assignExtrasToUserData(material, materialDef)
 

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -631,7 +631,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
 
   // if (materialDef.extensions) addUnknownExtensionsToUserData(GLTFExtensions, material, materialDef)
 
-  const materialParams = {} as any
+  let materialParams = {} as any
   const promises = [] as Promise<void>[]
   const materialExtensions = materialDef.extensions || {}
 
@@ -806,6 +806,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
       if (materialDelta) {
         const prototype = getState(MaterialPrototypeDefinitions)[materialPrototype]
         if (materialPrototype) materialConstructor = prototype.prototypeConstructor
+        materialParams = {}
         for (const key in materialDelta) {
           if (prototype.arguments[key]?.type === 'color') {
             materialParams[key] = new Color(materialDelta[key])

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -808,6 +808,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
         const prototype = getState(MaterialPrototypeDefinitions)[materialPrototype ?? materialConstructor.name] // this is insanely brittle but will do for now
         if (materialPrototype) {
           materialConstructor = prototype.prototypeConstructor
+          materialConstructorParameters = {}
         }
         for (const key in materialDelta) {
           switch (prototype.arguments[key]?.type) {

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -805,9 +805,10 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
       const materialDelta = nodeDelta[MATERIAL_JSON_ID]
       const materialPrototype = nodeDelta[MATERIAL_PROTOTYPE_JSON_ID]
       if (materialDelta) {
-        const prototype = getState(MaterialPrototypeDefinitions)[materialPrototype]
-        if (materialPrototype) materialConstructor = prototype.prototypeConstructor
-        materialConstructorParameters = {}
+        const prototype = getState(MaterialPrototypeDefinitions)[materialPrototype ?? materialConstructor.name] // this is insanely brittle but will do for now
+        if (materialPrototype) {
+          materialConstructor = prototype.prototypeConstructor
+        }
         for (const key in materialDelta) {
           switch (prototype.arguments[key]?.type) {
             case 'color':

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -104,6 +104,7 @@ import {
 } from 'three'
 import { parseStorageProviderURLs } from '../assets/functions/parseSceneJSON'
 import { loadResource, unloadResourcesForEntity } from '../assets/functions/resourceLoaderFunctions'
+import { getTextureAsync } from '../assets/functions/resourceLoaderHooks'
 import { FileLoader } from '../assets/loaders/base/FileLoader'
 import { Loader } from '../assets/loaders/base/Loader'
 import {
@@ -631,7 +632,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
 
   // if (materialDef.extensions) addUnknownExtensionsToUserData(GLTFExtensions, material, materialDef)
 
-  let materialParams = {} as any
+  let materialConstructorParameters = {} as any
   const promises = [] as Promise<void>[]
   const materialExtensions = materialDef.extensions || {}
 
@@ -639,10 +640,10 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
   if (!materialExtensions[EXTENSIONS.EE_MATERIAL] && materialExtensions[EXTENSIONS.KHR_MATERIALS_UNLIT]) {
     const kmuExtension = KHRUnlitExtensionComponent
     materialConstructor = kmuExtension.getMaterialType() as any
-    promises.push(kmuExtension.extendMaterialParams(options, materialParams, materialDef) as any)
+    promises.push(kmuExtension.extendMaterialParams(options, materialConstructorParameters, materialDef) as any)
   } else {
-    materialParams.color = new Color(1.0, 1.0, 1.0)
-    materialParams.opacity = 1.0
+    materialConstructorParameters.color = new Color(1.0, 1.0, 1.0)
+    materialConstructorParameters.opacity = 1.0
 
     if (typeof materialDef.pbrMetallicRoughness?.baseColorTexture !== 'undefined') {
       promises.push(
@@ -653,7 +654,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
           )
           if (map) {
             map.colorSpace = SRGBColorSpace
-            materialParams.map = map
+            materialConstructorParameters.map = map
           }
           resolve()
         })
@@ -663,16 +664,16 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
     if (typeof materialDef.pbrMetallicRoughness?.baseColorFactor !== 'undefined') {
       if (Array.isArray(materialDef.pbrMetallicRoughness?.baseColorFactor)) {
         const array = materialDef.pbrMetallicRoughness.baseColorFactor
-        ;(materialParams.color = new Color().setRGB(array[0], array[1], array[2], LinearSRGBColorSpace)),
-          (materialParams.opacity = array[3])
+        ;(materialConstructorParameters.color = new Color().setRGB(array[0], array[1], array[2], LinearSRGBColorSpace)),
+          (materialConstructorParameters.opacity = array[3])
       }
     }
-    materialParams.metalness =
+    materialConstructorParameters.metalness =
       materialDef.pbrMetallicRoughness?.metallicFactor !== undefined
         ? materialDef.pbrMetallicRoughness.metallicFactor
         : 1.0
 
-    materialParams.roughness =
+    materialConstructorParameters.roughness =
       materialDef.pbrMetallicRoughness?.roughnessFactor !== undefined
         ? materialDef.pbrMetallicRoughness.roughnessFactor
         : 1.0
@@ -686,7 +687,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
           )
 
           if (metalnessMap) {
-            materialParams.metalnessMap = metalnessMap
+            materialConstructorParameters.metalnessMap = metalnessMap
           }
           resolve()
         })
@@ -702,7 +703,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
           )
 
           if (roughnessMap) {
-            materialParams.roughnessMap = roughnessMap
+            materialConstructorParameters.roughnessMap = roughnessMap
           }
           resolve()
         })
@@ -710,50 +711,51 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
     }
   }
 
-  materialParams.side = materialDef.doubleSided === true ? DoubleSide : FrontSide
+  materialConstructorParameters.side = materialDef.doubleSided === true ? DoubleSide : FrontSide
 
   const alphaMode = materialDef.alphaMode || ALPHA_MODES.OPAQUE
-  materialParams.transparent = alphaMode === ALPHA_MODES.BLEND
+  materialConstructorParameters.transparent = alphaMode === ALPHA_MODES.BLEND
 
   // See: https://github.com/mrdoob/three.js/issues/17706
   if (alphaMode === ALPHA_MODES.BLEND) {
-    materialParams.depthWrite = false
+    materialConstructorParameters.depthWrite = false
   }
 
   if (materialDef.alphaMode === ALPHA_MODES.MASK) {
-    materialParams.alphaTest = typeof materialDef.alphaCutoff === 'number' ? materialDef.alphaCutoff : 0.5
+    materialConstructorParameters.alphaTest =
+      typeof materialDef.alphaCutoff === 'number' ? materialDef.alphaCutoff : 0.5
   } else {
-    materialParams.alphaTest = 0
+    materialConstructorParameters.alphaTest = 0
   }
 
   if (typeof materialDef.normalTexture !== 'undefined') {
     const normalMap = await GLTFLoaderFunctions.assignTexture(options, materialDef.normalTexture)
 
     if (normalMap) {
-      materialParams.normalMap = normalMap
+      materialConstructorParameters.normalMap = normalMap
     }
   }
 
   if (materialDef.normalTexture?.scale) {
     const scale = materialDef.normalTexture.scale
-    materialParams.normalScale = new Vector2(scale, scale)
+    materialConstructorParameters.normalScale = new Vector2(scale, scale)
   } else {
-    materialParams.normalScale = new Vector2(1, 1)
+    materialConstructorParameters.normalScale = new Vector2(1, 1)
   }
 
   if (typeof materialDef.occlusionTexture !== 'undefined') {
     const aoMap = await GLTFLoaderFunctions.assignTexture(options, materialDef.occlusionTexture)
 
     if (aoMap) {
-      materialParams.aoMap = aoMap
+      materialConstructorParameters.aoMap = aoMap
     }
   }
 
-  materialParams.aoMapIntensity = materialDef.occlusionTexture?.strength ?? 1.0
+  materialConstructorParameters.aoMapIntensity = materialDef.occlusionTexture?.strength ?? 1.0
 
   const emissiveFactor = materialDef.emissiveFactor
   if (emissiveFactor) {
-    materialParams.emissive = new Color().setRGB(
+    materialConstructorParameters.emissive = new Color().setRGB(
       emissiveFactor[0],
       emissiveFactor[1],
       emissiveFactor[2],
@@ -768,7 +770,7 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
 
         if (emissiveMap) {
           emissiveMap.colorSpace = SRGBColorSpace
-          materialParams.emissiveMap = emissiveMap
+          materialConstructorParameters.emissiveMap = emissiveMap
         }
         resolve()
       })
@@ -787,13 +789,12 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
       else console.warn('GLTFLoaderFunctions: Material type not found.')
     }
     if (typeof Component.extendMaterialParams === 'function') {
-      promises.push(Component.extendMaterialParams(options, materialParams, materialDef, materialIndex))
+      promises.push(Component.extendMaterialParams(options, materialConstructorParameters, materialDef, materialIndex))
     }
   }
 
   await Promise.all(promises)
 
-  const userData = {}
   //apply deltas
   const deltaState = getState(SceneDeltaState)
   const sourceDelta = deltaState[GLTFComponent.removeHashes(options.documentID)]
@@ -806,24 +807,29 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
       if (materialDelta) {
         const prototype = getState(MaterialPrototypeDefinitions)[materialPrototype]
         if (materialPrototype) materialConstructor = prototype.prototypeConstructor
-        materialParams = {}
+        materialConstructorParameters = {}
         for (const key in materialDelta) {
-          if (prototype.arguments[key]?.type === 'color') {
-            materialParams[key] = new Color(materialDelta[key])
-          } else {
-            materialParams[key] = materialDelta[key]
+          switch (prototype.arguments[key]?.type) {
+            case 'color':
+              materialConstructorParameters[key] = new Color(materialDelta[key])
+              break
+            case 'texture':
+              getTextureAsync(materialDelta[key]).then((texture) => {
+                materialConstructorParameters[key] = texture
+              })
+              break
           }
         }
       }
     }
   }
 
-  const material = new materialConstructor(materialParams)
+  const material = new materialConstructor(materialConstructorParameters)
   const uuid = getComponent(materialEntity, UUIDComponent)
   material.uuid = uuid
   material.name = materialDef.name || 'Material-' + materialIndex
 
-  setComponent(materialEntity, MaterialStateComponent, { material, parameters: materialParams })
+  setComponent(materialEntity, MaterialStateComponent, { material })
 
   assignExtrasToUserData(material, materialDef)
 

--- a/packages/engine/src/scene/systems/SceneDeltaState.tsx
+++ b/packages/engine/src/scene/systems/SceneDeltaState.tsx
@@ -34,6 +34,7 @@ import { SceneState } from '../../gltf/GLTFState'
 export type SceneDeltaEntry<C extends Component> = Record<string, Partial<SerializedComponentType<C>>>
 
 export const MATERIAL_JSON_ID = 'materialParameters' as const
+export const MATERIAL_PROTOTYPE_JSON_ID = 'prototypeConstructor' as const
 
 export type MaterialDeltaEntry = Record<typeof MATERIAL_JSON_ID, any>
 
@@ -55,7 +56,7 @@ export const SceneDeltaState = defineState({
     componentMap[component.jsonID] = { ...componentMap[component.jsonID], ...delta }
     source[nodeID].set(componentMap)
   },
-  registerMaterialDelta(entity: Entity, props: any) {
+  registerMaterialDelta(entity: Entity, props?: any, prototype?: string) {
     if (!hasComponent(entity, SourceComponent) || !hasComponent(entity, NodeIDComponent)) return
     const sourceID = GLTFComponent.removeHashes(getComponent(entity, SourceComponent))
     const nodeID = getComponent(entity, NodeIDComponent)
@@ -64,7 +65,8 @@ export const SceneDeltaState = defineState({
     const source = state[sourceID]
     if (!source.value[nodeID]) source[nodeID].set({} as MaterialDeltaEntry)
     const componentMap = source[nodeID].get(NO_PROXY_STEALTH) as MaterialDeltaEntry
-    componentMap[MATERIAL_JSON_ID] = { ...componentMap[MATERIAL_JSON_ID], ...props }
+    if (props) componentMap[MATERIAL_JSON_ID] = { ...componentMap[MATERIAL_JSON_ID], ...props }
+    if (prototype) componentMap[MATERIAL_PROTOTYPE_JSON_ID] = prototype
     source[nodeID].set(componentMap)
   },
   reactor: () => {

--- a/packages/engine/src/scene/systems/SceneDeltaState.tsx
+++ b/packages/engine/src/scene/systems/SceneDeltaState.tsx
@@ -65,7 +65,7 @@ export const SceneDeltaState = defineState({
     const source = state[sourceID]
     if (!source.value[nodeID]) source[nodeID].set({} as MaterialDeltaEntry)
     const componentMap = source[nodeID].get(NO_PROXY_STEALTH) as MaterialDeltaEntry
-    if (props) componentMap[MATERIAL_JSON_ID] = { ...componentMap[MATERIAL_JSON_ID], ...props }
+    if (props) componentMap[MATERIAL_JSON_ID] = { ...props }
     if (prototype) componentMap[MATERIAL_PROTOTYPE_JSON_ID] = prototype
     source[nodeID].set(componentMap)
   },

--- a/packages/spatial/src/renderer/materials/MaterialComponent.tsx
+++ b/packages/spatial/src/renderer/materials/MaterialComponent.tsx
@@ -105,7 +105,10 @@ export const MaterialStateComponent = defineComponent({
     material: S.Type<Material>({} as Material),
     parameters: S.Record(S.String(), S.Any()),
     // all entities using this material. an undefined entity at index 0 is a fake user
-    instances: S.NonSerialized(S.Array(S.Entity()))
+    /**@todo move to state */
+    instances: S.NonSerialized(S.Array(S.Entity())),
+    // this has to exist so scene deltas can keep track of material prototype changes
+    prototype: S.String()
   }),
 
   fallbackMaterialUUID: uuidv4() as EntityUUID,

--- a/packages/spatial/src/renderer/materials/materialFunctions.ts
+++ b/packages/spatial/src/renderer/materials/materialFunctions.ts
@@ -25,7 +25,15 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { Color, Material, Mesh, Texture } from 'three'
 
-import { Entity, EntityUUID, getComponent, getOptionalComponent, hasComponent, UUIDComponent } from '@ir-engine/ecs'
+import {
+  Entity,
+  EntityUUID,
+  getComponent,
+  getOptionalComponent,
+  hasComponent,
+  setComponent,
+  UUIDComponent
+} from '@ir-engine/ecs'
 
 import { getState } from '@ir-engine/hyperflux'
 import { MeshComponent } from '../components/MeshComponent'
@@ -129,4 +137,23 @@ export const injectMaterialDefaults = (materialUUID: EntityUUID) => {
   return Object.fromEntries(
     Object.entries(prototype).map(([k, v]: [string, any]) => [k, { ...v, default: material.parameters![k] }])
   )
+}
+
+/**sets up parameters for editing and serialization into a scene delta */
+export const setupMaterialParameters = (entity: Entity, properties: { [_: string]: any }) => {
+  const params = {} as any
+  Object.entries(properties).map(([k, v]) => {
+    if (!properties[k]) return
+    if (v.isTexture) {
+      const url = v.userData?.url
+      if (url) params[k] = url
+    } else if (v.isColor) {
+      params[k] = (v as Color).getHex()
+    } else {
+      params[k] = v
+    }
+  })
+
+  setComponent(entity, MaterialStateComponent, { parameters: params })
+  return params
 }


### PR DESCRIPTION
## Summary
It's a hack. This must be reimplemented ASAP using proper material asset references.

This PR lets scene deltas track the material prototype. Also tentatively also reimplements material drag and drop to replace existing gltf materials for the sake of scene deltas working.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-7942

## QA Steps
