### PR TITLE
Fix Auto-Scroll Chat Log

### DIFF
--- a/packages/client-core/src/user/InstanceChat.tsx
+++ b/packages/client-core/src/user/InstanceChat.tsx
@@ -260,7 +260,7 @@ function Messages() {
   useEffect(() => {
     if (!scrollRef.current || !isChatOpen.value) return
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-  }, [isChatOpen])
+  }, [isChatOpen, messages])
 
   if (!isChatOpen.value) return null
   return (


### PR DESCRIPTION
## Summary
Trigger auto-scrolling the chat window to the bottom when the message log is updated. 

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-8121]

## QA Steps


[IR-8121]: https://tsu.atlassian.net/browse/IR-8121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ