### PR TITLE
Use isIphone check instead for forcing default avatars on ios

### DIFF
--- a/packages/client-core/src/networking/AvatarSpawnSystem.tsx
+++ b/packages/client-core/src/networking/AvatarSpawnSystem.tsx
@@ -58,7 +58,7 @@ import { EngineState, useChildrenWithComponents } from '@ir-engine/ecs'
 import { AvatarNetworkAction } from '@ir-engine/engine/src/avatar/state/AvatarNetworkActions'
 import { ErrorComponent } from '@ir-engine/engine/src/scene/components/ErrorComponent'
 import { SceneSettingsComponent } from '@ir-engine/engine/src/scene/components/SceneSettingsComponent'
-import { iOS } from '@ir-engine/spatial/src/common/functions/isMobile'
+import { isIPhone } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { SearchParamState } from '../common/services/RouterService'
 import { useLoadedSceneEntity } from '../hooks/useLoadedSceneEntity'
 import { LocationState } from '../social/services/LocationService'
@@ -109,7 +109,7 @@ export const AvatarSpawnReactor = (props: { sceneEntity: Entity }) => {
     const avatarSpawnPose = getRandomSpawnPoint(userID)
     const user = getState(AuthState).user
     /**@todo force default avatars. Temporary solution for memory related crashing on iOS. */
-    const avatarURL = iOS
+    const avatarURL = isIPhone
       ? config.client.fileServer + '/projects/ir-engine/default-project/assets/avatars/irRobot.vrm'
       : userAvatar.avatar.modelResource!.url
     spawnLocalAvatarInWorld({
@@ -152,7 +152,7 @@ export const AvatarSpawnReactor = (props: { sceneEntity: Entity }) => {
   useEffect(() => {
     if (isSpectating || !userAvatar) return
     /**@todo force default avatars. Temporary solution for memory related crashing on iOS. */
-    const avatarURL = iOS
+    const avatarURL = isIPhone
       ? config.client.fileServer + '/projects/ir-engine/default-project/assets/avatars/irRobot.vrm'
       : userAvatar.avatar.modelResource!.url
     dispatchAction(

--- a/packages/client-core/src/user/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/menus/ProfileMenu.tsx
@@ -52,7 +52,7 @@ import {
 import { API } from '@ir-engine/common'
 import { USERNAME_MAX_LENGTH } from '@ir-engine/common/src/constants/UserConstants'
 import { INVALID_USER_NAME_REGEX } from '@ir-engine/common/src/regex'
-import { iOS, isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
+import { isIPhone, isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { Button, Checkbox, Input, Tooltip } from '@ir-engine/ui'
 import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 import {
@@ -384,7 +384,7 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
             <AvatarImage size="large" src={avatarThumbnail} className="object-cover" />
             {
               /**@todo disable avatar editing on iOS. Temporary solution for memory related crashing on iOS. */
-              !iOS && (
+              !isIPhone && (
                 <button
                   onClick={() => {
                     PopoverState.showPopupover(


### PR DESCRIPTION
## Summary
I have gotten at least one report of default avatars still being visible on iphone so im switching to the isIphone check in hopes that helps. I can't test because I don't have an iphone.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
