### PR TITLE
[GA] moderation window should hide top right icon button

### DIFF
--- a/packages/client-core/src/user/VideoWindows/index.tsx
+++ b/packages/client-core/src/user/VideoWindows/index.tsx
@@ -176,7 +176,7 @@ const ReportUserWindow = () => {
   if (!reportedPeerId || !reportedUserId || !reportedUser) return null
 
   return (
-    <div className="fixed right-[10%] top-[5%] grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-4 rounded-xl bg-surface-4 p-3 lg:right-[5%]">
+    <div className="fixed right-6 top-6 z-10 grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-4 rounded-xl bg-surface-4 p-3">
       <div className="h-[100px] w-[100px]">
         <AvatarImage size="fill" className="rounded-none" src={avatarThumbnail} />
       </div>


### PR DESCRIPTION
## Summary

the positioning now aligns with the location icon button and sits on top of the top right locationicon buttons

## References
closes https://tsu.atlassian.net/browse/IR-7943

## QA Steps
![photo-size-5-6235609038922564416-y](https://github.com/user-attachments/assets/3f3f5c22-15f9-432f-a85a-66f3aacb3024)
![photo-size-5-6235609038922564418-y](https://github.com/user-attachments/assets/744bb2c1-e8ba-4dcf-ac65-404f5a6ccdd4)


![image](https://github.com/user-attachments/assets/6706447e-cc5f-41d4-9325-de1c42583d17)
![image](https://github.com/user-attachments/assets/efe6a604-8677-4341-a40b-a8e482aec3a8)


