### PR TITLE
iPhone texture discarding

### DIFF
--- a/packages/engine/src/scene/systems/EnvironmentSystem.tsx
+++ b/packages/engine/src/scene/systems/EnvironmentSystem.tsx
@@ -165,7 +165,7 @@ const EnvMapSkyboxReactor = (props: { entity: Entity; rootEntity: Entity }) => {
     // threejs freaks out if matcap materials are passed in envmap related values
     if (disallowedMaterials.has(materialComponent.type.value)) return
 
-    materialComponent.envMap.set(backgroundComponent.value as any)
+    materialComponent.envMap.set(backgroundComponent.value.clone() as any)
   }, [backgroundComponent?.value, materialComponent?.uuid.value])
 
   return <IntensityReactor entity={entity} rootEntity={rootEntity} />

--- a/packages/spatial/src/resources/ResourceState.tsx
+++ b/packages/spatial/src/resources/ResourceState.tsx
@@ -44,6 +44,7 @@ import {
   QueryReactor,
   getAncestorWithComponents,
   getAuthoringCounterpart,
+  getComponent,
   getOptionalComponent,
   useComponent,
   useEntityContext
@@ -51,8 +52,10 @@ import {
 import { NO_PROXY, State, defineState, getMutableState, getState, none } from '@ir-engine/hyperflux'
 import { ObjectComponent } from '@ir-engine/spatial/src/renderer/components/ObjectComponent'
 
+import { ReferenceSpaceState } from '@ir-engine/spatial'
 import React, { useEffect } from 'react'
 import { Geometry } from '../common/constants/Geometry'
+import { isIPhone } from '../common/functions/isMobile'
 import iterateObject3D from '../common/functions/iterateObject3D'
 import { ColliderComponent } from '../physics/components/ColliderComponent'
 import { PerformanceState } from '../renderer/PerformanceState'
@@ -248,11 +251,32 @@ const resourceCallbacks = {
         resource.metadata.merge({ onGPU: true, discarded: discardUponUpload })
         //@ts-ignore
         // asset.onUpdate = null
-        if (discardUponUpload) {
-          // setTimeout(() => {
-          //   asset.source.data = null
-          //   asset.mipmaps = []
-          // }, 500)
+        const viewer = getState(ReferenceSpaceState).viewerEntity
+        const renderer = getComponent(viewer, RendererComponent)
+        const gl = renderer.renderContext as WebGL2RenderingContext
+        if (discardUponUpload && gl.fenceSync && isIPhone) {
+          const sync = gl.fenceSync(
+            gl.SYNC_GPU_COMMANDS_COMPLETE,
+            gl.getParameter(gl.MAX_CLIENT_WAIT_TIMEOUT_WEBGL) - 1
+          )
+          if (sync) {
+            const checkSync = () => {
+              const status = gl.clientWaitSync(sync, 0, 0)
+              if (
+                status === gl.TIMEOUT_EXPIRED ||
+                status === gl.ALREADY_SIGNALED ||
+                status === gl.CONDITION_SATISFIED
+              ) {
+                gl.deleteSync(sync)
+                resource.metadata.merge({ onGPU: true, discarded: true })
+                asset.source.data = null
+                asset.mipmaps = []
+              } else {
+                requestAnimationFrame(checkSync)
+              }
+            }
+            requestAnimationFrame(checkSync)
+          }
         }
       }
       if ((asset as CompressedTexture).isCompressedTexture && discardUponUpload) {


### PR DESCRIPTION
## Summary
Simply discards textures on iPhone upon GPU upload (this may occasionally break envmaps on iPhone)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
