### PR TITLE
rename PopoverState to ModalState

### DIFF
--- a/packages/client-core/src/admin/components/avatar/AddEditAvatarModal.tsx
+++ b/packages/client-core/src/admin/components/avatar/AddEditAvatarModal.tsx
@@ -27,7 +27,7 @@ import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiArrowPath } from 'react-icons/hi2'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { AvatarService } from '@ir-engine/client-core/src/user/services/AvatarService'
 import { THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH } from '@ir-engine/common/src/constants/AvatarConstants'
 import { AvatarType } from '@ir-engine/common/src/schema.type.module'
@@ -135,14 +135,14 @@ export default function AddEditAvatarModal({ avatar }: { avatar?: AvatarType }) 
       if (avatar?.id) {
         try {
           await AvatarService.patchAvatar(avatar, avatarAssets.name.value, true, avatarFile, avatarThumbnail)
-          PopoverState.hidePopupover()
+          ModalState.closeModal()
         } catch (e) {
           error.serverError.set(e.message)
         }
       } else {
         try {
           await AvatarService.createAvatar(avatarFile, avatarThumbnail, avatarAssets.name.value, true)
-          PopoverState.hidePopupover()
+          ModalState.closeModal()
         } catch (e) {
           error.serverError.set(e.message)
         }
@@ -222,7 +222,7 @@ export default function AddEditAvatarModal({ avatar }: { avatar?: AvatarType }) 
       title={avatar?.id ? t('admin:components.avatar.update') : t('admin:components.avatar.add')}
       className="w-[50vw]"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitButtonDisabled={
         avatarAssets.name.value.length === 0 ||
         (avatarAssets.source.value === 'file' && (!avatarAssets.model.value || !avatarAssets.thumbnail.value)) ||

--- a/packages/client-core/src/admin/components/avatar/AvatarTable.tsx
+++ b/packages/client-core/src/admin/components/avatar/AvatarTable.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useMutation, useSearch } from '@ir-engine/common'
 import { AvatarID, AvatarType, UserName, avatarPath } from '@ir-engine/common/src/schema.type.module'
 import { isValidId } from '@ir-engine/common/src/utils/isValidId'
@@ -108,7 +108,7 @@ export default function AvatarTable({ search }: { search: string }) {
           <ActionButton
             icon={Edit01Lg}
             title={t('admin:components.common.view')}
-            onClick={() => PopoverState.showPopupover(<AddEditAvatarModal avatar={row} />)}
+            onClick={() => ModalState.openModal(<AddEditAvatarModal avatar={row} />)}
             variant="green"
           />
 
@@ -116,7 +116,7 @@ export default function AvatarTable({ search }: { search: string }) {
             icon={Trash04Lg}
             title={t('admin:components.common.delete')}
             onClick={() => {
-              PopoverState.showPopupover(
+              ModalState.openModal(
                 <ConfirmDialog
                   text={`${t('admin:components.avatar.confirmAvatarDelete')} '${row.name}'?`}
                   onSubmit={async () => {

--- a/packages/client-core/src/admin/components/avatar/index.tsx
+++ b/packages/client-core/src/admin/components/avatar/index.tsx
@@ -27,7 +27,7 @@ import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiMagnifyingGlass, HiPlus } from 'react-icons/hi2'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useHookstate } from '@ir-engine/hyperflux'
 import { Button, Input } from '@ir-engine/ui'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
@@ -70,7 +70,7 @@ export default function Avatars() {
               size="sm"
               fullWidth
               onClick={() => {
-                PopoverState.showPopupover(<AddEditAvatarModal />)
+                ModalState.openModal(<AddEditAvatarModal />)
               }}
             >
               <HiPlus />

--- a/packages/client-core/src/admin/components/channel/AddEditChannelModal.tsx
+++ b/packages/client-core/src/admin/components/channel/AddEditChannelModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useMutation } from '@ir-engine/common'
 import { channelPath, ChannelType } from '@ir-engine/common/src/schema.type.module'
 import { useHookstate } from '@ir-engine/hyperflux'
@@ -61,7 +61,7 @@ export default function AddEditChannelModal({ channel }: { channel?: ChannelType
       } else {
         channelMutation.create({ name: channelName.value })
       }
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (err) {
       errors.serverError.set(err.message)
     }
@@ -72,7 +72,7 @@ export default function AddEditChannelModal({ channel }: { channel?: ChannelType
       title={channel?.id ? t('admin:components.channel.update') : t('admin:components.channel.createChannel')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitLoading={submitLoading.value}
     >
       {errors.serverError.value && <p className="mb-3 text-red-700">{errors.serverError.value}</p>}

--- a/packages/client-core/src/admin/components/channel/ChannelTable.tsx
+++ b/packages/client-core/src/admin/components/channel/ChannelTable.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useMutation, useSearch } from '@ir-engine/common'
 import { channelPath, ChannelType } from '@ir-engine/common/src/schema.type.module'
 import { isValidId } from '@ir-engine/common/src/utils/isValidId'
@@ -94,7 +94,7 @@ export default function ChannelTable({
           <ActionButton
             icon={Edit01Lg}
             title={t('admin:components.common.view')}
-            onClick={() => PopoverState.showPopupover(<AddEditChannelModal channel={row} />)}
+            onClick={() => ModalState.openModal(<AddEditChannelModal channel={row} />)}
             variant="green"
           />
 
@@ -102,7 +102,7 @@ export default function ChannelTable({
             icon={Trash04Lg}
             title={t('admin:components.common.delete')}
             onClick={() =>
-              PopoverState.showPopupover(
+              ModalState.openModal(
                 <ConfirmDialog
                   text={`${t('admin:components.channel.confirmChannelDelete')} '${row.name}'?`}
                   onSubmit={async () => {

--- a/packages/client-core/src/admin/components/channel/index.tsx
+++ b/packages/client-core/src/admin/components/channel/index.tsx
@@ -27,7 +27,7 @@ import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiMagnifyingGlass, HiPlus, HiTrash } from 'react-icons/hi2'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useMutation } from '@ir-engine/common'
 import { channelPath, ChannelType } from '@ir-engine/common/src/schema.type.module'
 import { useHookstate } from '@ir-engine/hyperflux'
@@ -79,7 +79,7 @@ export default function Channels() {
                   size="sm"
                   fullWidth
                   onClick={() => {
-                    PopoverState.showPopupover(
+                    ModalState.openModal(
                       <ConfirmDialog
                         text={t('admin:components.channel.confirmMultiChannelDelete')}
                         onSubmit={async () => {
@@ -103,7 +103,7 @@ export default function Channels() {
                 size="sm"
                 fullWidth
                 onClick={() => {
-                  PopoverState.showPopupover(<AddEditChannelModal />)
+                  ModalState.openModal(<AddEditChannelModal />)
                 }}
               >
                 <HiPlus />

--- a/packages/client-core/src/admin/components/instance/InstanceTable.tsx
+++ b/packages/client-core/src/admin/components/instance/InstanceTable.tsx
@@ -30,7 +30,7 @@ import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 import { EyeLg, Trash04Lg } from '@ir-engine/ui/src/icons'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import DataTable from '../../common/Table'
 import { instanceColumns } from '../../common/constants/instance'
 import ActionButton from '../ActionButton'
@@ -79,14 +79,14 @@ export default function InstanceTable({ search }: { search: string }) {
           <ActionButton
             icon={EyeLg}
             onClick={() => {
-              PopoverState.showPopupover(<ViewModal instanceId={row.id} />)
+              ModalState.openModal(<ViewModal instanceId={row.id} />)
             }}
           />
 
           <ActionButton
             icon={Trash04Lg}
             onClick={() => {
-              PopoverState.showPopupover(
+              ModalState.openModal(
                 <ConfirmDialog
                   text={`${t('admin:components.instance.confirmInstanceDelete')} (${row.id}) ?`}
                   onSubmit={async () => {

--- a/packages/client-core/src/admin/components/instance/PatchServerModal.tsx
+++ b/packages/client-core/src/admin/components/instance/PatchServerModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useMutation } from '@ir-engine/common'
 import { LocationID, locationPath } from '@ir-engine/common/src/schema.type.module'
 import { useHookstate } from '@ir-engine/hyperflux'
@@ -51,7 +51,7 @@ export default function PatchServerModal() {
         NotificationService.dispatchNotify(patchResponse.message, {
           variant: patchResponse.status ? 'success' : 'error'
         })
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
       })
       .catch((e) => {
         state.locationError.set(e.message)
@@ -73,7 +73,7 @@ export default function PatchServerModal() {
       title={t('admin:components.setting.patchInstanceserver')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitLoading={modalProcessing.value}
     >
       <Select

--- a/packages/client-core/src/admin/components/instance/ViewModal.tsx
+++ b/packages/client-core/src/admin/components/instance/ViewModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useMutation } from '@ir-engine/common'
 import {
   InstanceID,
@@ -121,7 +121,7 @@ export default function ViewUsersModal({ instanceId }: { instanceId: string }) {
       title="View"
       className="w-[50vw] max-w-2xl"
       onClose={() => {
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
       }}
     >
       {instanceUsersQuery.data.length === 0 ? (

--- a/packages/client-core/src/admin/components/instance/index.tsx
+++ b/packages/client-core/src/admin/components/instance/index.tsx
@@ -31,7 +31,7 @@ import { useHookstate } from '@ir-engine/hyperflux'
 import { Button, Input } from '@ir-engine/ui'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import InstanceTable from './InstanceTable'
 import PatchServerModal from './PatchServerModal'
 
@@ -70,7 +70,7 @@ export default function Instances() {
               size="sm"
               fullWidth
               onClick={() => {
-                PopoverState.showPopupover(<PatchServerModal />)
+                ModalState.openModal(<PatchServerModal />)
               }}
             >
               {t('admin:components.setting.patchInstanceserver')}

--- a/packages/client-core/src/admin/components/invites/AddEditInviteModal.tsx
+++ b/packages/client-core/src/admin/components/invites/AddEditInviteModal.tsx
@@ -26,8 +26,8 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { InviteService } from '@ir-engine/client-core/src/social/services/InviteService'
 import { useFind, useMutation } from '@ir-engine/common'
 import {
@@ -182,7 +182,7 @@ export default function AddEditInviteModal({ invite }: { invite?: InviteType }) 
 
     try {
       await Promise.all(sendInvitePromises)
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
       submitLoading.set(false)
@@ -194,7 +194,7 @@ export default function AddEditInviteModal({ invite }: { invite?: InviteType }) 
       title={invite?.id ? t('admin:components.invite.update') : t('admin:components.invite.create')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitLoading={submitLoading.value}
     >
       <div className="relative grid w-full gap-6">

--- a/packages/client-core/src/admin/components/invites/InviteTable.tsx
+++ b/packages/client-core/src/admin/components/invites/InviteTable.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useSearch } from '@ir-engine/common'
 import { invitePath, InviteType, UserName } from '@ir-engine/common/src/schema.type.module'
 import { isValidId } from '@ir-engine/common/src/utils/isValidId'
@@ -106,15 +106,12 @@ export default function InviteTable({
       spawnDetails: row.spawnDetails ? JSON.stringify(row.spawnDetails) : '',
       action: (
         <div className="flex items-center gap-3">
-          <ActionButton
-            icon={Edit01Lg}
-            onClick={() => PopoverState.showPopupover(<AddEditInviteModal invite={row} />)}
-          />
+          <ActionButton icon={Edit01Lg} onClick={() => ModalState.openModal(<AddEditInviteModal invite={row} />)} />
 
           <ActionButton
             icon={Trash04Lg}
             title={t('admin:components.common.delete')}
-            onClick={() => PopoverState.showPopupover(<RemoveInviteModal invites={[row]} />)}
+            onClick={() => ModalState.openModal(<RemoveInviteModal invites={[row]} />)}
             variant="red"
           />
         </div>

--- a/packages/client-core/src/admin/components/invites/RemoveInviteModal.tsx
+++ b/packages/client-core/src/admin/components/invites/RemoveInviteModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useMutation } from '@ir-engine/common'
 import { invitePath, InviteType, UserName } from '@ir-engine/common/src/schema.type.module'
 import { useHookstate } from '@ir-engine/hyperflux'
@@ -48,7 +48,7 @@ export default function RemoveInviteModal({ invites }: { invites: InviteType[] }
           adminInviteRemove(invite.id)
         })
       )
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (err) {
       error.set(err.message)
     }
@@ -59,7 +59,7 @@ export default function RemoveInviteModal({ invites }: { invites: InviteType[] }
     <Modal
       title={invites.length === 1 ? t('admin:components.invite.remove') : t('admin:components.invite.removeInvites')}
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitLoading={modalProcessing.value}
     >
       {error.value && <p className="mb-3 text-red-700">{error.value}</p>}

--- a/packages/client-core/src/admin/components/invites/index.tsx
+++ b/packages/client-core/src/admin/components/invites/index.tsx
@@ -27,7 +27,7 @@ import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiMagnifyingGlass, HiPlus } from 'react-icons/hi2'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { InviteType } from '@ir-engine/common/src/schema.type.module'
 import { useHookstate } from '@ir-engine/hyperflux'
 import { Button, Input } from '@ir-engine/ui'
@@ -77,7 +77,7 @@ export default function Invites() {
                   size="sm"
                   fullWidth
                   onClick={() => {
-                    PopoverState.showPopupover(<RemoveInviteModal invites={selectedInvites.value as InviteType[]} />)
+                    ModalState.openModal(<RemoveInviteModal invites={selectedInvites.value as InviteType[]} />)
                   }}
                 >
                   {t('admin:components.invite.removeInvites')}
@@ -89,7 +89,7 @@ export default function Invites() {
                 size="sm"
                 fullWidth
                 onClick={() => {
-                  PopoverState.showPopupover(<AddEditInviteModal />)
+                  ModalState.openModal(<AddEditInviteModal />)
                 }}
               >
                 <HiPlus />

--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -21,7 +21,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React, { lazy, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useMutation } from '@ir-engine/common'
 import { config } from '@ir-engine/common/src/config'
 import { ModelTransformStatus, transformModel } from '@ir-engine/common/src/model/ModelTransformFunctions'
@@ -222,7 +222,7 @@ export default function AddEditLocationModal(props: AddEditLocationModalProps) {
     if (!isValid) {
       return
     }
-    PopoverState.showPopupover(<CompressedPublishConfirmation />)
+    ModalState.openModal(<CompressedPublishConfirmation />)
     const { projectName, sceneName, rootEntity, sceneAssetID, scenePath } = getState(EditorState)
     const abortController = new AbortController()
     try {
@@ -381,10 +381,10 @@ export default function AddEditLocationModal(props: AddEditLocationModalProps) {
         //re-open the original scene
         const studioUrl = `${window.location.origin}/studio?project=${projectName}&scenePath=${scenePath}`
         window.open(studioUrl, '_blank')?.focus()
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
       }
     } catch (error) {
-      PopoverState.showPopupover(
+      ModalState.openModal(
         <ErrorDialog title={t('editor:savingError')} description={error?.message || t('editor:savingErrorMsg')} />
       )
     }
@@ -598,11 +598,7 @@ export default function AddEditLocationModal(props: AddEditLocationModalProps) {
         </div>
 
         <div className="grid grid-flow-col border-t border-t-ui-outline px-6 py-5">
-          <Button
-            variant="tertiary"
-            data-testid="publish-panel-cancel-button"
-            onClick={() => PopoverState.hidePopupover()}
-          >
+          <Button variant="tertiary" data-testid="publish-panel-cancel-button" onClick={() => ModalState.closeModal()}>
             {t('common:components.cancel')}
           </Button>
           <div className="ml-auto flex items-center gap-2">

--- a/packages/client-core/src/admin/components/locations/LocationTable.tsx
+++ b/packages/client-core/src/admin/components/locations/LocationTable.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useMutation, useSearch } from '@ir-engine/common'
 import { locationPath, LocationType, scopePath, ScopeType } from '@ir-engine/common/src/schema.type.module'
 import { isValidId } from '@ir-engine/common/src/utils/isValidId'
@@ -114,7 +114,7 @@ export default function LocationTable({ search }: { search: string }) {
           <ActionButton
             icon={Edit01Lg}
             title={t('admin:components.common.view')}
-            onClick={() => PopoverState.showPopupover(<AddEditLocationModal action="admin" location={row} />)}
+            onClick={() => ModalState.openModal(<AddEditLocationModal action="admin" location={row} />)}
             variant="green"
           />
 
@@ -122,7 +122,7 @@ export default function LocationTable({ search }: { search: string }) {
             icon={Trash04Lg}
             title={t('admin:components.common.delete')}
             onClick={() =>
-              PopoverState.showPopupover(
+              ModalState.openModal(
                 <ConfirmDialog
                   text={`${t('admin:components.location.confirmLocationDelete')} '${row.name}'?`}
                   onSubmit={async () => {

--- a/packages/client-core/src/admin/components/locations/index.tsx
+++ b/packages/client-core/src/admin/components/locations/index.tsx
@@ -27,7 +27,7 @@ import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiMagnifyingGlass, HiPlus } from 'react-icons/hi2'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useHookstate } from '@ir-engine/hyperflux'
 import { Button, Input } from '@ir-engine/ui'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
@@ -70,7 +70,7 @@ export default function Locations() {
               size="sm"
               fullWidth
               onClick={() => {
-                PopoverState.showPopupover(<AddEditLocationModal action="admin" />)
+                ModalState.openModal(<AddEditLocationModal action="admin" />)
               }}
             >
               <HiPlus />

--- a/packages/client-core/src/admin/components/moderation/BanUsersModal.tsx
+++ b/packages/client-core/src/admin/components/moderation/BanUsersModal.tsx
@@ -29,7 +29,7 @@ import { Select } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { UserSearchInput } from './common/UserSearchInput'
 
 export const BanUsersModal = ({ onSubmit }) => {
@@ -61,7 +61,7 @@ export const BanUsersModal = ({ onSubmit }) => {
     <Modal
       title={t('admin:components.moderation.addUser')}
       className="w-[50vw] max-w-2xl"
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       closeButtonText={t('common:components.cancel')}
       submitButtonText={t('admin:components.moderation.banUser')}
       onSubmit={handleSubmit}

--- a/packages/client-core/src/admin/components/moderation/ModerationBanContainer.tsx
+++ b/packages/client-core/src/admin/components/moderation/ModerationBanContainer.tsx
@@ -36,8 +36,8 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { FaPlus } from 'react-icons/fa'
 import { LuUserMinus } from 'react-icons/lu'
+import { ModalState } from '../../../common/services/ModalState'
 import { NotificationService } from '../../../common/services/NotificationService'
-import { PopoverState } from '../../../common/services/PopoverState'
 import { BanUsersModal } from './BanUsersModal'
 import ModerationBanTable from './ModerationBanTable'
 
@@ -85,7 +85,7 @@ export const ModerationBanContainer = ({ search }) => {
       console.error(error)
     }
 
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   return (
@@ -100,7 +100,7 @@ export const ModerationBanContainer = ({ search }) => {
             <p className="mb-6 text-gray-400">{t('admin:components.moderation.manageAccess')}</p>
             <Button
               variant="primary"
-              onClick={() => PopoverState.showPopupover(<BanUsersModal onSubmit={handleBanUser} />)}
+              onClick={() => ModalState.openModal(<BanUsersModal onSubmit={handleBanUser} />)}
               className="mx-auto flex items-center justify-center rounded-lg bg-blue-600 px-6 py-2 text-white hover:bg-blue-700"
             >
               <FaPlus className="mr-2" />
@@ -113,7 +113,7 @@ export const ModerationBanContainer = ({ search }) => {
           <div className="mb-4 flex items-center justify-between">
             <Button
               variant="primary"
-              onClick={() => PopoverState.showPopupover(<BanUsersModal onSubmit={handleBanUser} />)}
+              onClick={() => ModalState.openModal(<BanUsersModal onSubmit={handleBanUser} />)}
               className="flex items-center justify-center rounded-lg bg-blue-600 px-6 py-2 text-white hover:bg-blue-700"
             >
               <FaPlus className="mr-2" />

--- a/packages/client-core/src/admin/components/project/AddEditProjectModal.tsx
+++ b/packages/client-core/src/admin/components/project/AddEditProjectModal.tsx
@@ -28,7 +28,7 @@ import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CiCircleCheck, CiCircleRemove, CiWarning } from 'react-icons/ci'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { ProjectService } from '@ir-engine/client-core/src/common/services/ProjectService'
 import { DefaultUpdateSchedule } from '@ir-engine/common/src/interfaces/ProjectPackageJsonType'
 import {
@@ -395,7 +395,7 @@ export default function AddEditProjectModal({
       title={update ? t('admin:components.project.updateProject') : t('admin:components.project.addProject')}
       onClose={() => {
         ProjectUpdateService.clearProjectUpdate(project.name)
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
       }}
       onSubmit={handleSubmit}
       submitButtonDisabled={projectUpdateStatus.value?.submitDisabled}

--- a/packages/client-core/src/admin/components/project/ManageUserPermissionModal.tsx
+++ b/packages/client-core/src/admin/components/project/ManageUserPermissionModal.tsx
@@ -27,8 +27,8 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { MdOutlineRemoveCircleOutline } from 'react-icons/md'
 
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { ProjectService } from '@ir-engine/client-core/src/common/services/ProjectService'
 import { AuthState } from '@ir-engine/client-core/src/user/services/AuthService'
 import { useFind } from '@ir-engine/common'
@@ -114,7 +114,7 @@ export default function ManageUserPermissionModal({ project }: { project: Immuta
         handleCreatePermission()
       }}
       hideFooter={selfUserPermission !== 'owner'}
-      onClose={() => PopoverState.hidePopupover()}
+      onClose={() => ModalState.closeModal()}
     >
       {selfUserPermission === 'owner' && (
         <Input

--- a/packages/client-core/src/admin/components/project/ProjectHistoryModal.tsx
+++ b/packages/client-core/src/admin/components/project/ProjectHistoryModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { ProjectHistory } from './ProjectHistory'
 
 export const ProjectHistoryModal = ({ projectId, projectName }: { projectId: string; projectName: string }) => {
@@ -36,7 +36,7 @@ export const ProjectHistoryModal = ({ projectId, projectName }: { projectId: str
       className="relative max-h-full w-[75vw] p-4"
       title={t('admin:components.project.projectHistory')}
       onClose={() => {
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
       }}
     >
       <ProjectHistory projectId={projectId} projectName={projectName} />

--- a/packages/client-core/src/admin/components/project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/project/ProjectTable.tsx
@@ -36,8 +36,8 @@ import {
   HiOutlineUsers
 } from 'react-icons/hi2'
 
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { ProjectService } from '@ir-engine/client-core/src/common/services/ProjectService'
 import { useFind, useSearch } from '@ir-engine/common'
 import config from '@ir-engine/common/src/config'
@@ -113,7 +113,7 @@ export default function ProjectTable(props: { search: string }) {
       }).catch((err) => {
         NotificationService.dispatchNotify(err.message, { variant: 'error' })
       })
-      if (activeProjectId?.value === project.id) PopoverState.hidePopupover()
+      if (activeProjectId?.value === project.id) ModalState.closeModal()
     }
 
     return (
@@ -124,7 +124,7 @@ export default function ProjectTable(props: { search: string }) {
           disabled={project.name === 'ir-engine/default-project'}
           onClick={() => {
             activeProjectId.set(project.id)
-            PopoverState.showPopupover(
+            ModalState.openModal(
               <AddEditProjectModal update={true} inputProject={project} onSubmit={handleProjectUpdate} />
             )
           }}
@@ -137,7 +137,7 @@ export default function ProjectTable(props: { search: string }) {
           className="mr-2 h-min whitespace-pre  text-[#214AA6] disabled:opacity-50 dark:text-white"
           disabled={!project || !project.repositoryPath || project.name === 'ir-engine/default-project'}
           onClick={() => {
-            PopoverState.showPopupover(
+            ModalState.openModal(
               <ConfirmDialog
                 text={`${t('admin:components.project.confirmPushProjectToGithub')}? ${project.name} - ${
                   project.repositoryPath
@@ -158,7 +158,7 @@ export default function ProjectTable(props: { search: string }) {
           className="mr-2 h-min whitespace-pre  text-[#214AA6] disabled:opacity-50 dark:text-white"
           onClick={() => {
             activeProjectId.set(project.id)
-            PopoverState.showPopupover(<ManageUserPermissionModal project={project} />)
+            ModalState.openModal(<ManageUserPermissionModal project={project} />)
           }}
         >
           <HiOutlineUsers />
@@ -169,7 +169,7 @@ export default function ProjectTable(props: { search: string }) {
           className="mr-2 h-min whitespace-pre  text-[#214AA6] disabled:opacity-50 dark:text-white"
           disabled={config.client.localBuildOrDev}
           onClick={() => {
-            PopoverState.showPopupover(
+            ModalState.openModal(
               <ConfirmDialog
                 text={`${t('admin:components.project.confirmProjectInvalidate')} '${project.name}'?`}
                 onSubmit={async () => {
@@ -190,7 +190,7 @@ export default function ProjectTable(props: { search: string }) {
           size="sm"
           className="mr-2 h-min whitespace-pre  text-[#214AA6] disabled:opacity-50 dark:text-white"
           onClick={() => {
-            PopoverState.showPopupover(<ProjectHistoryModal projectId={project.id} projectName={project.name} />)
+            ModalState.openModal(<ProjectHistoryModal projectId={project.id} projectName={project.name} />)
           }}
         >
           <HiOutlineClock />
@@ -201,7 +201,7 @@ export default function ProjectTable(props: { search: string }) {
           className="h-min whitespace-pre  text-[#214AA6] disabled:opacity-50 dark:text-white"
           disabled={project.name === 'ir-engine/default-project'}
           onClick={() => {
-            PopoverState.showPopupover(
+            ModalState.openModal(
               <ConfirmDialog
                 text={`${t('admin:components.project.confirmProjectDelete')} '${project.name}'?`}
                 onSubmit={async () => {

--- a/packages/client-core/src/admin/components/project/ProjectTopMenu.tsx
+++ b/packages/client-core/src/admin/components/project/ProjectTopMenu.tsx
@@ -27,8 +27,8 @@ import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiArrowPath, HiPlus } from 'react-icons/hi2'
 
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { ProjectService, ProjectState } from '@ir-engine/client-core/src/common/services/ProjectService'
 import config from '@ir-engine/common/src/config'
 import { NO_PROXY, getMutableState, useHookstate, useMutableState } from '@ir-engine/hyperflux'
@@ -76,7 +76,7 @@ export default function ProjectTopMenu() {
         updateType: projectUpdateStatus.updateType,
         updateSchedule: projectUpdateStatus.updateSchedule
       })
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
     }
@@ -113,7 +113,7 @@ export default function ProjectTopMenu() {
         <Button
           size="sm"
           onClick={() => {
-            PopoverState.showPopupover(<UpdateEngineModal />)
+            ModalState.openModal(<UpdateEngineModal />)
           }}
           disabled={config.client.localBuildOrDev}
         >
@@ -128,7 +128,7 @@ export default function ProjectTopMenu() {
         <Button
           size="sm"
           onClick={() => {
-            PopoverState.showPopupover(<AddEditProjectModal onSubmit={handleSubmit} update={false} />)
+            ModalState.openModal(<AddEditProjectModal onSubmit={handleSubmit} update={false} />)
           }}
         >
           <HiPlus />

--- a/packages/client-core/src/admin/components/project/UpdateEngineModal.tsx
+++ b/packages/client-core/src/admin/components/project/UpdateEngineModal.tsx
@@ -27,7 +27,7 @@ import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuInfo } from 'react-icons/lu'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { ProjectService, ProjectState } from '@ir-engine/client-core/src/common/services/ProjectService'
 import { useFind } from '@ir-engine/common'
 import { DefaultUpdateSchedule } from '@ir-engine/common/src/interfaces/ProjectPackageJsonType'
@@ -115,7 +115,7 @@ export default function UpdateEngineModal() {
         project.updateType,
         project.updateSchedule
       )
-      PopoverState.showPopupover(
+      ModalState.openModal(
         <AddEditProjectModal
           inputProject={project}
           update={true}
@@ -124,7 +124,7 @@ export default function UpdateEngineModal() {
               set.add(project.name)
               return set
             })
-            PopoverState.hidePopupover()
+            ModalState.closeModal()
           }}
         />
       )
@@ -157,12 +157,12 @@ export default function UpdateEngineModal() {
           }
         })
       )
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (err) {
       errors.set(err.message)
     }
     modalProcessing.set(false)
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   useEffect(() => {
@@ -174,7 +174,7 @@ export default function UpdateEngineModal() {
       title={t('admin:components.project.updateEngine')}
       onSubmit={handleSubmit}
       className="w-[50vw]"
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitLoading={modalProcessing.value}
     >
       <div className="grid gap-6">

--- a/packages/client-core/src/admin/components/project/build-status/BuildStatusLogsModal.tsx
+++ b/packages/client-core/src/admin/components/project/build-status/BuildStatusLogsModal.tsx
@@ -35,7 +35,7 @@ import Label from '@ir-engine/ui/src/primitives/tailwind/Label'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 
 import { toDisplayDateTime } from '@ir-engine/common/src/utils/datetime-sql'
-import { PopoverState } from '../../../../common/services/PopoverState'
+import { ModalState } from '../../../../common/services/ModalState'
 
 const BuildStatusBadgeVariant = {
   success: 'success',
@@ -59,7 +59,7 @@ export default function BuildStatusLogsModal({ buildStatus }: { buildStatus: Bui
     <Modal
       className="w-[50vw]"
       title={t('admin:components.buildStatus.viewLogs')}
-      onClose={() => PopoverState.hidePopupover()}
+      onClose={() => ModalState.closeModal()}
     >
       <div className="grid grid-cols-2 gap-x-4 gap-y-6">
         <Input

--- a/packages/client-core/src/admin/components/project/build-status/BuildStatusTable.tsx
+++ b/packages/client-core/src/admin/components/project/build-status/BuildStatusTable.tsx
@@ -32,7 +32,7 @@ import { buildStatusPath, BuildStatusType } from '@ir-engine/common/src/schema.t
 
 import { Button } from '@ir-engine/ui'
 import TruncatedText from '@ir-engine/ui/src/primitives/tailwind/TruncatedText'
-import { PopoverState } from '../../../../common/services/PopoverState'
+import { ModalState } from '../../../../common/services/ModalState'
 import { buildStatusColumns, BuildStatusRowType } from '../../../common/constants/build-status'
 import DataTable from '../../../common/Table'
 import BuildStatusLogsModal, { BuildStatusBadge, getStartOrEndDate } from './BuildStatusLogsModal'
@@ -69,7 +69,7 @@ export default function BuildStatusTable() {
           size="sm"
           disabled={!row.logs || !row.logs.length}
           onClick={() => {
-            PopoverState.showPopupover(<BuildStatusLogsModal buildStatus={row} />)
+            ModalState.openModal(<BuildStatusLogsModal buildStatus={row} />)
           }}
         >
           <HiEye />

--- a/packages/client-core/src/admin/components/recordings/RecordingsTable.tsx
+++ b/packages/client-core/src/admin/components/recordings/RecordingsTable.tsx
@@ -31,7 +31,7 @@ import { RecordingType, recordingPath } from '@ir-engine/common/src/schema.type.
 import { isValidId } from '@ir-engine/common/src/utils/isValidId'
 import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 import { Trash04Lg } from '@ir-engine/ui/src/icons'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import DataTable from '../../common/Table'
 import { recordingColumns } from '../../common/constants/recordings'
 import ActionButton from '../ActionButton'
@@ -78,7 +78,7 @@ export default function RecordingsTable({ search }: { search: string }) {
             icon={Trash04Lg}
             title={t('admin:components.common.delete')}
             onClick={() => {
-              PopoverState.showPopupover(
+              ModalState.openModal(
                 <ConfirmDialog
                   text={`${t('admin:components.recording.confirmRecordingDelete')} (${row.id}) ?`}
                   onSubmit={async () => {

--- a/packages/client-core/src/admin/components/resources/AddEditResourceModal.tsx
+++ b/packages/client-core/src/admin/components/resources/AddEditResourceModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { StaticResourceType, uploadAssetPath } from '@ir-engine/common/src/schema.type.module'
 import { cleanURL } from '@ir-engine/common/src/utils/cleanURL'
 import { AssetsPreviewPanel } from '@ir-engine/editor/src/components/assets/AssetsPreviewPanel'
@@ -155,7 +155,7 @@ export default function CreateResourceModal({ selectedResource }: { selectedReso
           args: { path: state.name.value, project: state.project.value }
         })
       }
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (e) {
       NotificationService.dispatchNotify(e.message, { variant: 'error' })
       errors.serverError.set(e.message)
@@ -165,7 +165,7 @@ export default function CreateResourceModal({ selectedResource }: { selectedReso
   return (
     <Modal
       title={t('admin:components.resources.createResource')}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
     >

--- a/packages/client-core/src/admin/components/resources/ResourceTable.tsx
+++ b/packages/client-core/src/admin/components/resources/ResourceTable.tsx
@@ -32,7 +32,7 @@ import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 
 import { API } from '@ir-engine/common'
 import { Edit01Lg, Trash04Lg } from '@ir-engine/ui/src/icons'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import DataTable from '../../common/Table'
 import { resourceColumns } from '../../common/constants/resources'
 import ActionButton from '../ActionButton'
@@ -73,7 +73,7 @@ export default function ResourceTable({ search }: { search: string }) {
           <ActionButton
             icon={Edit01Lg}
             onClick={() => {
-              PopoverState.showPopupover(<AddEditResourceModal selectedResource={el} />)
+              ModalState.openModal(<AddEditResourceModal selectedResource={el} />)
             }}
             variant="green"
           />
@@ -82,7 +82,7 @@ export default function ResourceTable({ search }: { search: string }) {
             icon={Trash04Lg}
             title={t('admin:components.common.delete')}
             onClick={() => {
-              PopoverState.showPopupover(
+              ModalState.openModal(
                 <ConfirmDialog
                   text={`${t('admin:components.resources.confirmResourceDelete')} '${el.key}'?`}
                   onSubmit={async () => {

--- a/packages/client-core/src/admin/components/resources/index.tsx
+++ b/packages/client-core/src/admin/components/resources/index.tsx
@@ -31,7 +31,7 @@ import { useHookstate } from '@ir-engine/hyperflux'
 import { Button, Input } from '@ir-engine/ui'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import AddEditResourceModal from './AddEditResourceModal'
 import ResourceTable from './ResourceTable'
 
@@ -70,7 +70,7 @@ export default function Resources() {
               size="sm"
               fullWidth
               onClick={() => {
-                PopoverState.showPopupover(<AddEditResourceModal />)
+                ModalState.openModal(<AddEditResourceModal />)
               }}
             >
               <HiPlus />

--- a/packages/client-core/src/admin/components/server/ServerLogsModal.tsx
+++ b/packages/client-core/src/admin/components/server/ServerLogsModal.tsx
@@ -35,7 +35,7 @@ import { Button, Select } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { serverAutoRefreshOptions } from '../../common/constants/server'
 import { useServerInfoFind } from '../../services/ServerInfoQuery'
 
@@ -83,7 +83,7 @@ export default function ServerLogsModal({ podName, containerName }: { podName: s
     <Modal
       className="w-[50vw] max-w-[50vw]"
       title={t('admin:components.server.serverLogs')}
-      onClose={() => PopoverState.hidePopupover()}
+      onClose={() => ModalState.closeModal()}
     >
       <div className="space-y-4">
         <div className="space-between mb-2 flex w-full items-center">

--- a/packages/client-core/src/admin/components/server/ServerTable.tsx
+++ b/packages/client-core/src/admin/components/server/ServerTable.tsx
@@ -30,7 +30,7 @@ import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 import Badge from '@ir-engine/ui/src/primitives/tailwind/Badge'
 
 import { Trash04Lg } from '@ir-engine/ui/src/icons'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { serverColumns, ServerRowType } from '../../common/constants/server'
 import DataTable from '../../common/Table'
 import { useServerInfoFind } from '../../services/ServerInfoQuery'
@@ -101,9 +101,7 @@ export default function ServerTable({
             size="sm"
             variant="primary"
             onClick={() => {
-              PopoverState.showPopupover(
-                <ServerLogsModal podName={row.name} containerName={row.containers?.at(-1)?.name} />
-              )
+              ModalState.openModal(<ServerLogsModal podName={row.name} containerName={row.containers?.at(-1)?.name} />)
             }}
           >
             {t('admin:components.server.viewLogs')}
@@ -113,7 +111,7 @@ export default function ServerTable({
             icon={Trash04Lg}
             title={t('admin:components.common.delete')}
             onClick={() => {
-              PopoverState.showPopupover(
+              ModalState.openModal(
                 <ConfirmDialog
                   text={`${t('admin:components.server.confirmPodDelete')} ${row.name}?`}
                   onSubmit={async () => {

--- a/packages/client-core/src/admin/components/user/AddEditUserModal.tsx
+++ b/packages/client-core/src/admin/components/user/AddEditUserModal.tsx
@@ -21,7 +21,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useMutation } from '@ir-engine/common'
 import {
   ScopeType,
@@ -150,7 +150,7 @@ export default function AddEditUserModal({ user }: { user?: UserType }) {
           }
         })
       }
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (error) {
       errors.serviceError.set(error.message)
     }
@@ -167,7 +167,7 @@ export default function AddEditUserModal({ user }: { user?: UserType }) {
       title={user?.id ? t('admin:components.user.updateUser') : t('admin:components.user.addUser')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitLoading={submitLoading.value}
     >
       <div className="relative grid w-full gap-6">

--- a/packages/client-core/src/admin/components/user/UserTable.tsx
+++ b/packages/client-core/src/admin/components/user/UserTable.tsx
@@ -40,7 +40,7 @@ import { truncateText } from '@ir-engine/ui/src/primitives/tailwind/TruncatedTex
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { FaRegCircleCheck, FaRegCircleXmark } from 'react-icons/fa6'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { AuthState } from '../../../user/services/AuthService'
 import DataTable from '../../common/Table'
 import { UserRowType, userColumns } from '../../common/constants/user'
@@ -63,7 +63,7 @@ export const removeUsers = async (
       adminUserRemove(user.id)
     })
   )
-  PopoverState.hidePopupover()
+  ModalState.closeModal()
   modalProcessing.set(false)
 }
 
@@ -187,7 +187,7 @@ export default function UserTable({
             <ActionButton
               icon={Edit01Lg}
               title={t('admin:components.common.view')}
-              onClick={() => PopoverState.showPopupover(<AddEditUserModal user={row} />)}
+              onClick={() => ModalState.openModal(<AddEditUserModal user={row} />)}
               variant="green"
             />
 
@@ -195,7 +195,7 @@ export default function UserTable({
               icon={Trash04Lg}
               title={t('admin:components.common.delete')}
               onClick={() => {
-                PopoverState.showPopupover(
+                ModalState.openModal(
                   <ConfirmDialog
                     text={`${t('admin:components.user.confirmUserDelete')} '${row.name}'?`}
                     onSubmit={async () => {

--- a/packages/client-core/src/admin/components/user/index.tsx
+++ b/packages/client-core/src/admin/components/user/index.tsx
@@ -34,7 +34,7 @@ import { Button, Input } from '@ir-engine/ui'
 import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import UserTable, { removeUsers } from './UserTable'
 
 export default function Users() {
@@ -78,7 +78,7 @@ export default function Users() {
               variant="red"
               size="sm"
               onClick={() => {
-                PopoverState.showPopupover(
+                ModalState.openModal(
                   <ConfirmDialog
                     text={t('admin:components.user.confirmMultiUserDelete')}
                     onSubmit={async () => {

--- a/packages/client-core/src/common/components/ProfilePill/index.tsx
+++ b/packages/client-core/src/common/components/ProfilePill/index.tsx
@@ -35,7 +35,7 @@ import { MdOutlineKeyboardArrowDown } from 'react-icons/md'
 import { useUserAvatarThumbnail } from '../../../hooks/useUserAvatarThumbnail'
 import AvatarSelectMenu from '../../../user/menus/avatar/AvatarSelectMenu'
 import { AuthState } from '../../../user/services/AuthService'
-import { PopoverState } from '../../services/PopoverState'
+import { ModalState } from '../../services/ModalState'
 import { ThemeState } from '../../services/ThemeService'
 
 const ProfilePill = () => {
@@ -53,7 +53,7 @@ const ProfilePill = () => {
     if (avatarSelectMenuRef.current) {
       avatarSelectMenuRef.current?.handleClose()
     } else {
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     }
   }
 
@@ -87,7 +87,7 @@ const ProfilePill = () => {
               className="absolute bottom-0 left-10 rounded-full p-1 text-[#F5F5F5]"
               onClick={() => {
                 popUpOpened.set(false)
-                PopoverState.showPopupover(
+                ModalState.openModal(
                   <AvatarSelectMenu ref={avatarSelectMenuRef} showBackButton={false} />,
                   onAvatarSelectClose
                 )

--- a/packages/client-core/src/common/services/ModalState.tsx
+++ b/packages/client-core/src/common/services/ModalState.tsx
@@ -27,7 +27,7 @@ import { defineState, getMutableState } from '@ir-engine/hyperflux'
 
 type BackdropType = 'blur' | 'transparent'
 
-export interface PopupData {
+export interface ModalData {
   element: JSX.Element | null
   onClickOutside: VoidFunction
 }
@@ -35,42 +35,42 @@ export interface PopupData {
 /**
  * Popover state for tailwind routes
  */
-export const PopoverState = defineState({
-  name: 'ee.client.PopoverState',
+export const ModalState = defineState({
+  name: 'ee.client.ModalState',
   initial: {
-    popups: [] as PopupData[],
+    modals: [] as ModalData[],
     backdrop: 'blur' as BackdropType
   },
 
   /**shows a popupover. if a previous popover was already present, the `element` popover will be current showed */
-  showPopupover: (
+  openModal: (
     element: JSX.Element,
-    onClickOutside?: PopupData['onClickOutside'],
+    onClickOutside?: ModalData['onClickOutside'],
     backdrop = 'blur' as BackdropType
   ) => {
-    getMutableState(PopoverState).popups.merge([
+    getMutableState(ModalState).modals.merge([
       {
         element,
-        onClickOutside: onClickOutside || PopoverState.hidePopupover
+        onClickOutside: onClickOutside || ModalState.closeModal
       }
     ])
     if (backdrop === 'transparent') {
       /* if atleast one Modal is asking to use transparent backdrop, all the Modals "in this nesting" will use transparent backdrop. */
-      getMutableState(PopoverState).backdrop.set('transparent')
+      getMutableState(ModalState).backdrop.set('transparent')
     }
   },
   /**close the current popover. if a previous popover was present, the previous one will be shown */
-  hidePopupover: () => {
-    const currentCount = getMutableState(PopoverState).popups.length
-    getMutableState(PopoverState).popups.set((prevElements) => {
+  closeModal: () => {
+    const currentCount = getMutableState(ModalState).modals.length
+    getMutableState(ModalState).modals.set((prevElements) => {
       prevElements.pop()
       return prevElements
     })
     if (currentCount === 1) {
       /* if the current popover is the last one, the backdrop will be reset to blur */
-      getMutableState(PopoverState).backdrop.set('blur')
+      getMutableState(ModalState).backdrop.set('blur')
     }
   },
-  /**Returns true if there are any open popovers, false otherwise, based on the length of the elements array in PopoverState.*/
-  isPopupoverOpen: () => getMutableState(PopoverState).popups.length > 0
+  /**Returns true if there are any open popovers, false otherwise, based on the length of the elements array in ModalState.*/
+  isModalOpen: () => getMutableState(ModalState).modals.length > 0
 })

--- a/packages/client-core/src/common/services/ModalState.tsx
+++ b/packages/client-core/src/common/services/ModalState.tsx
@@ -33,7 +33,7 @@ export interface ModalData {
 }
 
 /**
- * Popover state for tailwind routes
+ * Modal state for tailwind routes
  */
 export const ModalState = defineState({
   name: 'ee.client.ModalState',
@@ -42,7 +42,8 @@ export const ModalState = defineState({
     backdrop: 'blur' as BackdropType
   },
 
-  /**shows a popupover. if a previous popover was already present, the `element` popover will be current showed */
+  /**shows a modal.
+   * if a previous modal was already present, the `element` modal will be current showed */
   openModal: (
     element: JSX.Element,
     onClickOutside?: ModalData['onClickOutside'],
@@ -59,7 +60,8 @@ export const ModalState = defineState({
       getMutableState(ModalState).backdrop.set('transparent')
     }
   },
-  /**close the current popover. if a previous popover was present, the previous one will be shown */
+  /**close the current modal.
+   * if a previous modal was present, the previous one will be shown */
   closeModal: () => {
     const currentCount = getMutableState(ModalState).modals.length
     getMutableState(ModalState).modals.set((prevElements) => {
@@ -67,10 +69,10 @@ export const ModalState = defineState({
       return prevElements
     })
     if (currentCount === 1) {
-      /* if the current popover is the last one, the backdrop will be reset to blur */
+      /* if the current modal is the last one, the backdrop will be reset to blur */
       getMutableState(ModalState).backdrop.set('blur')
     }
   },
-  /**Returns true if there are any open popovers, false otherwise, based on the length of the elements array in ModalState.*/
+  /**Returns true if there are any open modals, false otherwise, based on the length of the elements array in ModalState.*/
   isModalOpen: () => getMutableState(ModalState).modals.length > 0
 })

--- a/packages/client-core/src/components/ViewerInteractions/index.tsx
+++ b/packages/client-core/src/components/ViewerInteractions/index.tsx
@@ -32,7 +32,7 @@ import { getMutableState, NO_PROXY, useHookstate, useMutableState } from '@ir-en
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { useTranslation } from 'react-i18next'
 import { twMerge } from 'tailwind-merge'
-import { PopoverState } from '../../common/services/PopoverState'
+import { ModalState } from '../../common/services/ModalState'
 import { LoadingSystemState } from '../../systems/state/LoadingState'
 import LocationIconButton from '../../user/components/LocationIconButton'
 import InstanceChat from '../../user/InstanceChat'
@@ -116,7 +116,7 @@ export const ViewerInteractions = () => {
             key={menuName}
             title={props.title}
             icon={props.icon}
-            onClick={() => PopoverState.showPopupover(props.component as JSX.Element)}
+            onClick={() => ModalState.openModal(props.component as JSX.Element)}
           />
         ))}
       </div>

--- a/packages/client-core/src/components/modals/UnsupportedBrowser.tsx
+++ b/packages/client-core/src/components/modals/UnsupportedBrowser.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { getMutableState } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
@@ -40,7 +40,7 @@ export const UnsupportedBrowser = () => {
 
   const handleClose = () => {
     getMutableState(BrowserSupportState).acknowledgedUnsupportedBrowser.set(true)
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   return (

--- a/packages/client-core/src/components/modals/UnsupportedDevice.tsx
+++ b/packages/client-core/src/components/modals/UnsupportedDevice.tsx
@@ -30,7 +30,7 @@ import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiOutlineExclamationTriangle } from 'react-icons/hi2'
-import { PopoverState } from '../../common/services/PopoverState'
+import { ModalState } from '../../common/services/ModalState'
 import { BrowserSupportState } from '../../hooks/useUnsupported'
 
 export const UnsupportedDevice = () => {
@@ -38,7 +38,7 @@ export const UnsupportedDevice = () => {
 
   const handleClose = () => {
     getMutableState(BrowserSupportState).acknowledgedUnsupportedDevice.set(true)
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   return (

--- a/packages/client-core/src/hooks/useUnsupported.tsx
+++ b/packages/client-core/src/hooks/useUnsupported.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { defineState, getState, isDev, syncStateWithLocalStorage } from '@ir-engine/hyperflux'
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import React, { useEffect } from 'react'
@@ -49,11 +49,11 @@ export const useUnsupported = ({ device = false, browser = false }: Props) => {
   useEffect(() => {
     const { acknowledgedUnsupportedBrowser, acknowledgedUnsupportedDevice } = getState(BrowserSupportState)
     if (!acknowledgedUnsupportedDevice && isMobile && device) {
-      PopoverState.showPopupover(<UnsupportedDevice />)
+      ModalState.openModal(<UnsupportedDevice />)
       return
     }
     if (!acknowledgedUnsupportedBrowser && !isSupportedBrowser() && browser) {
-      PopoverState.showPopupover(<UnsupportedBrowser />)
+      ModalState.openModal(<UnsupportedBrowser />)
       return
     }
   }, [isMobile, device, browser])

--- a/packages/client-core/src/user/InstanceChat.tsx
+++ b/packages/client-core/src/user/InstanceChat.tsx
@@ -44,7 +44,7 @@ import React, { createContext, useContext, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { twMerge } from 'tailwind-merge'
 import { useMediaNetwork } from '../common/services/MediaInstanceConnectionService'
-import { PopoverState } from '../common/services/PopoverState'
+import { ModalState } from '../common/services/ModalState'
 import { ChannelState } from '../social/services/ChannelService'
 import { AvatarUIActions, AvatarUIState } from '../systems/state/AvatarUIState'
 import { ReportUserState } from '../util/ReportUserState'
@@ -329,7 +329,7 @@ function MessagesWrapper() {
           <Button
             variant="secondary"
             className="mx-auto mt-4 rounded-[20px]"
-            onClick={() => PopoverState.showPopupover(<ProfileMenu />)}
+            onClick={() => ModalState.openModal(<ProfileMenu />)}
           >
             {isGuest ? t('user:instanceChat.register') : t('user:instanceChat.verifyAge')}
           </Button>

--- a/packages/client-core/src/user/UserUISystem.tsx
+++ b/packages/client-core/src/user/UserUISystem.tsx
@@ -35,7 +35,7 @@ import { FeatureFlags } from '@ir-engine/common/src/constants/FeatureFlags'
 import { EngineState, QueryReactor, setComponent, useEntityContext, useOptionalComponent } from '@ir-engine/ecs'
 import { OverlayComponent } from '@ir-engine/engine/src/scene/components/OverlayComponent'
 import { NetworkState } from '@ir-engine/network'
-import { PopoverState } from '../common/services/PopoverState'
+import { ModalState } from '../common/services/ModalState'
 import { InviteService } from '../social/services/InviteService'
 import { LoadingUISystemState } from '../systems/LoadingUISystem'
 import { OverlayComponentState } from '../systems/OverlaySystem'
@@ -48,7 +48,7 @@ const OverlayReactor = () => {
 
   const onClose = () => {
     setComponent(entity, OverlayComponent, { isOpen: false })
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
     setIsPopoverOpen(false)
   }
 
@@ -57,7 +57,7 @@ const OverlayReactor = () => {
       const popoverType = overlayComponent?.type.value
       if (!popoverType) return
       const Component = getState(OverlayComponentState)[popoverType]
-      PopoverState.showPopupover(<Component component={overlayComponent.value} onClose={onClose} />, () => {
+      ModalState.openModal(<Component component={overlayComponent.value} onClose={onClose} />, () => {
         onClose()
       })
       setIsPopoverOpen(true)

--- a/packages/client-core/src/user/VideoWindows/index.tsx
+++ b/packages/client-core/src/user/VideoWindows/index.tsx
@@ -48,7 +48,7 @@ import AvatarImage from '@ir-engine/ui/src/primitives/tailwind/AvatarImage'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import { useTranslation } from 'react-i18next'
 import { useMediaNetwork } from '../../common/services/MediaInstanceConnectionService'
-import { PopoverState } from '../../common/services/PopoverState'
+import { ModalState } from '../../common/services/ModalState'
 import { useUserAvatarThumbnail } from '../../hooks/useUserAvatarThumbnail'
 import { LocationState } from '../../social/services/LocationService'
 import { ReportUserState } from '../../util/ReportUserState'
@@ -230,9 +230,7 @@ const ReportUserWindow = () => {
             className="rounded-full bg-ui-error p-[15px]"
             title={t('user:videoWindows.reportUser')}
             onClick={() =>
-              PopoverState.showPopupover(
-                <ReportMenu type="user" userId={reportedUserId} locationId={currentLocation.id} />
-              )
+              ModalState.openModal(<ReportMenu type="user" userId={reportedUserId} locationId={currentLocation.id} />)
             }
           >
             <IoWarning className="h-5 w-5 text-text-primary-button" />

--- a/packages/client-core/src/user/menus/EmoteMenu.tsx
+++ b/packages/client-core/src/user/menus/EmoteMenu.tsx
@@ -31,7 +31,7 @@ import { AvatarNetworkAction } from '@ir-engine/engine/src/avatar/state/AvatarNe
 import { dispatchAction, useHookstate } from '@ir-engine/hyperflux'
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import React, { HTMLProps, useLayoutEffect, useRef } from 'react'
-import { PopoverState } from '../../common/services/PopoverState'
+import { ModalState } from '../../common/services/ModalState'
 
 const iconItems = [
   {
@@ -241,7 +241,7 @@ const EmoteMenu = (): JSX.Element => {
         entityUUID: getComponent(selfAvatarEntity, UUIDComponent)
       })
     )
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   const dimensions = useHookstate({ width: 474, height: 440 })

--- a/packages/client-core/src/user/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/menus/ProfileMenu.tsx
@@ -78,8 +78,8 @@ import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import { FaApple } from 'react-icons/fa'
 import { twMerge } from 'tailwind-merge'
 import { initialAuthState, initialOAuthConnectedState } from '../../common/initialAuthState'
+import { ModalState } from '../../common/services/ModalState'
 import { NotificationService } from '../../common/services/NotificationService'
-import { PopoverState } from '../../common/services/PopoverState'
 import { useUserAvatarThumbnail } from '../../hooks/useUserAvatarThumbnail'
 import { useZendesk } from '../../hooks/useZendesk'
 import { LocationState } from '../../social/services/LocationService'
@@ -369,7 +369,7 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
     if (avatarSelectMenuRef.current) {
       avatarSelectMenuRef.current?.handleClose()
     } else {
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     }
   }
 
@@ -395,7 +395,7 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
               !iOS && (
                 <button
                   onClick={() => {
-                    PopoverState.showPopupover(
+                    ModalState.openModal(
                       <AvatarSelectMenu ref={avatarSelectMenuRef} showBackButton={true} previewEnabled={true} />,
                       onAvatarSelectClose
                     )
@@ -439,7 +439,7 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
               initialized ? 'justify-self-end' : 'col-start-3'
             )}
             onClick={() => {
-              PopoverState.showPopupover(<SettingsMenu />)
+              ModalState.openModal(<SettingsMenu />)
             }}
           >
             <CogLg className="h-[1.875rem] w-[1.875rem]" />
@@ -456,9 +456,7 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
                 variant="red"
                 fullWidth={!isMobile}
                 className="w-[136px] rounded-[10px] lg:w-full"
-                onClick={() =>
-                  PopoverState.showPopupover(<ReportMenu type="location" locationId={currentLocation.id} />)
-                }
+                onClick={() => ModalState.openModal(<ReportMenu type="location" locationId={currentLocation.id} />)}
               >
                 <ReportWebsiteDefaullg />
                 {t('user:usermenu.profile.reportWorld')}
@@ -621,20 +619,20 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
           <button
             className="flex w-full items-center justify-start gap-x-2 p-2 text-text-primary"
             onClick={() => {
-              PopoverState.hidePopupover() // Close the ProfileMenu popover
-              PopoverState.showPopupover(
+              ModalState.closeModal() // Close the ProfileMenu popover
+              ModalState.openModal(
                 <ConfirmDialog
                   text={t('user:usermenu.profile.logout.title')}
                   onSubmit={async () => {
                     handleLogout()
                   }}
                   onClose={() => {
-                    PopoverState.showPopupover(<ProfileMenu />)
+                    ModalState.openModal(<ProfileMenu />)
                   }}
                 />,
                 () => {
-                  PopoverState.hidePopupover()
-                  PopoverState.showPopupover(<ProfileMenu />)
+                  ModalState.closeModal()
+                  ModalState.openModal(<ProfileMenu />)
                 }
               )
             }}
@@ -646,8 +644,8 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
           <button
             className="flex w-full items-center justify-start gap-x-2 p-2 text-text-primary"
             onClick={() => {
-              PopoverState.hidePopupover() // Close the ProfileMenu popover
-              PopoverState.showPopupover(
+              ModalState.closeModal() // Close the ProfileMenu popover
+              ModalState.openModal(
                 <ConfirmDialog
                   title={t('user:usermenu.profile.delete.finalDeleteConfirm')}
                   text={t('user:usermenu.profile.delete.finalDeleteText')}
@@ -656,12 +654,12 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
                     AuthService.logoutUser()
                   }}
                   onClose={() => {
-                    PopoverState.showPopupover(<ProfileMenu />)
+                    ModalState.openModal(<ProfileMenu />)
                   }}
                 />,
                 () => {
-                  PopoverState.hidePopupover()
-                  PopoverState.showPopupover(<ProfileMenu />)
+                  ModalState.closeModal()
+                  ModalState.openModal(<ProfileMenu />)
                 }
               )
             }}

--- a/packages/client-core/src/user/menus/ReportMenu.tsx
+++ b/packages/client-core/src/user/menus/ReportMenu.tsx
@@ -43,8 +43,8 @@ import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import TextArea from '@ir-engine/ui/src/primitives/tailwind/TextArea'
 import { useTranslation } from 'react-i18next'
 import { twMerge } from 'tailwind-merge'
+import { ModalState } from '../../common/services/ModalState'
 import { NotificationService } from '../../common/services/NotificationService'
-import { PopoverState } from '../../common/services/PopoverState'
 import { uploadToFeathersService } from '../../util/upload'
 
 type ReportMenuProps = { type: ModerationTypeType; userId?: UserID; locationId?: LocationID }
@@ -80,7 +80,7 @@ const ReportMenu = (props: ReportMenuProps) => {
   const userReportsMutation = useMutation(moderationPath)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const closePopover = () => {
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   const formData = useHookstate({
@@ -177,7 +177,7 @@ const ReportMenu = (props: ReportMenuProps) => {
         )
       }
       closePopover()
-      PopoverState.showPopupover(<ReportSuccessReportModal handleClose={closePopover} />)
+      ModalState.openModal(<ReportSuccessReportModal handleClose={closePopover} />)
     } catch (error) {
       closePopover()
       NotificationService.dispatchNotify(`Something went wrong Reporting a ${typeReport}`, {

--- a/packages/client-core/src/user/menus/SettingsMenu.tsx
+++ b/packages/client-core/src/user/menus/SettingsMenu.tsx
@@ -36,7 +36,7 @@ import { OptionType } from '@ir-engine/ui/src/primitives/tailwind/Select'
 import SidebarNavigation from '@ir-engine/ui/src/primitives/tailwind/SidebarNavigation'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { PopoverState } from '../../common/services/PopoverState'
+import { ModalState } from '../../common/services/ModalState'
 import { XruiNameplateState } from '../../social/XruiNameplateState'
 import BlockSlider from '../components/BlockSlider'
 import ControllerMappingMobileImage from './images/controller-mapping-mobile.svg'
@@ -293,7 +293,7 @@ export default function SettingsMenu() {
   return (
     <div className="absolute z-50 h-fit max-h-[90dvh] w-[50vw] min-w-[720px] max-w-2xl overflow-y-auto rounded-2xl bg-surface-4 p-6 text-text-secondary smh:max-h-[60dvh] smh:p-10">
       <div className="mb-[17px]">
-        <button onClick={() => PopoverState.hidePopupover()}>
+        <button onClick={() => ModalState.closeModal()}>
           <ArrowNarrowLeftLg />
         </button>
       </div>

--- a/packages/client-core/src/user/menus/avatar/AvatarCreatorMenu.tsx
+++ b/packages/client-core/src/user/menus/avatar/AvatarCreatorMenu.tsx
@@ -37,7 +37,7 @@ import { ArrowLeftLg, XCloseLg } from '@ir-engine/ui/src/icons'
 import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import AvatarPreview from '../../../common/components/AvatarPreview'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { AVATAR_ID_REGEX, generateAvatarId } from '../../../util/avatarIdFunctions'
 import { AvatarService } from '../../services/AvatarService'
 import { DiscardAvatarChangesMenu } from './DiscardAvatarChangesMenu'
@@ -234,15 +234,15 @@ const AvatarCreatorMenu = (selectedSdk: string) =>
       )
 
       loading.set(LoadingState.None)
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     }
 
     const handleClose = () => {
-      PopoverState.showPopupover(
+      ModalState.openModal(
         <DiscardAvatarChangesMenu
           handleConfirm={() => {
-            PopoverState.hidePopupover()
-            PopoverState.hidePopupover()
+            ModalState.closeModal()
+            ModalState.closeModal()
           }}
         />
       )

--- a/packages/client-core/src/user/menus/avatar/AvatarModifyMenu.tsx
+++ b/packages/client-core/src/user/menus/avatar/AvatarModifyMenu.tsx
@@ -47,7 +47,7 @@ import { Button, Input } from '@ir-engine/ui'
 import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
 import { Upload01Lg, User01Lg, XCloseLg } from '@ir-engine/ui/src/icons'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { AvatarService } from '../../services/AvatarService'
 import AvatarCreatorMenu2, { SupportedSdks } from './AvatarCreatorMenu'
 import AvatarSelectMenu from './AvatarSelectMenu'
@@ -234,7 +234,7 @@ const AvatarModifyMenu = ({ selectedAvatar }: Props) => {
 
   const handleGenerateThumbnail = () => {
     if (thumbnailSrc) {
-      PopoverState.showPopupover(
+      ModalState.openModal(
         <ConfirmDialog
           text={t('admin:components.avatar.confirmThumbnailReplace')}
           onSubmit={handleProcessGenerateThumbnail}
@@ -258,7 +258,7 @@ const AvatarModifyMenu = ({ selectedAvatar }: Props) => {
 
     const blob = await getCanvasBlob(canvas)
     setState({ ...state, thumbnailUrl: 'thumbnail.png', thumbnailFile: new File([blob!], 'thumbnail.png') })
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   const handleSave = async () => {
@@ -291,10 +291,10 @@ const AvatarModifyMenu = ({ selectedAvatar }: Props) => {
           avatarFile,
           thumbnailFile
         )
-        PopoverState.showPopupover(<AvatarSelectMenu showBackButton={true} previewEnabled={true} />)
+        ModalState.openModal(<AvatarSelectMenu showBackButton={true} previewEnabled={true} />)
       } else if (avatarFile && thumbnailFile) {
         await AvatarService.createAvatar(avatarFile, thumbnailFile, state.name, false)
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
       }
     } catch (err) {
       console.error(err)
@@ -309,7 +309,7 @@ const AvatarModifyMenu = ({ selectedAvatar }: Props) => {
       onSubmit={handleSave}
       submitLoading={isSaving}
       title={selectedAvatar ? t('user:avatar.titleEditAvatar') : t('user:avatar.createAvatar')}
-      onClose={() => PopoverState.hidePopupover()}
+      onClose={() => ModalState.closeModal()}
       className="pointer-events-auto w-[50vw] min-w-[720px] max-w-2xl"
     >
       <div className="grid grid-cols-2 gap-x-4">
@@ -322,7 +322,7 @@ const AvatarModifyMenu = ({ selectedAvatar }: Props) => {
               fullWidth
               onClick={() => {
                 const Menu = AvatarCreatorMenu2(SupportedSdks.ReadyPlayerMe)
-                PopoverState.showPopupover(<Menu showBackButton={false} previewEnabled={true} />)
+                ModalState.openModal(<Menu showBackButton={false} previewEnabled={true} />)
               }}
             >
               {t('user:usermenu.profile.useReadyPlayerMe')}
@@ -334,7 +334,7 @@ const AvatarModifyMenu = ({ selectedAvatar }: Props) => {
               fullWidth
               onClick={() => {
                 const Menu = AvatarCreatorMenu2(SupportedSdks.Avaturn)
-                PopoverState.showPopupover(<Menu showBackButton={false} previewEnabled={true} />)
+                ModalState.openModal(<Menu showBackButton={false} previewEnabled={true} />)
               }}
             >
               {t('user:usermenu.profile.useAvaturn')}

--- a/packages/client-core/src/user/menus/avatar/AvatarSelectMenu.tsx
+++ b/packages/client-core/src/user/menus/avatar/AvatarSelectMenu.tsx
@@ -42,7 +42,7 @@ import { Button, Input } from '@ir-engine/ui'
 import { ArrowLeftLg, UserPlus01Sm, XCloseLg } from '@ir-engine/ui/src/icons'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import { twMerge } from 'tailwind-merge'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { AuthService, AuthState } from '../../services/AuthService'
 import AvatarCreatorMenu2, { SupportedSdks } from './AvatarCreatorMenu'
 import AvatarModifyMenu from './AvatarModifyMenu'
@@ -97,7 +97,7 @@ const AvatarSelectMenu = forwardRef(({ showBackButton, previewEnabled = true }: 
       if (!selfAvatarEntity || !hasComponent(selfAvatarEntity, SpawnEffectComponent)) {
         await userAvatarMutation.patch(null, { avatarId: selectedAvatarId.value }, { query: { userId } })
         if (selfAvatarEntity) avatarLoading.set(true)
-        else PopoverState.hidePopupover()
+        else ModalState.closeModal()
       }
     }
     selectedAvatarId.set('' as AvatarID)
@@ -122,7 +122,7 @@ const AvatarSelectMenu = forwardRef(({ showBackButton, previewEnabled = true }: 
   useEffect(() => {
     if (avatarLoading.value && selfAvatarLoaded) {
       avatarLoading.set(false)
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     }
   }, [selfAvatarLoaded, avatarLoading])
 
@@ -141,7 +141,7 @@ const AvatarSelectMenu = forwardRef(({ showBackButton, previewEnabled = true }: 
     if (userAvatarId !== selectedAvatarId.value) {
       await handleConfirmAvatar()
     }
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   // expose handleClose since only the parent component
@@ -156,7 +156,7 @@ const AvatarSelectMenu = forwardRef(({ showBackButton, previewEnabled = true }: 
     if (avatarCreatorMenuRef.current) {
       avatarCreatorMenuRef.current?.handleClose()
     } else {
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     }
   }
 
@@ -228,7 +228,7 @@ const AvatarSelectMenu = forwardRef(({ showBackButton, previewEnabled = true }: 
                   variant="primary"
                   onClick={() => {
                     const Menu = AvatarCreatorMenu2(SupportedSdks.ReadyPlayerMe)
-                    PopoverState.showPopupover(
+                    ModalState.openModal(
                       <Menu
                         ref={avatarCreatorMenuRef}
                         showBackButton={showBackButton}
@@ -247,7 +247,7 @@ const AvatarSelectMenu = forwardRef(({ showBackButton, previewEnabled = true }: 
                   className="min-w-[8rem] rounded-md text-sm font-normal"
                   variant="secondary"
                   onClick={() => {
-                    PopoverState.showPopupover(<AvatarModifyMenu />)
+                    ModalState.openModal(<AvatarModifyMenu />)
                   }}
                 >
                   {t('user:avatar.uploadAvatar')}
@@ -264,7 +264,7 @@ const AvatarSelectMenu = forwardRef(({ showBackButton, previewEnabled = true }: 
                       name={avatar.name}
                       type="rectangle"
                       onClick={() => selectedAvatarId.set(avatar.id)}
-                      onChange={() => PopoverState.showPopupover(<AvatarModifyMenu selectedAvatar={avatar} />)}
+                      onChange={() => ModalState.openModal(<AvatarModifyMenu selectedAvatar={avatar} />)}
                     />
                   </Fragment>
                 ))}

--- a/packages/client-core/src/user/menus/avatar/DiscardAvatarChangesMenu.tsx
+++ b/packages/client-core/src/user/menus/avatar/DiscardAvatarChangesMenu.tsx
@@ -29,7 +29,7 @@ import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { GoAlert } from 'react-icons/go'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 
 interface Props {
   handleConfirm: () => void
@@ -40,7 +40,7 @@ export const DiscardAvatarChangesMenu = ({ handleConfirm, handleCancel }: Props)
   const { t } = useTranslation()
 
   const handleClose = () => {
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
     if (handleCancel) handleCancel()
   }
 

--- a/packages/client-core/src/user/menus/index.tsx
+++ b/packages/client-core/src/user/menus/index.tsx
@@ -31,7 +31,7 @@ import PopupMenu from '@ir-engine/ui/src/primitives/tailwind/PopupMenu'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { FaUserFriends } from 'react-icons/fa'
-import { PopoverState } from '../../common/services/PopoverState'
+import { ModalState } from '../../common/services/ModalState'
 import { ViewerMenuState } from '../../util/ViewerMenuState'
 import LocationIconButton from '../components/LocationIconButton'
 import EmoteMenu from './EmoteMenu'
@@ -53,7 +53,7 @@ export default function UserMenus() {
               position: 'top'
             }}
             icon={isMobile ? User01Md : User01Lg}
-            onClick={() => PopoverState.showPopupover(<ProfileMenu />)}
+            onClick={() => ModalState.openModal(<ProfileMenu />)}
           />
         )}
         {userMenus.share.value && (
@@ -63,7 +63,7 @@ export default function UserMenus() {
               position: 'top'
             }}
             icon={isMobile ? Send01Md : Send01Lg}
-            onClick={() => PopoverState.showPopupover(<ShareMenu />)}
+            onClick={() => ModalState.openModal(<ShareMenu />)}
           />
         )}
         {userMenus.emote.value && (
@@ -73,7 +73,7 @@ export default function UserMenus() {
               position: 'top'
             }}
             icon={isMobile ? EmoteLg : EmoteM}
-            onClick={() => PopoverState.showPopupover(<EmoteMenu />, undefined, 'transparent')}
+            onClick={() => ModalState.openModal(<EmoteMenu />, undefined, 'transparent')}
           />
         )}
         {userMenus.social.value && (
@@ -83,7 +83,7 @@ export default function UserMenus() {
               position: 'top'
             }}
             icon={FaUserFriends}
-            onClick={() => PopoverState.showPopupover(<FriendsMenu />)}
+            onClick={() => ModalState.openModal(<FriendsMenu />)}
           />
         )}
       </div>

--- a/packages/client-core/src/user/menus/social/FriendsMenu.tsx
+++ b/packages/client-core/src/user/menus/social/FriendsMenu.tsx
@@ -46,7 +46,7 @@ import AvatarImage from '@ir-engine/ui/src/primitives/tailwind/AvatarImage'
 import Tabs from '@ir-engine/ui/src/primitives/tailwind/Tabs'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import { IoIosCall } from 'react-icons/io'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { useUserAvatarThumbnail } from '../../../hooks/useUserAvatarThumbnail'
 import { ChannelService, ChannelState } from '../../../social/services/ChannelService'
 import { FriendService, FriendState } from '../../../social/services/FriendService'
@@ -112,23 +112,23 @@ const FriendsMenu = ({ defaultSelectedTab }: Props): JSX.Element => {
   }
 
   const handleProfile = (user: DisplayedUserInterface) => {
-    PopoverState.showPopupover(<AvatarContextMenu userId={user.id} />)
+    ModalState.openModal(<AvatarContextMenu userId={user.id} />)
   }
 
   const handleOpenChat = (id: string) => {
     if (TabNames[selectedTabIndex.value] === 'messages') {
-      PopoverState.showPopupover(<MessagesMenu channelID={id as ChannelID} name="" />)
+      ModalState.openModal(<MessagesMenu channelID={id as ChannelID} name="" />)
     } else {
       const channelWithFriend = privateChannels.find(
         (channel) =>
           channel.channelUsers.length === 2 && channel.channelUsers.find((channelUser) => channelUser.userId === id)
       )
       if (channelWithFriend) {
-        PopoverState.showPopupover(<MessagesMenu channelID={channelWithFriend.id} name="" />)
+        ModalState.openModal(<MessagesMenu channelID={channelWithFriend.id} name="" />)
       } else {
         ChannelService.createChannel([id as UserID]).then((channel) => {
           if (channel) {
-            PopoverState.showPopupover(<MessagesMenu channelID={channel.id} name="" />)
+            ModalState.openModal(<MessagesMenu channelID={channel.id} name="" />)
           }
         })
       }

--- a/packages/client-core/src/user/menus/social/MessagesMenu.tsx
+++ b/packages/client-core/src/user/menus/social/MessagesMenu.tsx
@@ -35,7 +35,7 @@ import { Input } from '@ir-engine/ui'
 import { ArrowLeftLg, Send01Lg } from '@ir-engine/ui/src/icons'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import { MdCall, MdCallEnd } from 'react-icons/md'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { useUserAvatarThumbnail } from '../../../hooks/useUserAvatarThumbnail'
 import { ChannelService, ChannelState } from '../../../social/services/ChannelService'
 import XRIconButton from '../../../systems/components/XRIconButton'
@@ -200,7 +200,7 @@ const MessagesMenu = (props: { channelID: ChannelID; name: string }): JSX.Elemen
         xr-layer="true"
         className="iconBlock"
         variant="iconOnly"
-        onClick={() => PopoverState.showPopupover(<FriendsMenu />)}
+        onClick={() => ModalState.openModal(<FriendsMenu />)}
         content={<ArrowLeftLg fontSize="larger" />}
       />
       <div style={{ height: '600px', maxWidth: '100%', overflowX: 'hidden' }}>

--- a/packages/client-core/src/user/menus/social/RelationMenu.tsx
+++ b/packages/client-core/src/user/menus/social/RelationMenu.tsx
@@ -35,7 +35,7 @@ import AvatarImage from '@ir-engine/ui/src/primitives/tailwind/AvatarImage'
 import Badge from '@ir-engine/ui/src/primitives/tailwind/Badge'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
-import { PopoverState } from '../../../common/services/PopoverState'
+import { ModalState } from '../../../common/services/ModalState'
 import { useUserAvatarThumbnail } from '../../../hooks/useUserAvatarThumbnail'
 import { FriendService, FriendState } from '../../../social/services/FriendService'
 import { AuthState } from '../../services/AuthService'
@@ -96,7 +96,7 @@ const AvatarContextMenu = ({ userId }: { userId: UserID }): JSX.Element => {
             fullWidth
             onClick={() => {
               FriendService.requestFriend(selfId, userId)
-              PopoverState.showPopupover(<FriendsMenu defaultSelectedTab="find" />)
+              ModalState.openModal(<FriendsMenu defaultSelectedTab="find" />)
             }}
           >
             {t('user:personMenu.addAsFriend')}
@@ -107,7 +107,7 @@ const AvatarContextMenu = ({ userId }: { userId: UserID }): JSX.Element => {
             fullWidth
             onClick={() => {
               FriendService.unfriend(selfId, userId)
-              PopoverState.showPopupover(<FriendsMenu defaultSelectedTab="find" />)
+              ModalState.openModal(<FriendsMenu defaultSelectedTab="find" />)
             }}
           >
             {t('user:personMenu.unFriend')}
@@ -120,7 +120,7 @@ const AvatarContextMenu = ({ userId }: { userId: UserID }): JSX.Element => {
               fullWidth
               onClick={() => {
                 FriendService.acceptFriend(selfId, userId)
-                PopoverState.showPopupover(<FriendsMenu />)
+                ModalState.openModal(<FriendsMenu />)
               }}
             >
               {t('user:personMenu.acceptRequest')}
@@ -130,7 +130,7 @@ const AvatarContextMenu = ({ userId }: { userId: UserID }): JSX.Element => {
               fullWidth
               onClick={() => {
                 FriendService.declineFriend(selfId, userId)
-                PopoverState.showPopupover(<FriendsMenu defaultSelectedTab="find" />)
+                ModalState.openModal(<FriendsMenu defaultSelectedTab="find" />)
               }}
             >
               {t('user:personMenu.declineRequest')}
@@ -145,7 +145,7 @@ const AvatarContextMenu = ({ userId }: { userId: UserID }): JSX.Element => {
               fullWidth
               onClick={() => {
                 FriendService.unfriend(selfId, userId)
-                PopoverState.showPopupover(<FriendsMenu defaultSelectedTab="find" />)
+                ModalState.openModal(<FriendsMenu defaultSelectedTab="find" />)
               }}
             >
               {t('user:personMenu.cancelRequest')}
@@ -158,7 +158,7 @@ const AvatarContextMenu = ({ userId }: { userId: UserID }): JSX.Element => {
             fullWidth
             onClick={() => {
               FriendService.blockUser(selfId, userId)
-              PopoverState.showPopupover(<FriendsMenu defaultSelectedTab="blocked" />)
+              ModalState.openModal(<FriendsMenu defaultSelectedTab="blocked" />)
             }}
           >
             {t('user:personMenu.block')}
@@ -170,7 +170,7 @@ const AvatarContextMenu = ({ userId }: { userId: UserID }): JSX.Element => {
             fullWidth
             onClick={() => {
               FriendService.unblockUser(selfId, userId)
-              PopoverState.showPopupover(<FriendsMenu />)
+              ModalState.openModal(<FriendsMenu />)
             }}
           >
             {t('user:personMenu.unblock')}

--- a/packages/client/src/pages/index.tsx
+++ b/packages/client/src/pages/index.tsx
@@ -32,7 +32,7 @@ import { NotificationService } from '@ir-engine/client-core/src/common/services/
 import config from '@ir-engine/common/src/config'
 import { useMutableState } from '@ir-engine/hyperflux'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import ProfileMenu from '@ir-engine/client-core/src/user/menus/ProfileMenu'
 import { ViewerMenuState } from '@ir-engine/client-core/src/util/ViewerMenuState'
 import { useFind } from '@ir-engine/common'
@@ -50,7 +50,7 @@ export const HomePage = (): any => {
   useEffect(() => {
     const error = new URL(window.location.href).searchParams.get('error')
     if (error) NotificationService.dispatchNotify(error, { variant: 'error' })
-    PopoverState.showPopupover(<ProfileMenu />)
+    ModalState.openModal(<ProfileMenu />)
     viewerMenuState.userMenus.profile.set(true)
 
     return () => {

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { staticResourcePath } from '@ir-engine/common/src/schema.type.module'
 import { NO_PROXY, getMutableState, getState, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import ErrorDialog from '@ir-engine/ui/src/components/tailwind/ErrorDialog'
@@ -84,7 +84,7 @@ const onEditorWarning = (warning) => {
   })
 
   // popover design doesnt match the figma designs, we use notification for now
-  /*PopoverState.showPopupover(
+  /*ModalState.showPopupover(
     <WarningDialog title={t('editor:warning')} description={warning || t('editor:warningMsg')} />
   )*/
 }
@@ -92,11 +92,11 @@ const onEditorWarning = (warning) => {
 const onEditorError = (error) => {
   console.error(error)
   if (error['aborted']) {
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
     return
   }
 
-  PopoverState.showPopupover(
+  ModalState.openModal(
     <ErrorDialog title={error.title || t('editor:error')} description={error.message || t('editor:errorMsg')} />
   )
 }

--- a/packages/editor/src/components/assets/ImageCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ImageCompressionPanel.tsx
@@ -33,7 +33,7 @@ import {
 } from '@ir-engine/engine/src/assets/constants/CompressionParms'
 import { ImmutableArray, useHookstate } from '@ir-engine/hyperflux'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { Button, Checkbox, Input, Select } from '@ir-engine/ui'
 import { Slider } from '@ir-engine/ui/editor'
 import InputGroup from '@ir-engine/ui/src/components/editor/input/Group'
@@ -81,7 +81,7 @@ export default function ImageCompressionPanel({
     await refreshDirectory()
 
     compressionLoading.set(false)
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   const uploadImage = async (props: FileDataType, data: ArrayBuffer) => {
@@ -121,7 +121,7 @@ export default function ImageCompressionPanel({
         <Button
           variant="tertiary"
           className="absolute right-0 border-0 dark:bg-transparent dark:text-[#A3A3A3]"
-          onClick={() => PopoverState.hidePopupover()}
+          onClick={() => ModalState.closeModal()}
         >
           <MdClose />
         </Button>

--- a/packages/editor/src/components/assets/ModelCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ModelCompressionPanel.tsx
@@ -44,7 +44,7 @@ import {
 import { Heuristic, VariantComponent } from '@ir-engine/engine/src/scene/components/VariantComponent'
 import { NO_PROXY, none, useHookstate } from '@ir-engine/hyperflux'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useTranslation } from 'react-i18next'
 import { defaultLODs, LODList, LODVariantDescriptor } from '../../constants/GLTFPresets'
 import exportGLTF from '../../functions/exportGLTF'
@@ -161,7 +161,7 @@ export default function ModelCompressionPanel({
 
   const applyPreset = (preset: ModelTransformParameters) => {
     selectedPreset.set(JSON.parse(JSON.stringify(preset)))
-    PopoverState.showPopupover(
+    ModalState.openModal(
       <ConfirmDialog text={t('editor:properties.model.transform.applyPresetConfirmation')} onSubmit={confirmPreset} />
     )
   }
@@ -276,7 +276,7 @@ export default function ModelCompressionPanel({
         <Button
           variant="tertiary"
           className="absolute right-0 border-0 dark:bg-transparent dark:text-[#A3A3A3]"
-          onClick={() => PopoverState.hidePopupover()}
+          onClick={() => ModalState.closeModal()}
         >
           <MdClose />
         </Button>

--- a/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { API } from '@ir-engine/common'
 import config from '@ir-engine/common/src/config'
 import { staticResourcePath } from '@ir-engine/common/src/schema.type.module'
@@ -70,13 +70,13 @@ export default function CreatePrefabPanel({ entity, isExportLookDev }: { entity?
   const isOverwriteConfirmed = useHookstate(false)
 
   const finishSavePrefab = () => {
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
     defaultPrefabFolder.set('assets/custom-prefabs')
     prefabName.set('prefab')
     prefabTag.set([])
     isOverwriteModalVisible.set(false)
     isOverwriteConfirmed.set(false)
-    PopoverState.showPopupover(<PrefabConfirmationPanelDialog />)
+    ModalState.openModal(<PrefabConfirmationPanelDialog />)
   }
 
   const exportLookDevPrefab = async (srcProject: string, fileName: string) => {
@@ -211,7 +211,7 @@ export default function CreatePrefabPanel({ entity, isExportLookDev }: { entity?
           title={isExportLookDev ? 'Create Lookdev Prefab' : 'Create Prefab'}
           onSubmit={onExportPrefab}
           className="w-[50vw] max-w-2xl"
-          onClose={PopoverState.hidePopupover}
+          onClose={ModalState.closeModal}
           submitButtonDisabled={!resultFileName.value.isValid}
         >
           <Input

--- a/packages/editor/src/components/dialogs/CreateScenePanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/CreateScenePanelDialog.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
@@ -36,11 +36,7 @@ export default function CreateSceneDialog() {
   const element = useMutableState(UIAddonsState).editor.newScene.get(NO_PROXY)
   const { t } = useTranslation()
   return (
-    <Modal
-      title={t('editor:dialog.createScene.title')}
-      className="w-[15vw] max-w-2xl"
-      onClose={PopoverState.hidePopupover}
-    >
+    <Modal title={t('editor:dialog.createScene.title')} className="w-[15vw] max-w-2xl" onClose={ModalState.closeModal}>
       <div className="flex w-full flex-col justify-center gap-1">
         <Button
           size="sm"
@@ -49,7 +45,7 @@ export default function CreateSceneDialog() {
           onClick={() => {
             onNewScene()
             logNewScene('editor', 'editor')
-            PopoverState.hidePopupover()
+            ModalState.closeModal()
           }}
         >
           {t('editor:dialog.createScene.create')}

--- a/packages/editor/src/components/dialogs/ImportSettingsPanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/ImportSettingsPanelDialog.tsx
@@ -23,8 +23,8 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { KTX2EncodeArguments } from '@ir-engine/engine/src/assets/constants/CompressionParms'
 import { NO_PROXY, State, getMutableState, useHookstate } from '@ir-engine/hyperflux'
 import { Checkbox, Input, Select, Tooltip } from '@ir-engine/ui'
@@ -218,7 +218,7 @@ export default function ImportSettingsPanel() {
   }
 
   const handleCancel = () => {
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   return (
@@ -226,7 +226,7 @@ export default function ImportSettingsPanel() {
       title="Import Settings"
       onSubmit={handleSaveChanges}
       className="w-[50vw] max-w-2xl"
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
     >
       <Input
         value={defaultImportFolder}

--- a/packages/editor/src/components/dialogs/PrefabConfirmationPanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/PrefabConfirmationPanelDialog.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,7 +34,7 @@ export default function PrefabConfirmationPanelDialog() {
     <Modal
       title={t('editor:properties.prefab.lbl-confimation')}
       className="w-[50vw] max-w-2xl"
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       closeButtonText="OK"
     ></Modal>
   )

--- a/packages/editor/src/components/dialogs/QuitToDashboardConfirmationDialog.tsx
+++ b/packages/editor/src/components/dialogs/QuitToDashboardConfirmationDialog.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { Button } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import React from 'react'
@@ -35,7 +35,7 @@ export default function QuitToDashboardConfirmationDialog({ resolve }: { resolve
 
   const onClose = (quit: boolean) => {
     resolve(quit)
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
   return (
     <Modal
@@ -44,7 +44,7 @@ export default function QuitToDashboardConfirmationDialog({ resolve }: { resolve
       hideFooter={true}
       onClose={() => {
         resolve(false)
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
       }}
       rawChildren={
         <>

--- a/packages/editor/src/components/dialogs/SaveNewSceneDialog.tsx
+++ b/packages/editor/src/components/dialogs/SaveNewSceneDialog.tsx
@@ -22,7 +22,7 @@ Original Code is the Infinite Reality Engine team.
 All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
 Infinite Reality Engine. All Rights Reserved.
 */
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import isValidSceneName from '@ir-engine/common/src/utils/validateSceneName'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { AssetModifiedState } from '@ir-engine/engine/src/gltf/GLTFState'
@@ -60,13 +60,13 @@ export default function SaveNewSceneDialog(props: { onConfirm?: () => void; onCa
           getMutableState(AssetModifiedState)[sourceID].set(none)
         }
       }
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
       if (props.onConfirm) props.onConfirm()
     } catch (error) {
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
       if (props.onCancel) props.onCancel()
       console.error(error)
-      PopoverState.showPopupover(
+      ModalState.openModal(
         <ErrorDialog title={t('editor:savingError')} description={error?.message || t('editor:savingErrorMsg')} />
       )
     }
@@ -77,7 +77,7 @@ export default function SaveNewSceneDialog(props: { onConfirm?: () => void; onCa
     <Modal
       title={t('editor:dialog.saveNewScene.title')}
       onClose={() => {
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
         if (props.onCancel) props.onCancel()
       }}
       onSubmit={handleSubmit}

--- a/packages/editor/src/components/dialogs/SavePrefabDialog.tsx
+++ b/packages/editor/src/components/dialogs/SavePrefabDialog.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { isValidFileName } from '@ir-engine/common/src/utils/validateFileName'
 import { getComponent, hasComponent } from '@ir-engine/ecs'
 import { STATIC_ASSET_REGEX } from '@ir-engine/engine/src/assets/functions/pathResolver'
@@ -48,7 +48,7 @@ export default function SavePrefabPanel({ entity }) {
   const onSavePrefab = async () => {
     const saveName = srcPath.value + '.gltf'
     await exportRelativeGLTF(entity, getState(EditorState).projectName!, saveName, false)
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   return (
@@ -57,7 +57,7 @@ export default function SavePrefabPanel({ entity }) {
       onSubmit={onSavePrefab}
       submitButtonDisabled={!resultFileName.isValid.value}
       className="w-[50vw] max-w-2xl"
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
     >
       <Input
         value={srcPath.value}

--- a/packages/editor/src/components/projects/EditorNavbarProfile.tsx
+++ b/packages/editor/src/components/projects/EditorNavbarProfile.tsx
@@ -25,7 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import React from 'react'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import ProfileMenu from '@ir-engine/client-core/src/user/menus/ProfileMenu'
 import { AuthState } from '@ir-engine/client-core/src/user/services/AuthService'
 import { getMutableState, useHookstate } from '@ir-engine/hyperflux'
@@ -35,7 +35,7 @@ export const EditorNavbarProfile = () => {
   const name = useHookstate(getMutableState(AuthState).user.name)
 
   const handleClick = () => {
-    PopoverState.showPopupover(<ProfileMenu />)
+    ModalState.openModal(<ProfileMenu />)
   }
 
   return (

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -26,8 +26,8 @@ Infinite Reality Engine. All Rights Reserved.
 import AddEditProjectModal from '@ir-engine/client-core/src/admin/components/project/AddEditProjectModal'
 import ManageUserPermissionModal from '@ir-engine/client-core/src/admin/components/project/ManageUserPermissionModal'
 import { ProjectUpdateState } from '@ir-engine/client-core/src/admin/services/ProjectUpdateService'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { ProjectService } from '@ir-engine/client-core/src/common/services/ProjectService'
 import { AuthState } from '@ir-engine/client-core/src/user/services/AuthService'
 import { useFind } from '@ir-engine/common'
@@ -276,7 +276,7 @@ const ProjectPage = ({ studioPath }: { studioPath: string }) => {
     }).catch((err) => {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
     })
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   const renderProjectList = (projects: ProjectType[], areInstalledProjects?: boolean) => {
@@ -387,7 +387,7 @@ const ProjectPage = ({ studioPath }: { studioPath: string }) => {
 
           <Button
             onClick={() => {
-              PopoverState.showPopupover(<AddEditProjectModal onSubmit={handleProjectUpdate} update={false} />)
+              ModalState.openModal(<AddEditProjectModal onSubmit={handleProjectUpdate} update={false} />)
             }}
             variant="tertiary"
           >
@@ -451,7 +451,7 @@ const ProjectPage = ({ studioPath }: { studioPath: string }) => {
               onClick={() => {
                 if (projectContextState.project) {
                   setProjectContextState({ event: undefined, project: null })
-                  PopoverState.showPopupover(<ManageUserPermissionModal project={projectContextState.project} />)
+                  ModalState.openModal(<ManageUserPermissionModal project={projectContextState.project} />)
                 }
               }}
               variant="tertiary"
@@ -470,7 +470,7 @@ const ProjectPage = ({ studioPath }: { studioPath: string }) => {
                 onClick={() => {
                   if (projectContextState.project) {
                     setProjectContextState({ event: undefined, project: null })
-                    PopoverState.showPopupover(<AddEditProjectModal onSubmit={handleProjectUpdate} update={true} />)
+                    ModalState.openModal(<AddEditProjectModal onSubmit={handleProjectUpdate} update={true} />)
                   }
                 }}
                 variant="tertiary"
@@ -489,7 +489,7 @@ const ProjectPage = ({ studioPath }: { studioPath: string }) => {
                 onClick={() => {
                   if (projectContextState.project) {
                     setProjectContextState({ event: undefined, project: null })
-                    PopoverState.showPopupover(<AddEditProjectModal onSubmit={handleProjectUpdate} update={true} />)
+                    ModalState.openModal(<AddEditProjectModal onSubmit={handleProjectUpdate} update={true} />)
                   }
                 }}
                 variant="tertiary"
@@ -508,7 +508,7 @@ const ProjectPage = ({ studioPath }: { studioPath: string }) => {
                 onClick={() => {
                   if (projectContextState.project) {
                     setProjectContextState({ event: undefined, project: null })
-                    PopoverState.showPopupover(<AddEditProjectModal onSubmit={handleProjectUpdate} update={true} />)
+                    ModalState.openModal(<AddEditProjectModal onSubmit={handleProjectUpdate} update={true} />)
                   }
                 }}
                 variant="tertiary"
@@ -534,7 +534,7 @@ const ProjectPage = ({ studioPath }: { studioPath: string }) => {
             <Button
               onClick={() => {
                 setProjectContextState({ event: undefined, project: null })
-                PopoverState.showPopupover(<AddEditProjectModal onSubmit={handleProjectUpdate} update={false} />)
+                ModalState.openModal(<AddEditProjectModal onSubmit={handleProjectUpdate} update={false} />)
               }}
               variant="tertiary"
               fullWidth

--- a/packages/editor/src/components/toolbar/Toolbar.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar.tsx
@@ -25,8 +25,8 @@ Infinite Reality Engine. All Rights Reserved.
 
 import AddEditLocationModal from '@ir-engine/client-core/src/admin/components/locations/AddEditLocationModal'
 import ProfilePill from '@ir-engine/client-core/src/common/components/ProfilePill'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { RouterState } from '@ir-engine/client-core/src/common/services/RouterService'
 import { useProjectPermissions } from '@ir-engine/client-core/src/hooks/useUserProjectPermission'
 import { useFind } from '@ir-engine/common'
@@ -71,7 +71,7 @@ export const confirmSceneSaveIfModified = async () => {
 
   if (isModified && isSceneExists) {
     return new Promise((resolve) => {
-      PopoverState.showPopupover(<QuitToDashboardConfirmationDialog resolve={resolve} />)
+      ModalState.openModal(<QuitToDashboardConfirmationDialog resolve={resolve} />)
     })
   }
   return true
@@ -83,7 +83,7 @@ const onClickNewScene = async () => {
   const newSceneUIAddons = getState(UIAddonsState).editor.newScene
 
   if (Object.keys(newSceneUIAddons).length > 0) {
-    PopoverState.showPopupover(<CreateSceneDialog />)
+    ModalState.openModal(<CreateSceneDialog />)
   } else {
     onNewScene()
   }
@@ -124,11 +124,11 @@ const generateToolbarMenu = () => {
     },
     {
       name: t('editor:menubar.saveAs'),
-      action: () => PopoverState.showPopupover(<SaveNewSceneDialog />)
+      action: () => ModalState.openModal(<SaveNewSceneDialog />)
     },
     {
       name: t('editor:menubar.importSettings'),
-      action: () => PopoverState.showPopupover(<ImportSettingsPanel />)
+      action: () => ModalState.openModal(<ImportSettingsPanel />)
     },
     {
       name: t('editor:menubar.importAsset'),
@@ -136,7 +136,7 @@ const generateToolbarMenu = () => {
     },
     {
       name: t('editor:menubar.exportLookdev'),
-      action: () => PopoverState.showPopupover(<CreatePrefabPanel isExportLookDev={true} />)
+      action: () => ModalState.openModal(<CreatePrefabPanel isExportLookDev={true} />)
     },
     {
       name: t('editor:menubar.quit'),
@@ -218,7 +218,7 @@ export default function Toolbar() {
                 data-testid="publish-button"
                 disabled={!hasPublishAccess}
                 onClick={() =>
-                  PopoverState.showPopupover(
+                  ModalState.openModal(
                     <AddEditLocationModal
                       action="studio"
                       sceneID={sceneAssetID.value}

--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -26,8 +26,8 @@ Infinite Reality Engine. All Rights Reserved.
 import i18n from 'i18next'
 
 import { GLTF } from '@gltf-transform/core'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { createScene } from '@ir-engine/client-core/src/world/SceneAPI'
 import { API } from '@ir-engine/common'
 import config from '@ir-engine/common/src/config'
@@ -204,7 +204,7 @@ export const onSaveScene = async () => {
   }
 
   if (!sceneModified) {
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
     NotificationService.dispatchNotify(`${i18n.t('editor:dialog.saveScene.info-save-success')}`, { variant: 'success' })
     return
   }
@@ -217,10 +217,10 @@ export const onSaveScene = async () => {
     const sourceID = GLTFComponent.getInstanceID(rootEntity)
     getMutableState(AssetModifiedState)[sourceID].set(none)
 
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   } catch (error) {
     console.error(error)
-    PopoverState.showPopupover(
+    ModalState.openModal(
       <ErrorDialog
         title={i18n.t('editor:savingError')}
         description={error.message || i18n.t('editor:savingErrorMsg')}

--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -26,7 +26,7 @@ import {
   FileThumbnailJobState,
   removeFromFileThumbnailsSeen
 } from '@ir-engine/client-core/src/common/services/FileThumbnailJobState'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import ProgressBar from '@ir-engine/client-core/src/systems/ui/LoadingDetailView/SimpleProgressBar'
 import { AuthState } from '@ir-engine/client-core/src/user/services/AuthService'
 import { StaticResourceType } from '@ir-engine/common/src/schema.type.module'
@@ -115,7 +115,7 @@ function ResourceFileContextMenu({
             size="sm"
             fullWidth
             onClick={() => {
-              PopoverState.showPopupover(
+              ModalState.openModal(
                 <DeleteFileModal
                   files={[
                     {

--- a/packages/editor/src/panels/files/contextmenu.tsx
+++ b/packages/editor/src/panels/files/contextmenu.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useMutation } from '@ir-engine/common'
 import { fileBrowserPath } from '@ir-engine/common/src/schema.type.module'
 import { NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
@@ -120,7 +120,7 @@ export function FileContextMenu({
       condition: selectedFiles.length === 1,
       label: t('editor:layout.filebrowser.renameAsset'),
       action: () => {
-        PopoverState.showPopupover(
+        ModalState.openModal(
           <RenameFileModal projectName={filesState.projectName.value} file={selectedFiles.value[0]} />
         )
         setAnchorEvent(undefined)
@@ -132,7 +132,7 @@ export function FileContextMenu({
       condition: hasSelection,
       label: t('editor:layout.assetGrid.deleteAsset'),
       action: () => {
-        PopoverState.showPopupover(
+        ModalState.openModal(
           <DeleteFileModal
             files={selectedFiles.get(NO_PROXY)}
             onComplete={(err) => {
@@ -150,7 +150,7 @@ export function FileContextMenu({
       condition: hasFiles && fileConsistsOfContentType(selectedFiles.value, 'model'),
       label: t('editor:layout.filebrowser.compress'),
       action: () => {
-        PopoverState.showPopupover(
+        ModalState.openModal(
           <ModelCompressionPanel selectedFiles={selectedFiles.value} refreshDirectory={refreshDirectory} />
         )
         setAnchorEvent(undefined)
@@ -162,7 +162,7 @@ export function FileContextMenu({
       condition: hasFiles && fileConsistsOfContentType(selectedFiles.value, 'image'),
       label: t('editor:layout.filebrowser.compress') + ' Image',
       action: () => {
-        PopoverState.showPopupover(
+        ModalState.openModal(
           <ImageCompressionPanel selectedFiles={selectedFiles.value} refreshDirectory={refreshDirectory} />
         )
         setAnchorEvent(undefined)
@@ -243,7 +243,7 @@ export function FileContextMenu({
       condition: hasSelection,
       label: t('editor:layout.filebrowser.viewAssetProperties'),
       action: () => {
-        PopoverState.showPopupover(<FilePropertiesModal />)
+        ModalState.openModal(<FilePropertiesModal />)
         setAnchorEvent(undefined)
       },
       testId: 'files-panel-file-item-context-menu-view-asset-properties-button'

--- a/packages/editor/src/panels/files/modals/DeleteFileModal.tsx
+++ b/packages/editor/src/panels/files/modals/DeleteFileModal.tsx
@@ -26,8 +26,8 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { useMutation } from '@ir-engine/common'
 import { fileBrowserPath } from '@ir-engine/common/src/schema.type.module'
 import { useHookstate } from '@ir-engine/hyperflux'
@@ -51,7 +51,7 @@ export default function DeleteFileModal({
     try {
       await Promise.all(files.map((file) => fileService.remove(file.key)))
       modalProcessing.set(false)
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
       onComplete?.()
     } catch (err) {
       NotificationService.dispatchNotify(err?.message, { variant: 'error' })
@@ -65,7 +65,7 @@ export default function DeleteFileModal({
       title={t('editor:layout.filebrowser.deleteFile')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitLoading={modalProcessing.value}
     >
       <Text className="w-full text-center">

--- a/packages/editor/src/panels/files/modals/FilePropertiesModal.tsx
+++ b/packages/editor/src/panels/files/modals/FilePropertiesModal.tsx
@@ -24,7 +24,7 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { FileThumbnailJobState } from '@ir-engine/client-core/src/common/services/FileThumbnailJobState'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { uploadToFeathersService } from '@ir-engine/client-core/src/util/upload'
 import { API, useFind } from '@ir-engine/common'
 import config from '@ir-engine/common/src/config'
@@ -96,7 +96,7 @@ export default function FilePropertiesModal() {
   }
 
   const handleSubmit = async () => {
-    PopoverState.showPopupover(<FilePropertiesSaveConfirmationModal />)
+    ModalState.openModal(<FilePropertiesSaveConfirmationModal />)
     if (modifiedFields.value.length > 0) {
       const addedTags: string[] = resourceDigest.tags.value!.filter((tag) => !sharedTags.value.includes(tag))
       const removedTags: string[] = sharedTags.value!.filter((tag) => !resourceDigest.tags.value!.includes(tag))
@@ -138,16 +138,16 @@ export default function FilePropertiesModal() {
           ) {
             console.log('All properties successfully updated')
             modifiedFields.set([])
-            PopoverState.hidePopupover()
-            PopoverState.hidePopupover()
+            ModalState.closeModal()
+            ModalState.closeModal()
             reactor.stop()
           }
         }
         return null
       })
     } else {
-      PopoverState.hidePopupover()
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
+      ModalState.closeModal()
     }
   }
 
@@ -233,7 +233,7 @@ export default function FilePropertiesModal() {
       title={title}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitButtonText={t('editor:layout.filebrowser.fileProperties.save-changes')}
       closeButtonText={t('editor:layout.filebrowser.fileProperties.discard')}
     >

--- a/packages/editor/src/panels/files/modals/ImageConvertModal.tsx
+++ b/packages/editor/src/panels/files/modals/ImageConvertModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useMutation } from '@ir-engine/common'
 import { imageConvertPath } from '@ir-engine/common/src/schema.type.module'
 import { ImageConvertDefaultParms, ImageConvertParms } from '@ir-engine/engine/src/assets/constants/ImageConvertParms'
@@ -59,7 +59,7 @@ export default function ImageConvertModal({
       })
       .then(() => {
         refreshDirectory()
-        PopoverState.hidePopupover()
+        ModalState.hidePopupover()
       })
   }
 
@@ -68,7 +68,7 @@ export default function ImageConvertModal({
       title={t('editor:layout.filebrowser.convert')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.hidePopupover}
       submitLoading={modalProcessing.value}
     >
       <div className="ml-32 flex flex-col gap-4">

--- a/packages/editor/src/panels/files/modals/ImageConvertModal.tsx
+++ b/packages/editor/src/panels/files/modals/ImageConvertModal.tsx
@@ -59,7 +59,7 @@ export default function ImageConvertModal({
       })
       .then(() => {
         refreshDirectory()
-        ModalState.hidePopupover()
+        ModalState.closeModal()
       })
   }
 
@@ -68,7 +68,7 @@ export default function ImageConvertModal({
       title={t('editor:layout.filebrowser.convert')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={ModalState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitLoading={modalProcessing.value}
     >
       <div className="ml-32 flex flex-col gap-4">

--- a/packages/editor/src/panels/files/modals/RenameFileModal.tsx
+++ b/packages/editor/src/panels/files/modals/RenameFileModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useMutation } from '@ir-engine/common'
 import { fileBrowserPath } from '@ir-engine/common/src/schema.type.module'
 import { isValidFileName } from '@ir-engine/common/src/utils/validateFileName'
@@ -53,7 +53,7 @@ export default function RenameFileModal({ projectName, file }: { projectName: st
         isCopy: false
       })
     }
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   return (
@@ -61,7 +61,7 @@ export default function RenameFileModal({ projectName, file }: { projectName: st
       title={t('editor:layout.filebrowser.renameFile')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitButtonDisabled={!resultFileName.isValid}
     >
       <Input

--- a/packages/editor/src/panels/files/toolbar.tsx
+++ b/packages/editor/src/panels/files/toolbar.tsx
@@ -23,8 +23,8 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
 import { REMOVE_EDGE_SLASH_REGEX } from '@ir-engine/common/src/regex'
 import { NO_PROXY, useMutableState } from '@ir-engine/hyperflux'
 import { Button, Checkbox, Input, Tooltip } from '@ir-engine/ui'
@@ -72,12 +72,12 @@ export const showMultipleFileModal = (projectName: string, directoryPath: string
 
   const onSubmit = async () => {
     await handleUploadFiles(projectName, directoryPath, files)
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
-  PopoverState.showPopupover(
+  ModalState.openModal(
     <>
-      <Modal title={'test'} className="w-[50vw] max-w-2xl" onSubmit={onSubmit} onClose={PopoverState.hidePopupover}>
+      <Modal title={'test'} className="w-[50vw] max-w-2xl" onSubmit={onSubmit} onClose={ModalState.closeModal}>
         <div className="flex flex-col rounded-lg bg-[#0e0f11] px-5 py-10 text-center">
           Warning: You will overwrite existing files by uploading these. Do you wish to continue? <br />
           {fileNames.length > 0 && `Files: ${fileNames.join(', ')}`}

--- a/packages/editor/src/panels/hierarchy/contextmenu.tsx
+++ b/packages/editor/src/panels/hierarchy/contextmenu.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { hasComponent } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { DropdownItem } from '@ir-engine/ui'
@@ -131,7 +131,7 @@ export default function HierarchyTreeContextMenu() {
         <DropdownItem
           onClick={() => {
             setMenu()
-            PopoverState.showPopupover(<CreatePrefabPanel entity={entity} isExportLookDev={false} />)
+            ModalState.openModal(<CreatePrefabPanel entity={entity} isExportLookDev={false} />)
           }}
           label={t('editor:hierarchy.lbl-createPrefab')}
         />
@@ -139,7 +139,7 @@ export default function HierarchyTreeContextMenu() {
           <DropdownItem
             onClick={() => {
               setMenu()
-              PopoverState.showPopupover(<SavePrefabPanel entity={entity} />)
+              ModalState.openModal(<SavePrefabPanel entity={entity} />)
             }}
             label={t('editor:hierarchy.lbl-savePrefab')}
           />

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { userHasProjectPermission } from '@ir-engine/client-core/src/hooks/useUserProjectPermission'
 import { API } from '@ir-engine/common'
 import { projectPermissionPath } from '@ir-engine/common/src/schema.type.module'
@@ -466,7 +466,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
                   className="p-0"
                   title={t('common:components.save')}
                   onClick={() =>
-                    PopoverState.showPopupover(
+                    ModalState.openModal(
                       <ConfirmDialog
                         onSubmit={onSaveChanges}
                         title={t('editor:dialog.saveModel.title')}
@@ -483,7 +483,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
                   className="p-0"
                   title={t('editor:dialog.revertModel.lbl-name')}
                   onClick={() =>
-                    PopoverState.showPopupover(
+                    ModalState.openModal(
                       <ConfirmDialog
                         onSubmit={onRevert}
                         title={t('editor:dialog.revertModel.title')}

--- a/packages/editor/src/panels/scenes/RenameSceneModal.tsx
+++ b/packages/editor/src/panels/scenes/RenameSceneModal.tsx
@@ -26,7 +26,7 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 
 import { renameScene } from '@ir-engine/client-core/src/world/SceneAPI'
 import { StaticResourceType } from '@ir-engine/common/src/schema.type.module'
@@ -61,7 +61,7 @@ export default function RenameSceneModal({ sceneName, onRenameScene, scene, refe
       onRenameScene(newData[0].key)
     }
 
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   return (
@@ -69,7 +69,7 @@ export default function RenameSceneModal({ sceneName, onRenameScene, scene, refe
       title={t('editor:hierarchy.lbl-renameScene')}
       className="w-[50vw] max-w-2xl"
       onSubmit={handleSubmit}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       submitButtonDisabled={newSceneName.value === sceneName || inputError.value.length > 0}
     >
       <Input

--- a/packages/editor/src/panels/scenes/SceneItem.tsx
+++ b/packages/editor/src/panels/scenes/SceneItem.tsx
@@ -22,7 +22,7 @@ Original Code is the Infinite Reality Engine team.
 All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023
 Infinite Reality Engine. All Rights Reserved.
 */
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { ThemeState } from '@ir-engine/client-core/src/common/services/ThemeService'
 import { deleteScene } from '@ir-engine/client-core/src/world/SceneAPI'
 import IRLogoModalDark from '@ir-engine/client/public/iR-logo-Modal-dark.png'
@@ -72,7 +72,7 @@ export default function SceneItem({
         refetchProjectsData()
       }
     }
-    PopoverState.hidePopupover()
+    ModalState.closeModal()
   }
 
   const defaultThumbnail = theme?.value === 'dark' ? IRLogoModalLight : IRLogoModalDark
@@ -126,7 +126,7 @@ export default function SceneItem({
               disabled: false,
               icon: <Edit01Sm />,
               onClick: () => {
-                PopoverState.showPopupover(
+                ModalState.openModal(
                   <RenameSceneModal
                     sceneName={sceneName}
                     scene={scene}
@@ -141,7 +141,7 @@ export default function SceneItem({
               disabled: disableDeleteScene,
               icon: <Trash04Sm />,
               onClick: () => {
-                PopoverState.showPopupover(
+                ModalState.openModal(
                   <ConfirmDialog
                     title={t('editor:hierarchy.lbl-deleteScene')}
                     text={t('editor:hierarchy.lbl-deleteSceneDescription', { sceneName })}

--- a/packages/editor/src/panels/scenes/index.tsx
+++ b/packages/editor/src/panels/scenes/index.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useFind, useRealtime } from '@ir-engine/common'
 import { StaticResourceType, fileBrowserPath, staticResourcePath } from '@ir-engine/common/src/schema.type.module'
 import CreateSceneDialog from '@ir-engine/editor/src/components/dialogs/CreateScenePanelDialog'
@@ -66,7 +66,7 @@ function ScenesPanel() {
     isCreatingScene.set(true)
     const newSceneUIAddons = getState(UIAddonsState).editor.newScene
     if (Object.keys(newSceneUIAddons).length > 0) {
-      PopoverState.showPopupover(<CreateSceneDialog />)
+      ModalState.openModal(<CreateSceneDialog />)
     } else {
       await onNewScene()
     }

--- a/packages/ui/src/components/tailwind/ConfirmDialog/index.tsx
+++ b/packages/ui/src/components/tailwind/ConfirmDialog/index.tsx
@@ -25,7 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 import { t } from 'i18next'
 import React from 'react'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useHookstate } from '@ir-engine/hyperflux'
 
 import Modal, { ModalProps } from '../../../primitives/tailwind/Modal'
@@ -47,7 +47,7 @@ export const ConfirmDialog = ({ title, text, onSubmit, onClose, modalProps }: Co
     modalProcessing.set(true)
     try {
       await onSubmit()
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (error) {
       errorText.set(error.message)
     }
@@ -59,7 +59,7 @@ export const ConfirmDialog = ({ title, text, onSubmit, onClose, modalProps }: Co
       title={title || t('admin:components.common.confirmation')}
       onSubmit={handled}
       onClose={() => {
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
         onClose?.()
       }}
       className="h-[90dvh] w-[50vw] min-w-[720px] max-w-2xl bg-surface-1 mdh:h-auto mdh:min-w-fit"

--- a/packages/ui/src/components/tailwind/ErrorDialog/index.tsx
+++ b/packages/ui/src/components/tailwind/ErrorDialog/index.tsx
@@ -22,7 +22,7 @@ Original Code is the Infinite Reality Engine team.
 All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
 Infinite Reality Engine. All Rights Reserved.
 */
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { t } from 'i18next'
 import React from 'react'
 import ErrorView from '../../../primitives/tailwind/ErrorView'
@@ -38,9 +38,9 @@ const ErrorDialog = ({ title, description, modalProps }: ErrorDialogProps) => {
   return (
     <Modal
       title={t('admin:components.common.confirmation')}
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.closeModal}
       showCloseButton={false}
-      onSubmit={() => PopoverState.hidePopupover()}
+      onSubmit={() => ModalState.closeModal()}
       className="w-[50vw] max-w-2xl"
       {...modalProps}
     >

--- a/packages/ui/src/components/tailwind/InputDialog/index.tsx
+++ b/packages/ui/src/components/tailwind/InputDialog/index.tsx
@@ -25,7 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 import { t } from 'i18next'
 import React from 'react'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { useHookstate } from '@ir-engine/hyperflux'
 
 import Input from '../../../primitives/tailwind/Input'
@@ -66,7 +66,7 @@ export const InputDialog = ({ title, fields, onSubmit, onClose, modalProps }: In
     modalProcessing.set(true)
     try {
       await onSubmit(fieldValues.value)
-      PopoverState.hidePopupover()
+      ModalState.closeModal()
     } catch (error) {
       errorText.set(error.message)
     }
@@ -83,7 +83,7 @@ export const InputDialog = ({ title, fields, onSubmit, onClose, modalProps }: In
       title={title || t('admin:components.common.confirmation')}
       onSubmit={handleSubmit}
       onClose={() => {
-        PopoverState.hidePopupover()
+        ModalState.closeModal()
         onClose?.()
       }}
       className="w-[50vw] max-w-2xl"

--- a/packages/ui/src/components/tailwind/WarningDialog/index.tsx
+++ b/packages/ui/src/components/tailwind/WarningDialog/index.tsx
@@ -36,10 +36,10 @@ interface WarningDialogProps {
 const WarningDialog = ({ title, description, modalProps }: WarningDialogProps) => {
   return (
     <Modal
-      onClose={ModalState.hidePopupover}
+      onClose={ModalState.closeModal}
       showCloseButton={false}
       submitButtonDisabled={true}
-      onSubmit={() => ModalState.hidePopupover()}
+      onSubmit={() => ModalState.closeModal()}
       className="w-[50vw] max-w-2xl bg-yellow-600"
       hideFooter={true}
       {...modalProps}

--- a/packages/ui/src/components/tailwind/WarningDialog/index.tsx
+++ b/packages/ui/src/components/tailwind/WarningDialog/index.tsx
@@ -22,7 +22,7 @@ Original Code is the Infinite Reality Engine team.
 All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
 Infinite Reality Engine. All Rights Reserved.
 */
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import React from 'react'
 import Modal, { ModalProps } from '../../../primitives/tailwind/Modal'
 import WarningView from '../../../primitives/tailwind/WarningView'
@@ -36,10 +36,10 @@ interface WarningDialogProps {
 const WarningDialog = ({ title, description, modalProps }: WarningDialogProps) => {
   return (
     <Modal
-      onClose={PopoverState.hidePopupover}
+      onClose={ModalState.hidePopupover}
       showCloseButton={false}
       submitButtonDisabled={true}
-      onSubmit={() => PopoverState.hidePopupover()}
+      onSubmit={() => ModalState.hidePopupover()}
       className="w-[50vw] max-w-2xl bg-yellow-600"
       hideFooter={true}
       {...modalProps}

--- a/packages/ui/src/primitives/tailwind/ClickawayListener/index.tsx
+++ b/packages/ui/src/primitives/tailwind/ClickawayListener/index.tsx
@@ -25,7 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import React from 'react'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 
 import { getState } from '@ir-engine/hyperflux'
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile.ts'
@@ -33,7 +33,7 @@ import { useEffect, useRef } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 const ClickawayListener = (props: { children: React.ReactNode; onClickOutside: VoidFunction | null }) => {
-  const backdropMode = getState(PopoverState).backdrop
+  const backdropMode = getState(ModalState).backdrop
   const callbackRef = useRef<VoidFunction | null>(null)
   const backdropRef = useRef<HTMLDivElement>(null)
 

--- a/packages/ui/src/primitives/tailwind/Modal/index.stories.tsx
+++ b/packages/ui/src/primitives/tailwind/Modal/index.stories.tsx
@@ -25,7 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import React from 'react'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 
 import Button from '../Button'
 import PopupMenu from '../PopupMenu'
@@ -33,11 +33,11 @@ import Modal from './index'
 
 const ModelStory = ({ title }) => {
   const onClose = () => {
-    PopoverState.hidePopupover()
+    ModalState.hidePopupover()
   }
 
   const onOpen = () => {
-    PopoverState.showPopupover(
+    ModalState.showPopupover(
       <Modal title={title} onClose={onClose} onSubmit={() => {}}>
         <div className="mb-5 flex flex-col border-b border-[#e5e7eb]">
           <label className="text-secondary">Location</label>
@@ -65,11 +65,11 @@ const ModelStory = ({ title }) => {
 
 const MultipleModelStory = ({ title }) => {
   const onClose = () => {
-    PopoverState.hidePopupover()
+    ModalState.hidePopupover()
   }
 
   const onSecondPopupOpen = () => {
-    PopoverState.showPopupover(
+    ModalState.showPopupover(
       <Modal title={title} onClose={onClose} onSubmit={() => {}}>
         <div className="mb-5 flex flex-col border-b border-[#e5e7eb]">
           <label className="text-secondary">Location</label>
@@ -91,7 +91,7 @@ const MultipleModelStory = ({ title }) => {
     <div>
       <Button
         onClick={() => {
-          PopoverState.showPopupover(
+          ModalState.showPopupover(
             <Modal title="First Modal" onClose={onClose}>
               <Button onClick={onSecondPopupOpen}>Click to open modal</Button>
             </Modal>

--- a/packages/ui/src/primitives/tailwind/Modal/index.stories.tsx
+++ b/packages/ui/src/primitives/tailwind/Modal/index.stories.tsx
@@ -33,11 +33,11 @@ import Modal from './index'
 
 const ModelStory = ({ title }) => {
   const onClose = () => {
-    ModalState.hidePopupover()
+    ModalState.closeModal()
   }
 
   const onOpen = () => {
-    ModalState.showPopupover(
+    ModalState.openModal(
       <Modal title={title} onClose={onClose} onSubmit={() => {}}>
         <div className="mb-5 flex flex-col border-b border-[#e5e7eb]">
           <label className="text-secondary">Location</label>
@@ -65,11 +65,11 @@ const ModelStory = ({ title }) => {
 
 const MultipleModelStory = ({ title }) => {
   const onClose = () => {
-    ModalState.hidePopupover()
+    ModalState.closeModal()
   }
 
   const onSecondPopupOpen = () => {
-    ModalState.showPopupover(
+    ModalState.openModal(
       <Modal title={title} onClose={onClose} onSubmit={() => {}}>
         <div className="mb-5 flex flex-col border-b border-[#e5e7eb]">
           <label className="text-secondary">Location</label>
@@ -91,7 +91,7 @@ const MultipleModelStory = ({ title }) => {
     <div>
       <Button
         onClick={() => {
-          ModalState.showPopupover(
+          ModalState.openModal(
             <Modal title="First Modal" onClose={onClose}>
               <Button onClick={onSecondPopupOpen}>Click to open modal</Button>
             </Modal>

--- a/packages/ui/src/primitives/tailwind/PopupMenu/index.tsx
+++ b/packages/ui/src/primitives/tailwind/PopupMenu/index.tsx
@@ -25,13 +25,13 @@ Infinite Reality Engine. All Rights Reserved.
 
 import React, { useEffect } from 'react'
 
-import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import { ModalState } from '@ir-engine/client-core/src/common/services/ModalState'
 import { NO_PROXY, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 
 import ClickawayListener from '../ClickawayListener'
 
 const PopupMenu = () => {
-  const popups = useMutableState(PopoverState).popups
+  const popups = useMutableState(ModalState).modals
 
   const currentOnClose = useHookstate<{
     callback: VoidFunction | null


### PR DESCRIPTION
## Summary

PopoverState is now renamed to ModalState.

ModalState internally uses the Modal component instead of a Popup or Popover component

show and hide are renamed to open and close respectively. this is more indicative of the modal behaviour where it actually closes (and loses it state) instead of staying visually hidden

### Related PRs

https://github.com/theinfinitereality/irpro-multitenancy/pull/811
https://github.com/theinfinitereality/irpro-ecommerce-tools/pull/205

## References
closes https://tsu.atlassian.net/browse/IR-8256

## QA Steps
