### PR TITLE
Fix Thumbnails: added timeout to trigger resources refetch

### DIFF
--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -160,7 +160,7 @@ const uploadThumbnail = async (src: string, projectName: string, blob: Blob | nu
           }
           updateThumbnailKey(staticResourceId)
         } else {
-          console.error('static Resource not foudn for key - ', fileKeyKey)
+          console.error('static Resource not found for key - ', fileKeyKey)
         }
       })
       .catch((e) => console.error(e))
@@ -185,7 +185,8 @@ export const FileThumbnailJobState = defineState({
   name: 'FileThumbnailJobState',
   initial: {
     seenResources: [] as string[],
-    jobs: [] as ThumbnailJob[]
+    jobs: [] as ThumbnailJob[],
+    refreshIndex: 0
   },
   reactor: () => <ThumbnailJobReactor />,
   removeCurrentJob: () => {

--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -408,8 +408,19 @@ function ResourceItems() {
   }
 
   const thumbnailJobState = useMutableState(FileThumbnailJobState)
+  const debouncedRefetchResourcesRef = useRef<ReturnType<typeof setTimeout>>()
+
   useEffect(() => {
-    refetchResources()
+    clearTimeout(debouncedRefetchResourcesRef.current)
+  }, [])
+
+  useEffect(() => {
+    if (debouncedRefetchResourcesRef) {
+      clearTimeout(debouncedRefetchResourcesRef.current)
+    }
+    debouncedRefetchResourcesRef.current = setTimeout(() => {
+      refetchResources()
+    }, 500)
   }, [thumbnailJobState.jobs.length])
 
   return (


### PR DESCRIPTION
added a debounced timeout to trigger a refetchResources 0.5 sec after the last thumbnailJobState.jobs.length reaction

## Summary
https://tsu.atlassian.net/browse/IR-7830

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
