### PR TITLE
Ir 8171 app lacks server side validation allowing attackers to bypass client side restrictions and upload malicious files

### DIFF
--- a/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
+++ b/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
@@ -56,8 +56,8 @@ function isValidFileType(fileType: string, fileName: string): boolean {
     fileType.startsWith('image/') ||
     fileType.startsWith('audio/') ||
     fileType.startsWith('video/') ||
-    (fileType === 'application/octet-stream' && (fileName.endsWith('.gltf') || fileName.endsWith('.glb'))) ||
-    fileName.endsWith('.bin') ||
+    (fileType === 'application/octet-stream' &&
+      (fileName.endsWith('.gltf') || fileName.endsWith('.glb') || fileName.endsWith('.bin'))) ||
     (fileType === 'application/macbinary' && fileName.endsWith('.bin')) // Mac changes the mimetype to this when using browser document upload.
   )
 }

--- a/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
+++ b/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
@@ -58,7 +58,7 @@ function isValidFileType(fileType: string, fileName: string): boolean {
     fileType.startsWith('video/') ||
     (fileType === 'application/octet-stream' && (fileName.endsWith('.gltf') || fileName.endsWith('.glb'))) ||
     fileName.endsWith('.bin') ||
-    (fileType === 'application/macbinary' && fileName.endsWith('.bin'))
+    (fileType === 'application/macbinary' && fileName.endsWith('.bin')) // Mac changes the mimetype to this when using browser document upload.
   )
 }
 

--- a/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
+++ b/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
@@ -51,13 +51,14 @@ import verifyScope from '../../hooks/verify-scope'
 //   return context
 // }
 
-function isValidFileType(fileType: string): boolean {
+function isValidFileType(fileType: string, fileName: string): boolean {
   return (
     fileType.startsWith('image/') ||
     fileType.startsWith('audio/') ||
     fileType.startsWith('video/') ||
-    fileType.endsWith('.gltf') ||
-    fileType.endsWith('.glb')
+    (fileType === 'application/octet-stream' && (fileName.endsWith('.gltf') || fileName.endsWith('.glb'))) ||
+    fileName.endsWith('.bin') ||
+    (fileType === 'application/macbinary' && fileName.endsWith('.bin'))
   )
 }
 
@@ -65,7 +66,7 @@ const validateFile = (context: HookContext) => {
   const args = context.arguments
   const file = args?.[1]?.files?.[0]
 
-  if (!isValidFileType(file.mimetype)) {
+  if (!isValidFileType(file.mimetype, file.originalname)) {
     throw new BadRequest('Unsupported file type')
   }
 }

--- a/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
+++ b/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
@@ -26,6 +26,8 @@ Infinite Reality Engine. All Rights Reserved.
 import { iff, isProvider } from 'feathers-hooks-common'
 import { SYNC } from 'feathers-sync'
 
+import { BadRequest } from '@feathersjs/errors'
+import { HookContext } from '../../../declarations'
 import verifyScope from '../../hooks/verify-scope'
 
 // An example of calculating the remaining space left on a hypothetical project max size
@@ -49,6 +51,25 @@ import verifyScope from '../../hooks/verify-scope'
 //   return context
 // }
 
+function isValidFileType(fileType: string): boolean {
+  return (
+    fileType.startsWith('image/') ||
+    fileType.startsWith('audio/') ||
+    fileType.startsWith('video/') ||
+    fileType.endsWith('.gltf') ||
+    fileType.endsWith('.glb')
+  )
+}
+
+const validateFile = (context: HookContext) => {
+  const args = context.arguments
+  const file = args?.[1]?.files?.[0]
+
+  if (!isValidFileType(file.mimetype)) {
+    throw new BadRequest('Unsupported file type')
+  }
+}
+
 export default {
   before: {
     all: [iff(isProvider('external'), verifyScope('editor', 'write'))],
@@ -58,14 +79,16 @@ export default {
       (context) => {
         context[SYNC] = false
         return context
-      }
+      },
+      validateFile
     ],
     update: [],
     patch: [
       (context) => {
         context[SYNC] = false
         return context
-      }
+      },
+      validateFile
     ],
     remove: []
   },


### PR DESCRIPTION
## Summary
Adds server side validation for file types allowed by browser upload.

## References
closes #IR-8171
## QA Steps

First: Using Either a client such as Postman or cli utility make POST requests to the `/file-browser-upload`API endpoint using a variety of files such as images, videos, model files. Cross check these files with the ones allowed via the asset upload functionality in the browser on the project dashboard.

```sh
curl -i --location 'https://localhost:3030/file-browser-upload' \
--insecure \
--header 'Authorization: Bearer <insert authtoken>' \
--form 'media=@"/Users/santiagogarza/Downloads/putty.exe"' \ # Change to location of your file
--form 'args="[{\"project\":\"lively-nest/sfg\",\"path\":\"public/putty.exe\"}]"' #change to match to your project and remote path/filename