### PR TITLE
[GA] allow both "more" and the "moderations options" to be closed when clicked outside

### DIFF
--- a/packages/client-core/src/user/VideoWindows/index.tsx
+++ b/packages/client-core/src/user/VideoWindows/index.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import React from 'react'
+import React, { useRef } from 'react'
 
 import { UserID, userPath } from '@ir-engine/common/src/schema.type.module'
 import { Engine } from '@ir-engine/ecs/src/Engine'
@@ -43,6 +43,7 @@ import {
 } from '@ir-engine/ui/src/icons'
 import { IoWarning } from 'react-icons/io5'
 
+import { useClickOutside, useTouchOutside } from '@ir-engine/common/src/utils/useClickOutside'
 import AvatarImage from '@ir-engine/ui/src/primitives/tailwind/AvatarImage'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import { useTranslation } from 'react-i18next'
@@ -172,11 +173,18 @@ const ReportUserWindow = () => {
     peerID: reportedPeerId!,
     type: 'cam'
   })
+  const ref = useRef<HTMLDivElement>(null)
+
+  useClickOutside(ref, () => resetPeerId())
+  useTouchOutside(ref, () => resetPeerId())
 
   if (!reportedPeerId || !reportedUserId || !reportedUser) return null
 
   return (
-    <div className="fixed right-[10%] top-[5%] grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-4 rounded-xl bg-surface-4 p-3 lg:right-[5%]">
+    <div
+      className="fixed right-[10%] top-[5%] grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-4 rounded-xl bg-surface-4 p-3 lg:right-[5%]"
+      ref={ref}
+    >
       <div className="h-[100px] w-[100px]">
         <AvatarImage size="fill" className="rounded-none" src={avatarThumbnail} />
       </div>

--- a/packages/client-core/src/user/VideoWindows/window.tsx
+++ b/packages/client-core/src/user/VideoWindows/window.tsx
@@ -30,6 +30,7 @@ import Button from '@ir-engine/ui/src/primitives/tailwind/Button'
 import Canvas from '@ir-engine/ui/src/primitives/tailwind/Canvas'
 import React, { useEffect, useRef } from 'react'
 
+import { useClickOutside, useTouchOutside } from '@ir-engine/common/src/utils/useClickOutside'
 import { useTranslation } from 'react-i18next'
 import { Props, useReportUser, useUserMediaWindowHook } from './hook'
 
@@ -51,6 +52,7 @@ export const SingleVideoWindow = ({ peerID, type }: Props): JSX.Element => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const canvasCtxRef = useRef<CanvasRenderingContext2D>()
   const isMoreButtonVisible = useHookstate(false)
+  const containerRef = useRef<HTMLDivElement>(null)
 
   // @todo - currently this adds lots of systems unnecessarily
   // useDrawMocapLandmarks(videoElement, canvasCtxRef, canvasRef, peerID)
@@ -74,8 +76,11 @@ export const SingleVideoWindow = ({ peerID, type }: Props): JSX.Element => {
     if (canvasRef.current) canvasCtxRef.current = canvasRef.current.getContext('2d')!
   })
 
+  useClickOutside(containerRef, () => isMoreButtonVisible.set(false))
+  useTouchOutside(containerRef, () => isMoreButtonVisible.set(false))
+
   return (
-    <div className="group/video-window flex items-center gap-x-2">
+    <div className="group/video-window flex items-center gap-x-2" ref={containerRef}>
       <div
         tabIndex={0}
         id={peerID + '_' + type + '_container'}


### PR DESCRIPTION
## Summary

both the "more" button the video window and the "moderation options" which open when the more button is clicked should close when clicked anywhere outside


## References
closes https://tsu.atlassian.net/browse/IR-7940

## QA Steps

https://github.com/user-attachments/assets/1e7daaa0-fedb-463f-b4ab-5022ff70da8f




