### PR TITLE
Fixed bug in getServerPodInfo and getServerContainerInfo

### DIFF
--- a/packages/server-core/src/cluster/pods/pods-helper.ts
+++ b/packages/server-core/src/cluster/pods/pods-helper.ts
@@ -204,12 +204,12 @@ const getServerPodInfo = (item: V1Pod) => {
     name: item.metadata?.name,
     status: item.status?.phase,
     age: item.status?.startTime?.toString(),
-    containers: getServerContainerInfo(item.status?.containerStatuses!)
+    containers: getServerContainerInfo((item.status?.containerStatuses as V1ContainerStatus[]) || [])
   } as ServerPodInfoType
 }
 
 const getServerContainerInfo = (items: V1ContainerStatus[]) => {
-  return items.map((item) => {
+  return items?.map((item) => {
     return {
       name: item.name,
       status: item.state?.running


### PR DESCRIPTION
## Summary

getServerPodInfo was passing containerStatuses of server pod assuming it was defined, but failed/evicted pods have no containerStatuses. This was causing getServerContainerInfo to error out when attempting to call .map on undefined.

Made getServerPodInfo default to an empty array if containerStatuses is undefined/null. Also added a conditional check on getServerContainerInfo's .map so that it'll just return null if somehow no items are passed to it.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
