### PR TITLE
IR-7992 hover interact fix

### DIFF
--- a/packages/engine/src/interaction/components/InteractableComponent.ts
+++ b/packages/engine/src/interaction/components/InteractableComponent.ts
@@ -31,6 +31,7 @@ import {
   EntityTreeComponent,
   getComponent,
   getMutableComponent,
+  getSimulationCounterpart,
   removeComponent,
   removeEntity,
   setComponent,
@@ -248,7 +249,7 @@ export const InteractableComponent = defineComponent({
     uiEntity: S.NonSerialized(S.Entity()),
     label: S.String('E'),
     uiVisibilityOverride: S.NonSerialized(S.Enum(XRUIVisibilityOverride, XRUIVisibilityOverride.none)),
-    uiActivationType: S.NonSerialized(S.Enum(XRUIActivationType, XRUIActivationType.proximity)),
+    uiActivationType: S.Enum(XRUIActivationType, XRUIActivationType.proximity),
     activationDistance: S.Number(2),
     clickInteract: S.Bool(false),
     highlighted: S.NonSerialized(S.Bool(false)),
@@ -307,8 +308,9 @@ export const InteractableComponent = defineComponent({
     )
 
     useEffect(() => {
+      const simulationEntity = getSimulationCounterpart(entity)
       if (!isEditing.value) {
-        const uiEntity = addInteractableUI(entity)
+        const uiEntity = addInteractableUI(simulationEntity)
         return () => {
           if (uiEntity) {
             removeEntity(uiEntity)


### PR DESCRIPTION
## Summary
hover interact fix

when hover activation mode is selected it now propagates correctly, mousing over the entity will pop up the interaction label

![image](https://github.com/user-attachments/assets/4ce141fe-ea31-4e62-9fcb-9bc9a1c2362f)


## References
[https://tsu.atlassian.net/browse/IR-7992](https://tsu.atlassian.net/browse/IR-7992)

