### PR TITLE
Fix get entities by name error

### DIFF
--- a/packages/spatial/src/common/NameComponent.ts
+++ b/packages/spatial/src/common/NameComponent.ts
@@ -70,6 +70,7 @@ export const NameComponent = defineComponent({
 
   /** @deprecated - will be removed in the future */
   getEntitiesByName: (name: string) => {
-    return [...getState(NameComponentState).entitiesByName[name]]
+    const entities = getState(NameComponentState).entitiesByName[name]
+    return entities ? [...entities] : []
   }
 })


### PR DESCRIPTION
Fixes error thrown if getEntitiesByName has no entities with a given name
