### PR TITLE
Add scene delta state key validation for migration on scene name change

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -242,7 +242,7 @@ const modifyMaterial = (nodes: string[], materialId: EntityUUID, properties: { [
       setupMaterialParameters(materialEntity, getComponent(materialEntity, MaterialStateComponent).material)
       EditorState.markModifiedScene(materialEntity)
       if (!EditorState.isInActiveScene(materialEntity)) {
-        SceneDeltaState.registerMaterialDelta(materialEntity, props)
+        SceneDeltaState.registerMaterialDelta(materialEntity, props, materialComponent.prototype.value)
       }
     })
 

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -55,6 +55,7 @@ import { SourceComponent } from '@ir-engine/engine/src/scene/components/SourceCo
 import { VideoComponent } from '@ir-engine/engine/src/scene/components/VideoComponent'
 import { VolumetricComponent } from '@ir-engine/engine/src/scene/components/VolumetricComponent'
 import { serializeEntity } from '@ir-engine/engine/src/scene/functions/serializeWorld'
+import { SceneDeltaState } from '@ir-engine/engine/src/scene/systems/SceneDeltaState'
 import { ComponentJsonType } from '@ir-engine/engine/src/scene/types/SceneTypes'
 import { getState } from '@ir-engine/hyperflux'
 import { MeshComponent } from '@ir-engine/spatial/src/renderer/components/MeshComponent'
@@ -137,6 +138,8 @@ export async function addMediaNode(
               /**scene deltas do not yet support this, so a temporary hackfix is to modify existing materials to match */
               const materialComponent = getComponent(material, MaterialStateComponent)
               const materialToMutate = UUIDComponent.getEntityByUUID(uuids[materialIndex], Layers.Authoring)
+              // wipe out any existing deltas for this material
+              SceneDeltaState.registerMaterialDelta(entity, {})
               EditorControlFunctions.updateMaterialPrototype(
                 materialToMutate,
                 materialComponent.material.userData?.type ?? materialComponent.material.type

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -807,11 +807,12 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
       const materialDelta = nodeDelta[MATERIAL_JSON_ID]
       const materialPrototype = nodeDelta[MATERIAL_PROTOTYPE_JSON_ID]
       if (materialDelta) {
-        const prototype = getState(MaterialPrototypeDefinitions)[materialPrototype ?? materialConstructor.name] // this is insanely brittle but will do for now
-        if (materialPrototype) {
-          materialConstructor = prototype.prototypeConstructor
-          materialConstructorParameters = {}
-        }
+        const prototype = getState(MaterialPrototypeDefinitions)[materialPrototype]
+        materialConstructor = prototype.prototypeConstructor
+        // optionally serializing the uuid to determine if we need to replace the material -
+        // this is insanely brittle but will do for now
+        if (materialDelta.uuid) materialConstructorParameters = {}
+
         for (const key in materialDelta) {
           switch (prototype.arguments[key]?.type) {
             case 'color':
@@ -845,7 +846,11 @@ const loadMaterial = async (options: GLTFParserOptions, materialIndex: number) =
   material.name = materialDef.name || 'Material-' + materialIndex
 
   setComponent(materialEntity, MaterialStateComponent, { material })
-  setupMaterialParameters(materialEntity, materialConstructorParameters)
+  setupMaterialParameters(materialEntity, {
+    ...materialConstructorParameters,
+    uuid: material.uuid,
+    name: material.name
+  })
 
   assignExtrasToUserData(material, materialDef)
 

--- a/packages/engine/src/gltf/GLTFState.tsx
+++ b/packages/engine/src/gltf/GLTFState.tsx
@@ -48,7 +48,7 @@ import {
   useOptionalComponent,
   useQuery
 } from '@ir-engine/ecs'
-import { defineState, getMutableState, startReactor } from '@ir-engine/hyperflux'
+import { defineState, getMutableState, none, startReactor } from '@ir-engine/hyperflux'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
 import { ObjectComponent } from '@ir-engine/spatial/src/renderer/components/ObjectComponent'
 import { SceneComponent } from '@ir-engine/spatial/src/renderer/components/SceneComponents'
@@ -87,7 +87,7 @@ export const SceneState = defineState({
         )
       }
       AssetState.unload(gltfEntity)
-      getMutableState(SceneState)[sceneURL].set(gltfEntity)
+      getMutableState(SceneState)[sceneURL].set(none)
     }
   }
 })

--- a/packages/engine/src/scene/systems/SceneDeltaState.tsx
+++ b/packages/engine/src/scene/systems/SceneDeltaState.tsx
@@ -73,7 +73,7 @@ export const SceneDeltaState = defineState({
     const source = state[sourceID]
     if (!source.value[nodeID]) source[nodeID].set({} as MaterialDeltaEntry)
     const componentMap = source[nodeID].get(NO_PROXY_STEALTH) as MaterialDeltaEntry
-    if (props) componentMap[MATERIAL_JSON_ID] = { ...props }
+    if (props) componentMap[MATERIAL_JSON_ID] = { ...componentMap[MATERIAL_JSON_ID], ...props }
     if (prototype) componentMap[MATERIAL_PROTOTYPE_JSON_ID] = prototype
     source[nodeID].set(componentMap)
   },
@@ -91,10 +91,16 @@ export const SceneDeltaState = defineState({
     // validate deltas by checking for changes in the scene name, then update deltas accordingly
     const sceneSource = useMutableState(NodesBySourceState)
     useEffect(() => {
-      if (!sceneSource[sceneSource.keys[0]].value) return
-      const nodes = sceneSource[sceneSource.keys[0]].value as Record<NodeID, Entity>
-      const deltas = getMutableState(SceneDeltaState)
+      let nodes = null as Record<string, Entity> | null
+      // get the source for the current root
+      for (const source in sceneSource.value) {
+        if (source.includes(currentRoot.value)) {
+          nodes = sceneSource[source].get(NO_PROXY)
+          break
+        }
+      }
 
+      const deltas = getMutableState(SceneDeltaState)
       for (const delta in deltas.value) {
         for (const node in nodes) {
           if (delta.includes(node)) {
@@ -111,7 +117,7 @@ export const SceneDeltaState = defineState({
           }
         }
       }
-    }, [sceneSource.keys[0]])
+    }, [sceneSource.keys])
     return null
   }
 })

--- a/packages/engine/src/scene/systems/SceneDeltaState.tsx
+++ b/packages/engine/src/scene/systems/SceneDeltaState.tsx
@@ -88,7 +88,7 @@ export const SceneDeltaState = defineState({
       }
     }, [sceneState.keys])
 
-    // check for changes in the scene name to update deltas accordingly
+    // validate deltas by checking for changes in the scene name, then update deltas accordingly
     const sceneSource = useMutableState(NodesBySourceState)
     useEffect(() => {
       if (!sceneSource[sceneSource.keys[0]].value) return
@@ -104,6 +104,7 @@ export const SceneDeltaState = defineState({
                   getComponent(nodes[node], GLTFComponent).src
                 }` as SourceID
               )
+              if (newSourceID === delta) continue
               deltas[newSourceID].set(deltas[delta].get(NO_PROXY))
               deltas[delta].set(none)
             }

--- a/packages/engine/src/scene/systems/SceneDeltaState.tsx
+++ b/packages/engine/src/scene/systems/SceneDeltaState.tsx
@@ -23,10 +23,18 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { Component, Entity, getComponent, hasComponent, SerializedComponentType } from '@ir-engine/ecs'
-import { NodeID, NodeIDComponent } from '@ir-engine/engine/src/gltf/NodeIDComponent'
+import { Component, Entity, getComponent, hasComponent, SerializedComponentType, UUIDComponent } from '@ir-engine/ecs'
+import { NodeID, NodeIDComponent, NodesBySourceState } from '@ir-engine/engine/src/gltf/NodeIDComponent'
 import { SourceComponent, SourceID } from '@ir-engine/engine/src/scene/components/SourceComponent'
-import { defineState, getMutableState, NO_PROXY_STEALTH, useHookstate, useMutableState } from '@ir-engine/hyperflux'
+import {
+  defineState,
+  getMutableState,
+  NO_PROXY,
+  NO_PROXY_STEALTH,
+  none,
+  useHookstate,
+  useMutableState
+} from '@ir-engine/hyperflux'
 import { useEffect } from 'react'
 import { GLTFComponent } from '../../gltf/GLTFComponent'
 import { SceneState } from '../../gltf/GLTFState'
@@ -79,6 +87,30 @@ export const SceneDeltaState = defineState({
         currentRoot.set(newRoot)
       }
     }, [sceneState.keys])
+
+    // check for changes in the scene name to update deltas accordingly
+    const sceneSource = useMutableState(NodesBySourceState)
+    useEffect(() => {
+      if (!sceneSource[sceneSource.keys[0]].value) return
+      const nodes = sceneSource[sceneSource.keys[0]].value as Record<NodeID, Entity>
+      const deltas = getMutableState(SceneDeltaState)
+
+      for (const delta in deltas.value) {
+        for (const node in nodes) {
+          if (delta.includes(node)) {
+            if (hasComponent(nodes[node], GLTFComponent)) {
+              const newSourceID = GLTFComponent.removeHashes(
+                `${getComponent(nodes[node], UUIDComponent)}-${
+                  getComponent(nodes[node], GLTFComponent).src
+                }` as SourceID
+              )
+              deltas[newSourceID].set(deltas[delta].get(NO_PROXY))
+              deltas[delta].set(none)
+            }
+          }
+        }
+      }
+    }, [sceneSource.keys[0]])
     return null
   }
 })

--- a/packages/spatial/src/renderer/materials/materialFunctions.ts
+++ b/packages/spatial/src/renderer/materials/materialFunctions.ts
@@ -154,6 +154,9 @@ export const setupMaterialParameters = (entity: Entity, properties: { [_: string
     }
   })
 
-  setComponent(entity, MaterialStateComponent, { parameters: params })
+  setComponent(entity, MaterialStateComponent, {
+    parameters: params,
+    prototype: properties.userData?.type || properties.type
+  })
   return params
 }


### PR DESCRIPTION
## Summary
Currently scene deltas will never be applied due to source component changes on scene save as / rename. This is some tentative logic to detect changes and correct them.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-8117

## QA Steps
