### PR TITLE
Bug Fix - IR-7845 - Fix avatars not spawning at specified spawn point

### DIFF
--- a/packages/client-core/src/networking/AvatarSpawnSystem.tsx
+++ b/packages/client-core/src/networking/AvatarSpawnSystem.tsx
@@ -57,7 +57,6 @@ import { EngineState, useChildrenWithComponents } from '@ir-engine/ecs'
 import { AvatarNetworkAction } from '@ir-engine/engine/src/avatar/state/AvatarNetworkActions'
 import { ErrorComponent } from '@ir-engine/engine/src/scene/components/ErrorComponent'
 import { SceneSettingsComponent } from '@ir-engine/engine/src/scene/components/SceneSettingsComponent'
-import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics.ts'
 import { SearchParamState } from '../common/services/RouterService'
 import { useLoadedSceneEntity } from '../hooks/useLoadedSceneEntity'
 import { LocationState } from '../social/services/LocationService'
@@ -100,10 +99,9 @@ export const AvatarSpawnReactor = (props: { sceneEntity: Entity }) => {
   })
 
   const userAvatar = userAvatarQuery.data[0]
-  const physicsWorld = Physics.useWorld(sceneEntity)!
 
   useEffect(() => {
-    if (isSpectating || !userAvatar || !physicsWorld) return
+    if (isSpectating || !userAvatar) return
 
     const rootUUID = getComponent(sceneEntity, UUIDComponent)
     const avatarSpawnPose = getRandomSpawnPoint(userID)
@@ -129,7 +127,7 @@ export const AvatarSpawnReactor = (props: { sceneEntity: Entity }) => {
         dispatchAction(WorldNetworkAction.destroyEntity({ entityUUID: getComponent(selfAvatarEntity, UUIDComponent) }))
       }
     }
-  }, [isSpectating, !!userAvatar, physicsWorld])
+  }, [isSpectating, !!userAvatar])
 
   const selfAvatarEntity = AvatarComponent.useSelfAvatarEntity()
   const errorWithAvatar = useHasComponent(selfAvatarEntity, ErrorComponent)

--- a/packages/client-core/src/networking/AvatarSpawnSystem.tsx
+++ b/packages/client-core/src/networking/AvatarSpawnSystem.tsx
@@ -57,6 +57,7 @@ import { EngineState, useChildrenWithComponents } from '@ir-engine/ecs'
 import { AvatarNetworkAction } from '@ir-engine/engine/src/avatar/state/AvatarNetworkActions'
 import { ErrorComponent } from '@ir-engine/engine/src/scene/components/ErrorComponent'
 import { SceneSettingsComponent } from '@ir-engine/engine/src/scene/components/SceneSettingsComponent'
+import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics.ts'
 import { SearchParamState } from '../common/services/RouterService'
 import { useLoadedSceneEntity } from '../hooks/useLoadedSceneEntity'
 import { LocationState } from '../social/services/LocationService'
@@ -99,9 +100,10 @@ export const AvatarSpawnReactor = (props: { sceneEntity: Entity }) => {
   })
 
   const userAvatar = userAvatarQuery.data[0]
+  const physicsWorld = Physics.useWorld(sceneEntity)!
 
   useEffect(() => {
-    if (isSpectating || !userAvatar) return
+    if (isSpectating || !userAvatar || !physicsWorld) return
 
     const rootUUID = getComponent(sceneEntity, UUIDComponent)
     const avatarSpawnPose = getRandomSpawnPoint(userID)
@@ -127,7 +129,7 @@ export const AvatarSpawnReactor = (props: { sceneEntity: Entity }) => {
         dispatchAction(WorldNetworkAction.destroyEntity({ entityUUID: getComponent(selfAvatarEntity, UUIDComponent) }))
       }
     }
-  }, [isSpectating, !!userAvatar])
+  }, [isSpectating, !!userAvatar, physicsWorld])
 
   const selfAvatarEntity = AvatarComponent.useSelfAvatarEntity()
   const errorWithAvatar = useHasComponent(selfAvatarEntity, ErrorComponent)

--- a/packages/engine/src/avatar/state/AvatarNetworkState.tsx
+++ b/packages/engine/src/avatar/state/AvatarNetworkState.tsx
@@ -40,6 +40,7 @@ import { AvatarNetworkAction } from '@ir-engine/engine/src/avatar/state/AvatarNe
 import { defineState, getMutableState, none, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { WorldNetworkAction } from '@ir-engine/network'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
+import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics.ts'
 import { TransformComponent } from '@ir-engine/spatial/src/transform/components/TransformComponent'
 import { GLTFComponent } from '../../gltf/GLTFComponent'
 
@@ -85,11 +86,12 @@ const AvatarReactor = ({ entityUUID }: { entityUUID: EntityUUID }) => {
   const { avatarURL, name } = useHookstate(getMutableState(AvatarState)[entityUUID])
   const entity = UUIDComponent.useEntityByUUID(entityUUID)
   const hasTransformComponent = useOptionalComponent(entity, TransformComponent)
+  const physicsWorld = Physics.useWorld(entity)!
 
   useLayoutEffect(() => {
-    if (!entity || !hasTransformComponent) return
+    if (!entity || !hasTransformComponent || !physicsWorld) return
     spawnAvatarReceptor(entityUUID)
-  }, [entity, hasTransformComponent])
+  }, [entity, hasTransformComponent, physicsWorld])
 
   useEffect(() => {
     if (!entity || !avatarURL.value) return


### PR DESCRIPTION
## Summary
Resolves [BUG IR-7845](https://tsu.atlassian.net/browse/IR-7845?atlOrigin=eyJpIjoiY2U1MjFmNjhiZTA2NGI2Yjg4NmRjMTRjYzJlYmM3NmMiLCJwIjoiaiJ9)
This fix adds physicsWorld as a dependency to AvatarReactor's useEffect(), so the physics world is ready for the avatar entity before the AvatarReceptor spawns the avatar. See the comments in the bug link for rationale. 

## Subtasks Checklist
N/A

## Breaking Changes
None

## References
[BUG IR-7845](https://tsu.atlassian.net/browse/IR-7845?atlOrigin=eyJpIjoiY2U1MjFmNjhiZTA2NGI2Yjg4NmRjMTRjYzJlYmM3NmMiLCJwIjoiaiJ9)

## QA Steps
1. Move the spawn point to any point not on or near world 0, 0, 0. 
2. Publish the scene. 
3. The avatar should spawn at the correct spawn point