### PR TITLE
[MT-INT] IR-7916 Studio: FIX:  Invalid File names are renamed instead of failing upload

### DIFF
--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -40,6 +40,7 @@ import {
 } from '@ir-engine/common/src/schema.type.module'
 import { CommonKnownContentTypes } from '@ir-engine/common/src/utils/CommonKnownContentTypes'
 import { cleanFileNameFile, cleanFileNameString } from '@ir-engine/common/src/utils/cleanFileName'
+import { isValidFileName } from '@ir-engine/common/src/utils/validateFileName'
 import { KTX2EncodeArguments } from '@ir-engine/engine/src/assets/constants/CompressionParms'
 import { pathJoin } from '@ir-engine/engine/src/assets/functions/miscUtils'
 import { modelResourcesPath } from '@ir-engine/engine/src/assets/functions/pathResolver'
@@ -106,25 +107,36 @@ function isValidFileType(file): { isValid: boolean; errorMessage?: string } {
   }
 }
 
-export function sanitizeFiles(files: FileList | File[]): File[] {
+export function validatedFiles(files: FileList | File[]): File[] {
   const { maxFileSizeToUpload } = config.client
-
   const invalidSizeFiles: string[] = []
   const newFiles: File[] = []
+
   for (const file of files) {
+    // Check file size
     if (file.size > maxFileSizeToUpload) {
       invalidSizeFiles.push(file.name)
       continue
     }
-    const newFile = cleanFileNameFile(file)
-    const { isValid, errorMessage } = isValidFileType(newFile)
-    if (!isValid) {
+
+    // Check file type
+    const { isValid: isValidType, errorMessage } = isValidFileType(file)
+    if (!isValidType) {
       NotificationService.dispatchNotify(
         i18n.t('editor:errors.fileNotSupported', { file: file.name, errorMessage: errorMessage || '' }) as string,
         { variant: 'warning' }
       )
+      continue
     }
-    newFiles.push(newFile)
+
+    // Check filename
+    const fileNameWithOutExtension = file.name.replace(/\.[^/.]+$/, '')
+    const resultFileNameValid = isValidFileName(fileNameWithOutExtension)
+    if (!resultFileNameValid.isValid) {
+      NotificationService.dispatchNotify(resultFileNameValid.error, { variant: 'warning', autoHideDuration: 20000 })
+      continue
+    }
+    newFiles.push(file)
   }
 
   if (invalidSizeFiles.length > 0) {
@@ -306,7 +318,7 @@ export const inputFileWithAddToScene = ({
     el.onchange = async () => {
       try {
         if (el.files?.length) {
-          const newFiles = sanitizeFiles(el.files)
+          const newFiles = validatedFiles(el.files)
           const uniqueFiles = await filterExistingFiles(projectName, directoryPath, newFiles)
           await handleUploadFiles(projectName, directoryPath, uniqueFiles)
         }
@@ -347,7 +359,7 @@ const createFileUploader = ({
     el.onchange = async () => {
       try {
         if (el.files?.length) {
-          const newFiles = sanitizeFiles(el.files)
+          const newFiles = validatedFiles(el.files)
           const uniqueFiles = await filterExistingFiles(projectName, directoryPath, newFiles)
           const [uploadedFileUrl] = await handleUploadFiles(projectName, directoryPath, uniqueFiles)
 

--- a/packages/editor/src/panels/files/helpers.tsx
+++ b/packages/editor/src/panels/files/helpers.tsx
@@ -42,7 +42,7 @@ import { AssetLoader } from '@ir-engine/engine/src/assets/classes/AssetLoader'
 import { NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
 import React, { ReactNode, createContext, useContext, useEffect } from 'react'
 import { DnDFileType, FileDataType } from '../../constants/AssetTypes'
-import { filterExistingFiles, handleUploadFiles, sanitizeFiles } from '../../functions/assetFunctions'
+import { filterExistingFiles, handleUploadFiles, validatedFiles } from '../../functions/assetFunctions'
 import { EditorState } from '../../services/EditorServices'
 import { FilesState } from '../../services/FilesState'
 import { AssetCategoryNode } from '../assets/categories'
@@ -281,7 +281,7 @@ export function useFileBrowserDrop() {
       if (filesToUpload.length) {
         try {
           const uniqueFiles = await filterExistingFiles(filesState.projectName.value, path, filesToUpload)
-          const sanitizedFiles = sanitizeFiles(uniqueFiles)
+          const sanitizedFiles = validatedFiles(uniqueFiles)
           await handleUploadFiles(filesState.projectName.value, path, sanitizedFiles)
         } catch (err) {
           NotificationService.dispatchNotify(err.message, { variant: 'error' })


### PR DESCRIPTION
## Summary
[MT-INT] IR-7916 Studio: FIX:  Invalid File names are renamed instead of failing upload

related jira issue [IR-7916](https://tsu.atlassian.net/browse/IR-7916)
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


[IR-7916]: https://tsu.atlassian.net/browse/IR-7916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ