### PR TITLE
Fix for onClose events being fired when incorrectly

### DIFF
--- a/packages/ui/src/primitives/tailwind/ClickawayListener/index.tsx
+++ b/packages/ui/src/primitives/tailwind/ClickawayListener/index.tsx
@@ -57,12 +57,10 @@ const ClickawayListener = (props: { children: React.ReactNode; onClickOutside: V
       }
     }
 
-    document.addEventListener('mousedown', handler)
-    document.addEventListener('touchstart', handler)
+    document.addEventListener('pointerup', handler)
 
     return () => {
-      document.removeEventListener('mousedown', handler)
-      document.removeEventListener('touchstart', handler)
+      document.removeEventListener('pointerup', handler)
     }
   }, [])
 


### PR DESCRIPTION
## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
