### PR TITLE
INT scope trace unhandle to just development(Memory Leak API server)

### DIFF
--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -62,7 +62,7 @@ const kubernetesEnabled = process.env.KUBERNETES === 'true'
 const testEnabled = process.env.TEST === 'true'
 
 if (!testEnabled) {
-  register()
+  if (process.env.APP_ENV === 'development' || process.env.LOCAL === 'true') register()
 
   // ensure process fails properly
   process.on('exit', async (code) => {


### PR DESCRIPTION
## Summary
So trace unhandle is just meant for development. On prod it was ballooning memory. Thank you @jose-galvan for the find.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
