### PR TITLE
IR-8123: implement ready player me guest accounts

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -603,7 +603,15 @@
         "subtitle": "Edit Zendesk Settings"
       },
       "keyName": "key Name",
-      "kid": "Key Id"
+      "kid": "Key Id",
+      "readyPlayerMe": {
+        "header": "Ready Player Me",
+        "subtitle": "Edit Ready Player Me Settings",
+        "appId": "App ID",
+        "api": "Api URL",
+        "apiKey": "Api Key",
+        "partner": "Partner"
+      }
     },
     "avatar": {
       "columns": {

--- a/packages/client-core/src/admin/components/settings/index.tsx
+++ b/packages/client-core/src/admin/components/settings/index.tsx
@@ -39,6 +39,7 @@ import HelmTab from './tabs/helm'
 import InstanceServerTab from './tabs/instanceServer'
 import MetabaseTab from './tabs/metabase'
 import ProjectTab from './tabs/project'
+import ReadyPlayerMeTab from './tabs/readyPlayerMe'
 import RedisTab from './tabs/redis'
 import ServerTab from './tabs/server'
 import TaskServerTab from './tabs/taskServer'
@@ -97,6 +98,10 @@ export const SettingsTabsData = [
   {
     label: t('admin:components.setting.zendesk.header'),
     Component: ZendeskTab
+  },
+  {
+    label: t('admin:components.setting.readyPlayerMe.header'),
+    Component: ReadyPlayerMeTab
   }
 ]
 

--- a/packages/client-core/src/admin/components/settings/tabs/readyPlayerMe.tsx
+++ b/packages/client-core/src/admin/components/settings/tabs/readyPlayerMe.tsx
@@ -1,0 +1,178 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import React, { forwardRef, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useFind, useMutation } from '@ir-engine/common'
+import { EngineSettings } from '@ir-engine/common/src/constants/EngineSettings'
+import { engineSettingPath } from '@ir-engine/common/src/schema.type.module'
+import { getDataType } from '@ir-engine/common/src/utils/dataTypeUtils'
+import { useHookstate } from '@ir-engine/hyperflux'
+import { Button, Input } from '@ir-engine/ui'
+import PasswordInput from '@ir-engine/ui/src/components/tailwind/PasswordInput'
+import Accordion from '@ir-engine/ui/src/primitives/tailwind/Accordion'
+import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
+
+const ReadyPlayerMeTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableRefObject<HTMLDivElement>) => {
+  const { t } = useTranslation()
+  const state = useHookstate<{ loading: boolean; errorMessage: string }>({
+    loading: false,
+    errorMessage: ''
+  })
+  const rpmSetting = useHookstate<{ appId: string; api: string; apiKey: string; partner: string }>({
+    appId: '',
+    api: '',
+    apiKey: '',
+    partner: ''
+  })
+
+  const readyPlayerMeMutation = useMutation(engineSettingPath)
+
+  const rpmSettingsQuery = useFind(engineSettingPath, {
+    query: {
+      category: 'ready-player-me',
+      paginate: false
+    }
+  })
+
+  useEffect(() => {
+    if (rpmSettingsQuery.status === 'success' && rpmSettingsQuery.data.length > 0) {
+      rpmSettingsQuery.data.map((setting) => {
+        rpmSetting.merge({
+          [setting.key]: setting.value
+        })
+      })
+    }
+  }, [rpmSettingsQuery.status])
+
+  const handleSubmit = async ($event) => {
+    $event.preventDefault()
+    const setting = rpmSetting.value
+
+    const hasEmptySetting = Object.keys(setting).some((key) => !setting[key])
+
+    if (hasEmptySetting) return
+
+    state.loading.set(true)
+    const operation = Object.values(EngineSettings.ReadyPlayerMe).map((key) => {
+      const settingInDb = rpmSettingsQuery.data.find((el) => el.key === key)
+      if (!settingInDb) {
+        return readyPlayerMeMutation.create({
+          key,
+          category: 'ready-player-me',
+          dataType: getDataType(setting[key]),
+          value: setting[key],
+          type: 'private'
+        })
+      }
+      return readyPlayerMeMutation.patch(settingInDb.id, {
+        key,
+        category: 'ready-player-me',
+        dataType: getDataType(setting[key]),
+        value: setting[key],
+        type: 'private'
+      })
+    })
+    try {
+      await Promise.all(operation)
+      state.set({ loading: false, errorMessage: '' })
+    } catch (error) {
+      state.set({ loading: false, errorMessage: error.message })
+    }
+  }
+
+  const handleReset = () => {
+    if (rpmSettingsQuery.data.length > 0) {
+      rpmSettingsQuery.data.map((setting) => {
+        rpmSetting.merge({
+          [setting.key]: setting.value
+        })
+      })
+    }
+  }
+
+  return (
+    <Accordion
+      title={t('admin:components.setting.readyPlayerMe.header')}
+      subtitle={t('admin:components.setting.readyPlayerMe.subtitle')}
+      ref={ref}
+      open={open}
+    >
+      <div className="my-6 grid grid-cols-3 gap-6">
+        <Input
+          fullWidth
+          labelProps={{
+            text: t('admin:components.setting.readyPlayerMe.appId'),
+            position: 'top'
+          }}
+          value={rpmSetting.appId?.value || ''}
+          onChange={(e) => rpmSetting.appId.set(e.target.value)}
+        />
+        <Input
+          fullWidth
+          labelProps={{
+            text: t('admin:components.setting.readyPlayerMe.api'),
+            position: 'top'
+          }}
+          value={rpmSetting.api?.value || ''}
+          onChange={(e) => rpmSetting.api.set(e.target.value)}
+        />
+
+        <PasswordInput
+          fullWidth
+          labelProps={{
+            text: t('admin:components.setting.readyPlayerMe.apiKey'),
+            position: 'top'
+          }}
+          value={rpmSetting.apiKey?.value || ''}
+          onChange={(e) => rpmSetting.apiKey.set(e.target.value)}
+        />
+
+        <Input
+          fullWidth
+          labelProps={{
+            text: t('admin:components.setting.readyPlayerMe.partner'),
+            position: 'top'
+          }}
+          value={rpmSetting.partner?.value || ''}
+          onChange={(e) => rpmSetting.partner.set(e.target.value)}
+        />
+      </div>
+
+      <div className="grid grid-cols-8 gap-6">
+        <Button size="sm" className="text-primary col-span-1 " fullWidth onClick={handleReset}>
+          {t('admin:components.common.reset')}
+        </Button>
+        <Button size="sm" variant="primary" className="col-span-1" fullWidth onClick={handleSubmit}>
+          {state.loading.value && <LoadingView spinnerOnly className="h-6 w-6" />}
+          {t('admin:components.common.save')}
+        </Button>
+      </div>
+    </Accordion>
+  )
+})
+
+export default ReadyPlayerMeTab

--- a/packages/client-core/src/user/menus/avatar/AvatarCreatorMenu.tsx
+++ b/packages/client-core/src/user/menus/avatar/AvatarCreatorMenu.tsx
@@ -30,8 +30,10 @@ import config from '@ir-engine/common/src/config'
 import { THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH } from '@ir-engine/common/src/constants/AvatarConstants'
 
 import { getCanvasBlob } from '@ir-engine/client-core/src/common/utils'
+import { useGet, useMutation } from '@ir-engine/common'
 import multiLogger from '@ir-engine/common/src/logger'
-import { useHookstate } from '@ir-engine/hyperflux'
+import { readyPlayerMeAccountPath } from '@ir-engine/common/src/schema.type.module'
+import { useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { Button, Input } from '@ir-engine/ui'
 import { ArrowLeftLg, XCloseLg } from '@ir-engine/ui/src/icons'
 import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
@@ -39,6 +41,7 @@ import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import AvatarPreview from '../../../common/components/AvatarPreview'
 import { ModalState } from '../../../common/services/ModalState'
 import { AVATAR_ID_REGEX, generateAvatarId } from '../../../util/avatarIdFunctions'
+import { AuthState } from '../../services/AuthService'
 import { AvatarService } from '../../services/AvatarService'
 import { DiscardAvatarChangesMenu } from './DiscardAvatarChangesMenu'
 
@@ -71,24 +74,30 @@ const AvatarCreatorMenu = (selectedSdk: string) =>
   forwardRef((props: AvatarCreatorMenuProps, ref) => {
     const { previewEnabled = true, previewDisabledMessage } = props
     const { t } = useTranslation()
+    const authState = useMutableState(AuthState)
+    const userId = authState.user?.id?.value
     const selectedBlob = useHookstate<Blob | null>(null)
     const thumbnail = useHookstate<Blob | null>(null)
     const avatarName = useHookstate('')
     const avatarUrl = useHookstate('')
     const loading = useHookstate(LoadingState.LoadingCreator)
     const error = useHookstate('')
-
+    const readyPlayerMeMutation = useMutation(readyPlayerMeAccountPath)
     const logger = multiLogger.child({ component: 'client-core:AvatarCreatorMenu' })
 
-    const getSdkUrl = () => {
-      switch (selectedSdk) {
-        case SupportedSdks.Avaturn:
-          return config.client.avaturnUrl
-        case SupportedSdks.ReadyPlayerMe:
-        default:
-          return config.client.readyPlayerMeUrl
+    const readyPlayerMeAccount = useGet(readyPlayerMeAccountPath, undefined, {
+      query: {
+        userId: userId
       }
-    }
+    })
+
+    useEffect(() => {
+      // If the condition is met, there's likely a token in cache that has already been used;
+      // therefore, a refetch is needed.
+      if (readyPlayerMeAccount.status === 'success') {
+        readyPlayerMeAccount.refetch()
+      }
+    }, [])
 
     useEffect(() => {
       window.addEventListener('message', handleMessageEvent)
@@ -98,9 +107,22 @@ const AvatarCreatorMenu = (selectedSdk: string) =>
     }, [])
 
     useEffect(() => {
-      const rpmIframe = document.getElementById('rpm-iframe') as HTMLIFrameElement
-      rpmIframe.src = getSdkUrl() as string
-    }, [])
+      const setSdkUrl = async (token?: string) => {
+        const rpmIframe = document.getElementById('rpm-iframe') as HTMLIFrameElement
+        let url = ''
+        if (selectedSdk === SupportedSdks.Avaturn) {
+          url = config.client.avaturnUrl as string
+        } else {
+          const tokenParam = token ? `&clearCache&token=${token}` : ''
+          url = `${config.client.readyPlayerMeUrl}${tokenParam}`
+        }
+        rpmIframe.src = url
+      }
+
+      if (readyPlayerMeAccount.status !== 'pending') {
+        setSdkUrl(readyPlayerMeAccount.data?.token)
+      }
+    }, [readyPlayerMeAccount])
 
     const export2DReadyPlayerMeAvatar = async (avatarId: string): Promise<Blob> => {
       const res = await fetch(
@@ -136,8 +158,9 @@ const AvatarCreatorMenu = (selectedSdk: string) =>
         return
       }
 
+      const rpmIframe = document.getElementById('rpm-iframe') as HTMLIFrameElement
+
       if (message.eventName === 'v1.frame.ready') {
-        const rpmIframe = document.getElementById('rpm-iframe') as HTMLIFrameElement
         rpmIframe?.contentWindow?.postMessage(
           JSON.stringify({
             target: 'readyplayerme',
@@ -149,6 +172,14 @@ const AvatarCreatorMenu = (selectedSdk: string) =>
       }
 
       if (message.eventName === 'v1.avatar.exported') {
+        rpmIframe?.contentWindow?.postMessage(
+          JSON.stringify({
+            target: 'readyplayerme',
+            type: 'query',
+            eventName: 'v1.user.logout'
+          }),
+          '*'
+        )
         loading.set(LoadingState.Downloading)
         error.set('')
         avatarName.set(message.data.avatarId)
@@ -168,6 +199,14 @@ const AvatarCreatorMenu = (selectedSdk: string) =>
           error.set(t('user:usermenu.avatar.selectValidFile'))
           loading.set(LoadingState.None)
         }
+      }
+
+      if (message.eventName === 'v1.user.authorized' && !!readyPlayerMeAccount.data?.id) {
+        await readyPlayerMeMutation.patch(readyPlayerMeAccount.data?.id, {
+          type: 'linked',
+          readyPlayerMeUserId: message.data.id
+        })
+        readyPlayerMeAccount.refetch()
       }
     }
 

--- a/packages/common/src/constants/EngineSettings.ts
+++ b/packages/common/src/constants/EngineSettings.ts
@@ -149,5 +149,11 @@ export const EngineSettings = {
       SecretAccessKey: 'eks.secretAccessKey',
       RoleArn: 'eks.roleArn'
     }
+  },
+  ReadyPlayerMe: {
+    appId: 'appId',
+    api: 'api',
+    apiKey: 'apiKey',
+    partner: 'partner'
   }
 }

--- a/packages/common/src/schema.type.module.ts
+++ b/packages/common/src/schema.type.module.ts
@@ -33,6 +33,7 @@ export type * from './schemas/cluster/logs-api.schema'
 export type * from './schemas/cluster/migrations-info.schema'
 export type * from './schemas/cluster/pods.schema'
 export type * from './schemas/integrations/metabase/metabase-url.schema'
+export type * from './schemas/integrations/ready-player-me/ready-player-me.schema'
 export type * from './schemas/integrations/zendesk/zendesk.schema'
 export type * from './schemas/matchmaking/match-instance.schema'
 export type * from './schemas/matchmaking/match-user.schema'
@@ -283,6 +284,8 @@ export const invalidationPath = 'invalidation'
 export const imageConvertPath = 'image-convert'
 
 export const zendeskPath = 'zendesk'
+
+export const readyPlayerMeAccountPath = 'ready-player-me-account'
 
 export const projectHistoryPath = 'project-history'
 

--- a/packages/common/src/schemas/integrations/ready-player-me/ready-player-me.schema.ts
+++ b/packages/common/src/schemas/integrations/ready-player-me/ready-player-me.schema.ts
@@ -1,0 +1,63 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import { getValidator, Static, StringEnum, Type } from '@feathersjs/typebox'
+import { TypedString } from '../../../types/TypeboxUtils'
+import { UserID } from '../../user/user.schema'
+import { dataValidator } from '../../validators'
+
+export const readyPlayerMeAccountPath = 'ready-player-me-account'
+
+export const readyPlayerMeAccountMethods = ['get', 'patch'] as const
+
+export const ReadyPlayerMeAccountSchema = Type.Object(
+  {
+    id: Type.String({
+      format: 'uuid'
+    }),
+    userId: TypedString<UserID>({
+      format: 'uuid'
+    }),
+    type: StringEnum(['linked', 'guest']),
+    token: Type.Optional(Type.String()),
+    readyPlayerMeUserId: Type.String(),
+    createdAt: Type.String({ format: 'date-time' }),
+    updatedAt: Type.String({ format: 'date-time' })
+  },
+  { $id: 'ReadyPlayerMeAccount', additionalProperties: false }
+)
+export interface ReadyPlayerMeAccountType extends Static<typeof ReadyPlayerMeAccountSchema> {}
+
+export interface ReadyPlayerMeAccountDatabaseType extends Omit<ReadyPlayerMeAccountType, 'token'> {}
+
+export const ReadyPlayerMeAccountDataSchema = Type.Pick(ReadyPlayerMeAccountSchema, ['type', 'readyPlayerMeUserId'], {
+  $id: 'readyPlayerMeAccountData'
+})
+export interface ReadyPlayerMeAccountData extends Static<typeof ReadyPlayerMeAccountDataSchema> {}
+
+export const readyPlayerMeAccountDataValidator = /* @__PURE__ */ getValidator(
+  ReadyPlayerMeAccountDataSchema,
+  dataValidator
+)

--- a/packages/common/src/utils/FeathersHooks.tsx
+++ b/packages/common/src/utils/FeathersHooks.tsx
@@ -131,7 +131,7 @@ export const useService = <S extends keyof ServiceTypes, M extends Methods>(
   const fetchRef = useRef<() => void>()
   fetchRef.current = () => {
     const state = getMutableState(FeathersState)[serviceName][queryId]
-    if (method === 'get' && (!args || args[0] == null || args[0] === '')) {
+    if (method === 'get' && (!args || args[0] == null || args[0] === '' || args[0] === undefined) && !args[1]) {
       state.merge({
         status: 'error',
         error: 'Get method requires an id or query object'

--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -455,6 +455,13 @@ const metabase = {
   environment: process.env.METABASE_ENVIRONMENT
 }
 
+const readyPlayerMe = {
+  appId: process.env.READY_PLAYER_ME_APP_ID,
+  api: process.env.READY_PLAYER_ME_API,
+  apiKey: process.env.READY_PLAYER_ME_API_KEY,
+  partner: process.env.READY_PLAYER_ME_PARTNER
+}
+
 /**
  * Full config
  */
@@ -488,7 +495,8 @@ const config = {
     typeof process.env.ALLOW_OUT_OF_DATE_PROJECTS === 'undefined' || process.env.ALLOW_OUT_OF_DATE_PROJECTS === 'true',
   fsProjectSyncEnabled: process.env.FS_PROJECT_SYNC_ENABLED === 'false' ? false : true,
   zendesk,
-  metabase
+  metabase,
+  readyPlayerMe
 }
 
 chargebeeInst.configure({

--- a/packages/server-core/src/integrations/ready-player-me-account/migrations/20250319230520_readyPlayerMeAccount.ts
+++ b/packages/server-core/src/integrations/ready-player-me-account/migrations/20250319230520_readyPlayerMeAccount.ts
@@ -1,0 +1,69 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import type { Knex } from 'knex'
+
+export const readyPlayerMeAccountPath = 'ready-player-me-account'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw('SET FOREIGN_KEY_CHECKS=0')
+
+  const tableExists = await knex.schema.hasTable(readyPlayerMeAccountPath)
+
+  if (tableExists === false) {
+    await knex.schema.createTable(readyPlayerMeAccountPath, (table) => {
+      //@ts-ignore
+      table.uuid('id').collate('utf8mb4_bin').primary()
+      //@ts-ignore
+      table.uuid('userId', 36).collate('utf8mb4_bin').index()
+      table.string('type').defaultTo('guest')
+      table.string('readyPlayerMeUserId').notNullable()
+      table.dateTime('createdAt').notNullable()
+      table.dateTime('updatedAt').notNullable()
+    })
+  }
+
+  await knex.raw('SET FOREIGN_KEY_CHECKS=1')
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('SET FOREIGN_KEY_CHECKS=0')
+
+  const tableExists = await knex.schema.hasTable(readyPlayerMeAccountPath)
+
+  if (tableExists === true) {
+    await knex.schema.dropTable(readyPlayerMeAccountPath)
+  }
+
+  await knex.raw('SET FOREIGN_KEY_CHECKS=1')
+}

--- a/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.class.ts
+++ b/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.class.ts
@@ -23,8 +23,25 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import MetabaseUrl from './metabase/metabase-url/metabase-url'
-import ReadyPlayerMeAccount from './ready-player-me-account/ready-player-me-account'
-import ZendeskAuthentication from './zendesk/zendesk'
+import { Params } from '@feathersjs/feathers'
+import { KnexAdapterParams, KnexService } from '@feathersjs/knex'
+import {
+  ReadyPlayerMeAccountData,
+  ReadyPlayerMeAccountType
+} from '@ir-engine/common/src/schemas/integrations/ready-player-me/ready-player-me.schema'
 
-export default [ZendeskAuthentication, MetabaseUrl, ReadyPlayerMeAccount]
+export interface ReadyPlayerMeAccountParams extends KnexAdapterParams {}
+
+/**
+ * A class for ReadyPlayerMe service
+ */
+
+export class ReadyPlayerMeAccountService<
+  T = ReadyPlayerMeAccountType,
+  ServiceParams extends Params = ReadyPlayerMeAccountParams
+> extends KnexService<
+  ReadyPlayerMeAccountType,
+  ReadyPlayerMeAccountData,
+  ReadyPlayerMeAccountParams,
+  ReadyPlayerMeAccountData
+> {}

--- a/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.docs.ts
+++ b/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.docs.ts
@@ -23,8 +23,12 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import MetabaseUrl from './metabase/metabase-url/metabase-url'
-import ReadyPlayerMeAccount from './ready-player-me-account/ready-player-me-account'
-import ZendeskAuthentication from './zendesk/zendesk'
+import { createSwaggerServiceOptions } from 'feathers-swagger'
 
-export default [ZendeskAuthentication, MetabaseUrl, ReadyPlayerMeAccount]
+export default createSwaggerServiceOptions({
+  schemas: {},
+  docs: {
+    description: 'Ready Player Me Account service description',
+    securities: ['all']
+  }
+})

--- a/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.hooks.ts
+++ b/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.hooks.ts
@@ -1,0 +1,126 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import { HookContext } from '@feathersjs/feathers/lib/declarations'
+import { hooks as schemaHooks } from '@feathersjs/schema'
+import {
+  readyPlayerMeAccountDataValidator,
+  readyPlayerMeAccountPath
+} from '@ir-engine/common/src/schemas/integrations/ready-player-me/ready-player-me.schema'
+import appConfig from '@ir-engine/server-core/src/appconfig'
+import { disallow } from 'feathers-hooks-common'
+import fetch from 'node-fetch'
+import { Application } from '../../../declarations'
+import logger from '../../ServerLogger'
+import {
+  readyPlayerMeAccountDatResolver,
+  readyPlayerMeAccountPatchResolver,
+  readyPlayerMeAccountResolver
+} from './ready-player-me-account.resolvers'
+
+const createReadyPlayerMeUser = async () => {
+  if (!appConfig.readyPlayerMe.apiKey || !appConfig.readyPlayerMe.api) {
+    logger.warn('createReadyPlayerMeUser: Missing RPM config', appConfig.readyPlayerMe)
+    return ''
+  }
+
+  const url = `${appConfig.readyPlayerMe.api}users/`
+  const data = { data: { applicationId: appConfig.readyPlayerMe.appId } }
+
+  const response = await (
+    await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': appConfig.readyPlayerMe.apiKey
+      },
+      body: JSON.stringify(data)
+    })
+  ).json()
+  return response.data
+}
+
+const createAccountIfNotExists = async (context: HookContext<Application>) => {
+  const [user] = await context.app.service(readyPlayerMeAccountPath).find({
+    query: {
+      userId: context.params.user?.id
+    },
+    paginate: false
+  })
+
+  if (user) return context
+
+  const readyPlayerMeUserId = (await createReadyPlayerMeUser())?.id
+
+  if (!readyPlayerMeUserId) {
+    context.result = {
+      readyPlayerMeUserId
+    }
+  }
+
+  const accountCreated = await context.app.service(readyPlayerMeAccountPath).create({
+    type: 'guest',
+    readyPlayerMeUserId
+  })
+
+  context.result = accountCreated
+  return context
+}
+
+export default {
+  around: {
+    all: [schemaHooks.resolveResult(readyPlayerMeAccountResolver)]
+  },
+  before: {
+    all: [],
+    find: [disallow('external')],
+    get: [createAccountIfNotExists],
+    create: [disallow('external'), schemaHooks.resolveData(readyPlayerMeAccountDatResolver)],
+    update: [disallow()],
+    patch: [
+      schemaHooks.validateData(readyPlayerMeAccountDataValidator),
+      schemaHooks.resolveData(readyPlayerMeAccountPatchResolver)
+    ],
+    remove: [disallow()]
+  },
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+} as any

--- a/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.resolvers.ts
+++ b/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.resolvers.ts
@@ -1,0 +1,86 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
+import { resolve, virtual } from '@feathersjs/schema'
+import appConfig from '@ir-engine/server-core/src/appconfig'
+import { v4 as uuidv4 } from 'uuid'
+
+import { BadRequest } from '@feathersjs/errors'
+import { ReadyPlayerMeAccountType } from '@ir-engine/common/src/schema.type.module'
+import { fromDateTimeSql, getDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import type { HookContext } from '@ir-engine/server-core/declarations'
+
+const getToken = async (userId: string) => {
+  if (!userId || !appConfig.readyPlayerMe.apiKey || !appConfig.readyPlayerMe.api) {
+    return ''
+  }
+  const response = await (
+    await fetch(
+      `${appConfig.readyPlayerMe.api}auth/token?userId=${userId}&partner=${appConfig.readyPlayerMe.partner}`,
+      {
+        headers: {
+          'x-api-key': appConfig.readyPlayerMe.apiKey
+        }
+      }
+    )
+  ).json()
+  return response?.data?.token ?? ''
+}
+
+export const readyPlayerMeAccountResolver = resolve<ReadyPlayerMeAccountType, HookContext>({
+  token: virtual(async (rpmUser: ReadyPlayerMeAccountType) => {
+    return await getToken(rpmUser.readyPlayerMeUserId)
+  }),
+  createdAt: virtual(async (account) => fromDateTimeSql(account.createdAt)),
+  updatedAt: virtual(async (account) => fromDateTimeSql(account.updatedAt))
+})
+
+export const readyPlayerMeAccountDatResolver = resolve<ReadyPlayerMeAccountType, HookContext>({
+  id: async () => {
+    return uuidv4()
+  },
+  userId: async (_value, _, context: HookContext) => {
+    return context.params.user?.id
+  },
+  createdAt: getDateTimeSql,
+  updatedAt: getDateTimeSql
+})
+
+export const readyPlayerMeAccountPatchResolver = resolve<ReadyPlayerMeAccountType, HookContext>({
+  type: async (type, account: ReadyPlayerMeAccountType) => {
+    const readyPlayerMeUserId = account?.readyPlayerMeUserId
+
+    if (type !== 'linked') {
+      throw new BadRequest('Invalid RPM account type')
+    }
+
+    if (type === 'linked' && !readyPlayerMeUserId) {
+      throw new BadRequest('Invalid RPM User Id')
+    }
+    return type
+  },
+  updatedAt: getDateTimeSql
+})

--- a/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.ts
+++ b/packages/server-core/src/integrations/ready-player-me-account/ready-player-me-account.ts
@@ -23,8 +23,38 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import MetabaseUrl from './metabase/metabase-url/metabase-url'
-import ReadyPlayerMeAccount from './ready-player-me-account/ready-player-me-account'
-import ZendeskAuthentication from './zendesk/zendesk'
+import {
+  readyPlayerMeAccountMethods,
+  readyPlayerMeAccountPath
+} from '@ir-engine/common/src/schemas/integrations/ready-player-me/ready-player-me.schema'
 
-export default [ZendeskAuthentication, MetabaseUrl, ReadyPlayerMeAccount]
+import { Application } from '../../../declarations'
+import { ReadyPlayerMeAccountService } from './ready-player-me-account.class'
+import ReadyPlayerMeDocs from './ready-player-me-account.docs'
+import hooks from './ready-player-me-account.hooks'
+
+declare module '@ir-engine/common/declarations' {
+  interface ServiceTypes {
+    [readyPlayerMeAccountPath]: ReadyPlayerMeAccountService
+  }
+}
+
+export default (app: Application): void => {
+  const options = {
+    name: readyPlayerMeAccountPath,
+    paginate: app.get('paginate'),
+    Model: app.get('knexClient'),
+    multi: false
+  }
+
+  app.use(readyPlayerMeAccountPath, new ReadyPlayerMeAccountService(options), {
+    // A list of all methods this service exposes externally
+    methods: readyPlayerMeAccountMethods,
+    // You can add additional custom events to be sent to clients here
+    events: [],
+    docs: ReadyPlayerMeDocs
+  })
+
+  const service = app.service(readyPlayerMeAccountPath)
+  service.hooks(hooks)
+}

--- a/packages/server-core/src/setting/engine-setting/engine-setting.seed.ts
+++ b/packages/server-core/src/setting/engine-setting/engine-setting.seed.ts
@@ -420,6 +420,28 @@ export async function seed(knex: Knex): Promise<void> {
     ],
     'email'
   )
+
+  const readyPlayerMeSeedData = await generateSeedData(
+    [
+      {
+        key: EngineSettings.ReadyPlayerMe.appId,
+        value: process.env.READY_PLAYER_ME_APP_ID || ''
+      },
+      {
+        key: EngineSettings.ReadyPlayerMe.api,
+        value: process.env.READY_PLAYER_ME_API || ''
+      },
+      {
+        key: EngineSettings.ReadyPlayerMe.apiKey,
+        value: process.env.READY_PLAYER_ME_API_KEY || ''
+      },
+      {
+        key: EngineSettings.ReadyPlayerMe.partner,
+        value: process.env.READY_PLAYER_ME_PARTNER || ''
+      }
+    ],
+    'ready-player-me'
+  )
   const seedData: EngineSettingType[] = [
     ...taskServerSeedData,
     ...chargebeeSettingSeedData,
@@ -432,7 +454,8 @@ export async function seed(knex: Knex): Promise<void> {
     ...zendeskSettingSeedData,
     ...helmSeedData,
     ...awsSeedData,
-    ...emailSeedData
+    ...emailSeedData,
+    ...readyPlayerMeSeedData
   ]
 
   if (forceRefresh || testEnabled) {

--- a/packages/server-core/src/setting/engine-setting/migrations/20250320151902_ready-player-me-settings.ts
+++ b/packages/server-core/src/setting/engine-setting/migrations/20250320151902_ready-player-me-settings.ts
@@ -1,0 +1,87 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import { EngineSettings } from '@ir-engine/common/src/constants/EngineSettings'
+import { engineSettingPath, EngineSettingType } from '@ir-engine/common/src/schemas/setting/engine-setting.schema'
+import { getDataType } from '@ir-engine/common/src/utils/dataTypeUtils'
+import { getDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
+import type { Knex } from 'knex'
+import { v4 as uuidv4 } from 'uuid'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  const tableExists = await knex.schema.hasTable(engineSettingPath)
+
+  if (tableExists) {
+    const settingExists = await knex.from(engineSettingPath).where('category', '=', 'ready-player-me')
+
+    if (settingExists.length === 0) {
+      const rpmSettings: EngineSettingType[] = await Promise.all(
+        [
+          {
+            key: EngineSettings.ReadyPlayerMe.appId,
+            value: process.env.READY_PLAYER_ME_APP_ID || ''
+          },
+          {
+            key: EngineSettings.ReadyPlayerMe.api,
+            value: process.env.READY_PLAYER_ME_API || ''
+          },
+          {
+            key: EngineSettings.ReadyPlayerMe.apiKey,
+            value: process.env.READY_PLAYER_ME_API_KEY || ''
+          },
+          {
+            key: EngineSettings.ReadyPlayerMe.partner,
+            value: process.env.READY_PLAYER_ME_PARTNER || ''
+          }
+        ].map(async (item) => ({
+          ...item,
+          id: uuidv4(),
+          dataType: getDataType(item.value),
+          type: 'private' as EngineSettingType['type'],
+          category: 'ready-player-me',
+          createdAt: await getDateTimeSql(),
+          updatedAt: await getDateTimeSql()
+        }))
+      )
+      await knex.from(engineSettingPath).insert(rpmSettings)
+    }
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {
+  const tableExists = await knex.schema.hasTable(engineSettingPath)
+
+  if (tableExists) {
+    await knex.from(engineSettingPath).where('category', '=', 'ready-player-me').delete()
+  }
+}


### PR DESCRIPTION
## Summary

**Current Behavior:**
Ready Player Me currently uses browser storage to manage user sessions and store created avatars. This means:

If multiple users share the same device, they will also share avatars (in ready player me, not in IR Engine).
If a user logs in on a different device, their avatars will not be available.

**Proposed Change:**
This PR implements guest accounts, allowing us to create and authenticate a Ready Player Me account on behalf of the user. This ensures that:

- Each user on a shared device has their own avatars.
- Users can restore their avatars across different devices.

https://docs.readyplayer.me/ready-player-me/integration-guides/web-and-native-integration/user-management


**Admin component to manage the ready player me settings**
![image](https://github.com/user-attachments/assets/93f0cb35-08a5-466c-8093-4273ff519df6)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

1.- Go to a publish location
2.- Log in 
3.- Create an avatar 
4.- Log out 
5.- Create an avatar as a (IR) guest user 
6.- Verify the avatar creator doesn't show the avatar created in step 3. 
7.- Log back in with the account used in step 2 
8.-Open the avatar creator, verify the avatar created in step 3 is visible and 
     the avatar created in step 5 is not displayed. 
  
