### PR TITLE
add physics world body check before updating avatar's local position

### DIFF
--- a/packages/engine/src/avatar/functions/moveAvatar.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.ts
@@ -376,6 +376,8 @@ export const translateAndRotateAvatar = (entity: Entity, translation: Vector3, r
 export const updateLocalAvatarPosition = (entity: Entity) => {
   const world = Physics.getWorld(entity)
   if (!world) return
+  const body = world.Rigidbodies.get(entity) // check for body, else we could update the entity transform position to rigid body's default value (0, 0, 0), because physics world hasn't created and updated the body, yet
+  if (!body) return
 
   const rigidbody = getComponent(entity, RigidBodyComponent)
   const transform = getComponent(entity, TransformComponent)

--- a/packages/engine/src/avatar/state/AvatarNetworkState.tsx
+++ b/packages/engine/src/avatar/state/AvatarNetworkState.tsx
@@ -40,6 +40,7 @@ import { AvatarNetworkAction } from '@ir-engine/engine/src/avatar/state/AvatarNe
 import { defineState, getMutableState, none, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { WorldNetworkAction } from '@ir-engine/network'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
+import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics.ts'
 import { TransformComponent } from '@ir-engine/spatial/src/transform/components/TransformComponent'
 import { GLTFComponent } from '../../gltf/GLTFComponent'
 
@@ -85,11 +86,12 @@ const AvatarReactor = ({ entityUUID }: { entityUUID: EntityUUID }) => {
   const { avatarURL, name } = useHookstate(getMutableState(AvatarState)[entityUUID])
   const entity = UUIDComponent.useEntityByUUID(entityUUID)
   const hasTransformComponent = useOptionalComponent(entity, TransformComponent)
+  const physicsWorld = Physics.useWorld(entity)!
 
   useLayoutEffect(() => {
-    if (!entity || !hasTransformComponent) return
+    if (!entity || !hasTransformComponent || !physicsWorld) return
     spawnAvatarReceptor(entityUUID)
-  }, [entity, hasTransformComponent])
+  }, [entity, hasTransformComponent, physicsWorld])
 
   useEffect(() => {
     if (!entity || !avatarURL.value) return

--- a/packages/engine/src/avatar/state/AvatarNetworkState.tsx
+++ b/packages/engine/src/avatar/state/AvatarNetworkState.tsx
@@ -40,7 +40,6 @@ import { AvatarNetworkAction } from '@ir-engine/engine/src/avatar/state/AvatarNe
 import { defineState, getMutableState, none, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { WorldNetworkAction } from '@ir-engine/network'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
-import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics.ts'
 import { TransformComponent } from '@ir-engine/spatial/src/transform/components/TransformComponent'
 import { GLTFComponent } from '../../gltf/GLTFComponent'
 
@@ -86,12 +85,11 @@ const AvatarReactor = ({ entityUUID }: { entityUUID: EntityUUID }) => {
   const { avatarURL, name } = useHookstate(getMutableState(AvatarState)[entityUUID])
   const entity = UUIDComponent.useEntityByUUID(entityUUID)
   const hasTransformComponent = useOptionalComponent(entity, TransformComponent)
-  const physicsWorld = Physics.useWorld(entity)!
 
   useLayoutEffect(() => {
-    if (!entity || !hasTransformComponent || !physicsWorld) return
+    if (!entity || !hasTransformComponent) return
     spawnAvatarReceptor(entityUUID)
-  }, [entity, hasTransformComponent, physicsWorld])
+  }, [entity, hasTransformComponent])
 
   useEffect(() => {
     if (!entity || !avatarURL.value) return


### PR DESCRIPTION
## Summary
Resolves [BUG IR-7845](https://tsu.atlassian.net/browse/IR-7845?atlOrigin=eyJpIjoiY2U1MjFmNjhiZTA2NGI2Yjg4NmRjMTRjYzJlYmM3NmMiLCJwIjoiaiJ9)
This fix adds a check for a physics world rigid body for the avatar entity, before updating the avatar's local position. This prevents us from updating the avatar's TransformComponent's position with a default RigidBodyComponents position (0, 0, 0), in the event the avatar loads and attempts to update it's position before the physics world creates a rigid body for the avatar entity, and updates it's RigidBodyComponents position properly. 

## Subtasks Checklist
N/A

## Breaking Changes
N/A

## References
[BUG IR-7845](https://tsu.atlassian.net/browse/IR-7845?atlOrigin=eyJpIjoiY2U1MjFmNjhiZTA2NGI2Yjg4NmRjMTRjYzJlYmM3NmMiLCJwIjoiaiJ9)

## QA Steps
Move the spawn point to any point not on or near world 0, 0, 0.
Publish the scene.
The avatar should spawn at the correct spawn point