### PR TITLE
Removed auto-deletion of login-tokens

### DIFF
--- a/packages/server-core/email-templates/account/magiclink-email.pug
+++ b/packages/server-core/email-templates/account/magiclink-email.pug
@@ -29,6 +29,7 @@ block content
                     a.magic-link(href=hashLink style='color:#c10d8b;') #{hashLink}
           tr
             td
+              p(style='font-family: "Campton", Arial, sans-serif;line-height:27px;margin-top:0') This link is only valid for 10 minutes.
               p(style='font-family: "Campton", Arial, sans-serif;line-height:27px;margin-top:0') Welcome on board.
               p(style='line-height:27px;margin-top:25px;')
                 strong(style='font-family: "Campton", Arial, sans-serif;') - Infinite Reality Team

--- a/packages/server-core/src/user/login-token/login-token.resolvers.ts
+++ b/packages/server-core/src/user/login-token/login-token.resolvers.ts
@@ -51,7 +51,7 @@ export const loginTokenDataResolver = resolve<LoginTokenType, HookContext>({
     return crypto.randomBytes(config.authentication.bearerToken.numBytes).toString('hex')
   },
   expiresAt: async (value, message, context) => {
-    return context.data.expiresAt ? context.data.expiresAt : toDateTimeSql(moment().utc().add(2, 'days').toDate())
+    return context.data.expiresAt ? context.data.expiresAt : toDateTimeSql(moment().utc().add(10, 'minutes').toDate())
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/login/login.class.ts
+++ b/packages/server-core/src/user/login/login.class.ts
@@ -166,7 +166,9 @@ export class LoginService implements ServiceInterface {
         }
       })
 
-      if (isValidId(loginToken.id)) await this.app.service(loginTokenPath).remove(loginToken.id)
+      // Disabling auto-delete of login-tokens due to some devices and email services auto-following links
+      // Uncomment to re-enable
+      // if (isValidId(loginToken.id)) await this.app.service(loginTokenPath).remove(loginToken.id)
       await this.app.service(userPath).patch(identityProvider.userId, {
         isGuest: false
       })


### PR DESCRIPTION
## Summary

Some email forwarding services, and seemingly Apple devices, will follow links that they detect, which would use up the token and cause valid attempts to follow the link to fail because the token was already used.

Set expiration of magiclink login tokens to 10 minutes.

Added a line to email template to note that the links are only valid for 10 minutes.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
