### PR TITLE
Hardened clientDbToSchema to account for different ways JSON is stored

### DIFF
--- a/packages/common/src/schemas/setting/client-setting.schema.ts
+++ b/packages/common/src/schemas/setting/client-setting.schema.ts
@@ -290,36 +290,31 @@ export const clientSettingPatchValidator = /* @__PURE__ */ getValidator(clientSe
 export const clientSettingQueryValidator = /* @__PURE__ */ getValidator(clientSettingQuerySchema, queryValidator)
 
 export const clientDbToSchema = (rawData: ClientSettingDatabaseType): ClientSettingType => {
-  let appSocialLinks = JSON.parse(rawData.appSocialLinks) as ClientSocialLinkType[]
-
+  let appSocialLinks = rawData.appSocialLinks
+  //In case the column is already pre-parsed JSON
+  if (typeof appSocialLinks === 'string') appSocialLinks = JSON.parse(appSocialLinks)
   // Usually above JSON.parse should be enough. But since our pre-feathers 5 data
   // was serialized multiple times, therefore we need to parse it twice.
-  if (typeof appSocialLinks === 'string') {
-    appSocialLinks = JSON.parse(appSocialLinks)
-  }
+  if (typeof appSocialLinks === 'string') appSocialLinks = JSON.parse(appSocialLinks)
 
-  let themeSettings = JSON.parse(rawData.themeSettings) as Record<string, ClientThemeOptionsType>
-
+  let themeSettings = rawData.themeSettings
+  if (typeof themeSettings === 'string') themeSettings = JSON.parse(themeSettings)
   // Usually above JSON.parse should be enough. But since our pre-feathers 5 data
   // was serialized multiple times, therefore we need to parse it twice.
-  if (typeof themeSettings === 'string') {
-    themeSettings = JSON.parse(themeSettings)
-  }
+  if (typeof themeSettings === 'string') themeSettings = JSON.parse(themeSettings)
 
-  let themeModes = JSON.parse(rawData.themeModes) as Record<string, string>
-
+  let themeModes = rawData.themeModes
+  if (typeof themeModes === 'string') themeModes = JSON.parse(themeModes)
   // Usually above JSON.parse should be enough. But since our pre-feathers 5 data
   // was serialized multiple times, therefore we need to parse it twice.
-  if (typeof themeModes === 'string') {
-    themeModes = JSON.parse(themeModes)
-  }
+  if (typeof themeModes === 'string') themeModes = JSON.parse(themeModes)
 
   if (typeof rawData.mediaSettings === 'string') rawData.mediaSettings = JSON.parse(rawData.mediaSettings)
 
   return {
     ...rawData,
-    appSocialLinks,
-    themeSettings,
-    themeModes
+    appSocialLinks: appSocialLinks as unknown as ClientSocialLinkType[],
+    themeSettings: themeSettings as unknown as Record<string, ClientThemeOptionsType>,
+    themeModes: themeModes as unknown as Record<string, string>
   }
 }


### PR DESCRIPTION
## Summary

Cloud SQL stores JSON as a type `JSON`, and seems to pre-parse this when queried. We assumed how MariaDB was storing it as longtext. Now checking from the start whether they're strings that need to be parsed.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
