### PR TITLE
updated entity name to match filename, with incrementer if needed

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.test.tsx
+++ b/packages/editor/src/functions/EditorControlFunctions.test.tsx
@@ -505,6 +505,93 @@ describe('EditorControlFunctions', () => {
       assert.equal(hemisphereLightComponent.intensity, 0.7)
     })
 
+    it('should create enities in hierarchy using the requested name, adding an increment if a sibling entity with the name already exists', async () => {
+      const nodeID = NodeIDComponent.generate()
+
+      const gltf: GLTF.IGLTF = {
+        asset: {
+          version: '2.0'
+        },
+        scenes: [{ nodes: [0] }],
+        scene: 0,
+        nodes: [
+          {
+            name: 'node',
+            extensions: {
+              [NodeIDComponent.jsonID]: nodeID
+            }
+          }
+        ]
+      }
+
+      Cache.add('/test.gltf', gltf)
+      const rootEntity = AssetState.load('/test.gltf', undefined, physicsWorldEntity, Layers.Authoring)
+      getMutableState(EditorState).rootEntity.set(rootEntity)
+      await waitForScene(rootEntity)
+
+      const simulationNodeEntity = NodeFunctions.getEntityFromNodeID(rootEntity, nodeID)!
+      const authoringNodeEntity = LayerFunctions.getAuthoringCounterpart(simulationNodeEntity)
+
+      const requestedName = 'Test'
+
+      const { entityUUID: entity1UUID } = EditorControlFunctions.createObjectFromSceneElement(
+        [
+          {
+            name: HemisphereLightComponent.jsonID,
+            props: {
+              skyColor: new Color('blue').getHex(),
+              groundColor: new Color('red').getHex(),
+              intensity: 0.7
+            }
+          }
+        ],
+        authoringNodeEntity,
+        UndefinedEntity,
+        requestedName
+      )
+      const entity1 = UUIDComponent.getEntityByUUID(entity1UUID, Layers.Authoring)
+      assert(entity1)
+      assert.equal(getComponent(entity1, NameComponent), 'Test')
+
+      const { entityUUID: entity2UUID } = EditorControlFunctions.createObjectFromSceneElement(
+        [
+          {
+            name: HemisphereLightComponent.jsonID,
+            props: {
+              skyColor: new Color('blue').getHex(),
+              groundColor: new Color('red').getHex(),
+              intensity: 0.7
+            }
+          }
+        ],
+        authoringNodeEntity,
+        UndefinedEntity,
+        requestedName
+      )
+      const entity2 = UUIDComponent.getEntityByUUID(entity2UUID, Layers.Authoring)
+      assert(entity2)
+      assert.equal(getComponent(entity2, NameComponent), 'Test 1')
+
+      const { entityUUID: entity3UUID } = EditorControlFunctions.createObjectFromSceneElement(
+        [
+          {
+            name: HemisphereLightComponent.jsonID,
+            props: {
+              skyColor: new Color('blue').getHex(),
+              groundColor: new Color('red').getHex(),
+              intensity: 0.7
+            }
+          }
+        ],
+        authoringNodeEntity,
+        UndefinedEntity,
+        requestedName
+      )
+      const entity3 = UUIDComponent.getEntityByUUID(entity3UUID, Layers.Authoring)
+      assert(entity3)
+      assert.equal(getComponent(entity3, NameComponent), 'Test 2')
+    })
+
     it('should create a new object from a scene element as child of node', async () => {
       const nodeID = NodeIDComponent.generate()
 

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -81,6 +81,7 @@ import { Color } from 'three'
 import { EditorHelperState } from '../services/EditorHelperState'
 import { EditorState } from '../services/EditorServices'
 import { SelectionState } from '../services/SelectionServices'
+import { getIncreamentedName } from './utils'
 
 const tempMatrix4 = new Matrix4()
 const tempVector = new Vector3()
@@ -285,6 +286,10 @@ const createObjectFromSceneElement = (
   beforeEntity?: Entity,
   requestedName?: string
 ): { entityUUID: EntityUUID; sourceID: string } => {
+  if (requestedName) {
+    requestedName = getIncreamentedName(requestedName, parentEntity)
+  }
+
   const nodeID: NodeID =
     componentJson.find((comp) => comp.name === NodeIDComponent.jsonID)?.props.uuid ?? generateEntityUUID()
 

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -58,6 +58,7 @@ import { serializeEntity } from '@ir-engine/engine/src/scene/functions/serialize
 import { SceneDeltaState } from '@ir-engine/engine/src/scene/systems/SceneDeltaState'
 import { ComponentJsonType } from '@ir-engine/engine/src/scene/types/SceneTypes'
 import { getState } from '@ir-engine/hyperflux'
+import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
 import { MeshComponent } from '@ir-engine/spatial/src/renderer/components/MeshComponent'
 import { VisibleComponent } from '@ir-engine/spatial/src/renderer/components/VisibleComponent'
 import { ObjectLayerMasks, ObjectLayers } from '@ir-engine/spatial/src/renderer/constants/ObjectLayers'
@@ -69,6 +70,7 @@ import { EditorHistoryFunctions } from '../services/EditorHistoryState'
 import { EditorState } from '../services/EditorServices'
 import { EditorControlFunctions } from './EditorControlFunctions'
 import { getIntersectingNodeOnScreen } from './getIntersectingNode'
+import { getIncreamentedName } from './utils'
 
 /**
  * Adds media node from passed url. Type of the media will be detected automatically
@@ -86,6 +88,11 @@ export async function addMediaNode(
 ): Promise<EntityUUID | null> {
   const contentType = (await getContentType(url)) || ''
   const { hostname } = new URL(url)
+
+  const urlObj = new URL(url)
+  const path = urlObj.pathname
+  const fileNameWithExtension = path.substring(path.lastIndexOf('/') + 1)
+  let requestedName = decodeURI(fileNameWithExtension.split('.')[0])
 
   if (contentType.startsWith('model/')) {
     if (contentType.startsWith('model/material')) {
@@ -178,6 +185,8 @@ export async function addMediaNode(
           const rootEntity = getState(EditorState).rootEntity
           const newSource = GLTFComponent.getInstanceID(rootEntity)
           for (const entity of entities) {
+            requestedName = getIncreamentedName(requestedName, parent)
+            setComponent(entity, NameComponent, requestedName)
             setComponent(entity, SourceComponent, newSource)
             setComponent(entity, NodeIDComponent, NodeIDComponent.generate())
             setComponent(
@@ -204,7 +213,8 @@ export async function addMediaNode(
           ...extraComponentJson
         ],
         parent!,
-        before
+        before,
+        requestedName
       )
       EditorHistoryFunctions.snapshot()
       return entityUUID
@@ -218,7 +228,8 @@ export async function addMediaNode(
         ...extraComponentJson
       ],
       parent!,
-      before
+      before,
+      requestedName
     )
     EditorHistoryFunctions.snapshot()
     return entityUUID
@@ -226,7 +237,8 @@ export async function addMediaNode(
     const { entityUUID } = EditorControlFunctions.createObjectFromSceneElement(
       [{ name: ImageComponent.jsonID, props: { source: url } }, ...extraComponentJson],
       parent!,
-      before
+      before,
+      requestedName
     )
     EditorHistoryFunctions.snapshot()
     return entityUUID
@@ -234,7 +246,8 @@ export async function addMediaNode(
     const { entityUUID } = EditorControlFunctions.createObjectFromSceneElement(
       [{ name: MediaComponent.jsonID, props: { resources: [url] } }, ...extraComponentJson],
       parent!,
-      before
+      before,
+      requestedName
     )
     EditorHistoryFunctions.snapshot()
     return entityUUID
@@ -247,7 +260,8 @@ export async function addMediaNode(
         ...extraComponentJson
       ],
       parent!,
-      before
+      before,
+      requestedName
     )
     EditorHistoryFunctions.snapshot()
     return entityUUID

--- a/packages/editor/src/functions/utils.ts
+++ b/packages/editor/src/functions/utils.ts
@@ -23,8 +23,11 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 import { isApple } from '@ir-engine/common/src/utils/getDeviceStats'
-import { Entity, getOptionalComponent } from '@ir-engine/ecs'
+import { Entity, EntityTreeComponent, getComponent, getOptionalComponent } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent.tsx'
+import { getState } from '@ir-engine/hyperflux'
+import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
+import { EditorState } from '../services/EditorServices'
 
 export function isEntityGlb(entity: Entity): boolean {
   const gltfComponent = getOptionalComponent(entity, GLTFComponent)
@@ -43,3 +46,20 @@ export function getStepSize(event, smallStep, mediumStep, largeStep) {
 }
 
 export const cmdOrCtrlString = isApple() ? 'meta' : 'ctrl'
+
+export const getIncreamentedName = (requestedName: string, parentEntity = getState(EditorState).rootEntity) => {
+  const siblings = getComponent(parentEntity, EntityTreeComponent).children
+  let counter = 0
+  siblings.forEach((child) => {
+    const name = getComponent(child, NameComponent)
+    const match = name.match(/^(.*?)\s+(\d+)?$/)
+    const adjustedName = match ? match[1] : name
+    if (adjustedName === requestedName || name === requestedName) {
+      counter++
+    }
+  })
+  if (counter > 0) {
+    requestedName = `${requestedName} ${counter}`
+  }
+  return requestedName
+}


### PR DESCRIPTION
updated added items to name their entity instance to be named after the filename without the file extension.

If their is a sibling entity with the same or incremented name, add a incremented number to the name

## Summary
https://tsu.atlassian.net/browse/IR-8287

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
