### PR TITLE
Fixed bug with searching files

### DIFF
--- a/packages/editor/src/panels/files/helpers.tsx
+++ b/packages/editor/src/panels/files/helpers.tsx
@@ -77,7 +77,8 @@ export const CurrentFilesQueryProvider = ({ children }: { children?: ReactNode }
   const filesQuery = useFind(fileBrowserPath, {
     query: {
       $limit: FILES_PAGE_LIMIT,
-      directory: filesState.searchText.value ? `${directory}/**` : directory
+      directory,
+      recursive: !!filesState.searchText.value
     }
   })
 

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -170,7 +170,7 @@ export class FileBrowserService
   async find(params?: FileBrowserParams) {
     if (!params) params = {}
     if (!params.query) params.query = {}
-    const { $skip, $limit } = params.query
+    const { $skip, $limit, recursive } = params.query
     let { directory } = params.query
 
     const skip = $skip ? $skip : 0
@@ -182,7 +182,7 @@ export class FileBrowserService
 
     ensureProjectsDirectory(directory)
 
-    let result = await storageProvider.listFolderContent(directory)
+    let result = await storageProvider.listFolderContent(directory, !!recursive)
     Object.entries(params.query).forEach(([key, value]) => {
       if (value['$like']) {
         result = result.filter(

--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -392,8 +392,9 @@ export class LocalStorage implements StorageProviderInterface {
    * List all the files/folders in the directory.
    * @param relativeDirPath Name of folder in the storage.
    */
-  listFolderContent = async (relativeDirPath: string): Promise<FileBrowserContentType[]> => {
-    const absoluteDirPath = path.join(this.PATH_PREFIX, relativeDirPath)
+  listFolderContent = async (relativeDirPath: string, recursive = false): Promise<FileBrowserContentType[]> => {
+    let absoluteDirPath = path.join(this.PATH_PREFIX, relativeDirPath)
+    if (recursive) absoluteDirPath = path.join(absoluteDirPath, '**')
 
     const folder = glob
       .sync(path.join(absoluteDirPath, '*/'))


### PR DESCRIPTION
## Summary

Call to file-browser.find now passes recursive: true, which gets passed to listFolderContent. Prior appending of '/**' to directory only worked for local file storage.

Resolves IR-7909

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
