### PR TITLE
Remove debug log from gizmo commit function

### DIFF
--- a/packages/editor/src/functions/transformGizmoHelper.ts
+++ b/packages/editor/src/functions/transformGizmoHelper.ts
@@ -937,7 +937,6 @@ export function onGizmoCommit(gizmoEntity) {
   }
   gizmoControlComponent.dragging.set(false)
   gizmoControlComponent.axis.set(null)
-  console.log('gizmo commit')
   EditorHistoryFunctions.setComponent(gizmoControlComponent.controlledEntities.value as Entity[], TransformComponent)
 }
 


### PR DESCRIPTION
Eliminate unnecessary debug logging in the gizmo commit function to clean up the code.