### PR TITLE
fix checkbox event propagating twice

### DIFF
--- a/packages/client-core/src/user/menus/SettingsMenu.tsx
+++ b/packages/client-core/src/user/menus/SettingsMenu.tsx
@@ -34,7 +34,7 @@ import { Slider } from '@ir-engine/ui/editor'
 import { ArrowNarrowLeftLg } from '@ir-engine/ui/src/icons'
 import { OptionType } from '@ir-engine/ui/src/primitives/tailwind/Select'
 import SidebarNavigation from '@ir-engine/ui/src/primitives/tailwind/SidebarNavigation'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { PopoverState } from '../../common/services/PopoverState'
 import { XruiNameplateState } from '../../social/XruiNameplateState'
@@ -289,8 +289,6 @@ export default function SettingsMenu() {
     1: <AudioTab />,
     2: <GraphicsTab />
   }
-
-  useEffect(() => {}, [])
 
   return (
     <div className="absolute z-50 h-fit max-h-[90dvh] w-[50vw] min-w-[720px] max-w-2xl overflow-y-auto rounded-2xl bg-surface-4 p-6 text-text-secondary smh:max-h-[60dvh] smh:p-10">

--- a/packages/ui/src/primitives/tailwind/Checkbox/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Checkbox/index.tsx
@@ -82,7 +82,8 @@ const Checkbox = (
   }: CheckboxProps,
   ref: React.ForwardedRef<HTMLDivElement>
 ) => {
-  const handleChange = () => {
+  const handleChange = (event: React.MouseEvent | React.KeyboardEvent) => {
+    event.stopPropagation()
     if (!disabled && onChange) {
       onChange(!checked)
     }
@@ -98,7 +99,7 @@ const Checkbox = (
         description && 'items-start'
       )}
       onKeyDown={(e) => {
-        if (['Enter', ' '].includes(e.key)) handleChange()
+        if (['Enter', ' '].includes(e.key)) handleChange(e)
       }}
       tabIndex={0}
       {...props}


### PR DESCRIPTION
## Summary

when checkbox was clicked earlier, it used to sometimes check and uncheck rapidly due to double clicking internally. we should stop the event propagation whenever any element inside the checkbox is clicked
