### PR TITLE
[MT-Dev.GCP] Studio: Transform component is missing when object is placed using "Place Object at Origin" option

### DIFF
--- a/packages/editor/src/panels/files/contextmenu.tsx
+++ b/packages/editor/src/panels/files/contextmenu.tsx
@@ -219,7 +219,9 @@ export function FileContextMenu({
         selectedFiles
           .filter((file) => !file.isFolder.value)
           .map((file) => {
-            addMediaNode(file.url.value)
+            addMediaNode(file.url.value, undefined, undefined, [
+              { name: TransformComponent.jsonID, props: { position: new Vector3() } }
+            ])
           })
         setAnchorEvent(undefined)
       },


### PR DESCRIPTION
## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-7535

## QA Steps
