### PR TITLE
Allow Manual Input for Image Input Urls

### DIFF
--- a/packages/editor/src/components/assets/DroppableImageInput.tsx
+++ b/packages/editor/src/components/assets/DroppableImageInput.tsx
@@ -35,12 +35,13 @@ const acceptDropItems = [...ItemTypes.Images, ItemTypes.File]
 
 export interface DroppableImageInputProps extends Omit<ImageLinkProps, 'onBlur'> {
   onBlur: (value: string) => void
+  onChange: (value: string) => void
 }
 
 /**
  * allows dropping of a file/asset and takes care of uploading it
  */
-export default function DroppableImageInput({ onBlur, ...props }: DroppableImageInputProps) {
+export default function DroppableImageInput({ onBlur, onChange, ...props }: DroppableImageInputProps) {
   const onUpload = useUpload({
     multiple: false,
     accepts: ImageFileTypes
@@ -71,7 +72,7 @@ export default function DroppableImageInput({ onBlur, ...props }: DroppableImage
 
   return (
     <div className={twMerge('rounded-[10px]', canDrop && isOver && 'border border-dotted border-white')} ref={dropRef}>
-      <ImageLink onBlur={onBlur} {...props} />
+      <ImageLink onBlur={onBlur} {...props} onChange={onChange} />
     </div>
   )
 }

--- a/packages/ui/src/components/editor/ImageLink/index.tsx
+++ b/packages/ui/src/components/editor/ImageLink/index.tsx
@@ -23,6 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+import { useHookstate } from '@ir-engine/hyperflux'
 import React, { ImgHTMLAttributes, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { twMerge } from 'tailwind-merge'
@@ -61,12 +62,13 @@ const imageVariants = {
 export default function ImageLink({ src, onChange, onBlur, variant = 'full', ...props }: ImageLinkProps) {
   const { t } = useTranslation()
   const imageRef = useRef<HTMLImageElement>(null)
+  const validSrc = useHookstate<typeof ImageUrlFallback | string>(ImageUrlFallback)
 
   useEffect(() => {
     if (!imageRef.current) return
     const onErrorCallback = () => {
       if (!imageRef.current) return
-      imageRef.current.src = ImageUrlFallback
+      validSrc.set(ImageUrlFallback)
     }
 
     imageRef.current.addEventListener('error', onErrorCallback)
@@ -78,15 +80,17 @@ export default function ImageLink({ src, onChange, onBlur, variant = 'full', ...
   }, [])
 
   useEffect(() => {
-    if (!src && imageRef.current) {
-      imageRef.current.src = ImageUrlFallback
+    if (!src || (src && !URL.canParse(src))) {
+      validSrc.set(ImageUrlFallback)
+      return
     }
+    validSrc.set(src)
   }, [src])
 
   return (
     <div className={twMerge('flex flex-col bg-ui-background', containerVariants[variant])}>
       <img
-        src={src}
+        src={validSrc.value}
         className={twMerge(
           'mx-auto rounded',
           imageVariants[variant],

--- a/packages/ui/src/components/editor/properties/envmap/index.tsx
+++ b/packages/ui/src/components/editor/properties/envmap/index.tsx
@@ -70,6 +70,10 @@ export const EnvMapEditor: EditorComponentType = (props) => {
     commitProperty(EnvMapComponent, 'envMapCubemapURL')(directory)
   }, [])
 
+  const onChangeEnvMapSourceURL = useCallback((value) => {
+    commitProperty(EnvMapComponent, 'envMapSourceURL')(value)
+  }, [])
+
   const envmapComponent = useComponent(entity, EnvMapComponent)
 
   const errors = getEntityErrors(props.entity, EnvMapComponent)
@@ -119,6 +123,7 @@ export const EnvMapEditor: EditorComponentType = (props) => {
               <DroppableImageInput
                 src={envmapComponent.envMapSourceURL.value}
                 onBlur={commitProperty(EnvMapComponent, 'envMapSourceURL')}
+                onChange={onChangeEnvMapSourceURL}
               />
             )}
             {errors?.MISSING_FILE && (


### PR DESCRIPTION
## Summary
Added an `onChange` listener to the `DroppableImageInput` editor panel, allowing manual user input. 
Wrap the img tag `src` attribute in a useHookState function to prevent image flickering when typing in the input field.
## Subtasks Checklist

## Breaking Changes

## References
closes [IR-7809]

## QA Steps


[IR-7809]: https://tsu.atlassian.net/browse/IR-7809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ