### PR TITLE
IR-8171 add server side validation for media upload filetypes (#1427)

### DIFF
--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -77,6 +77,7 @@ import { SkyboxComponent } from '@ir-engine/engine/src/scene/components/SkyboxCo
 import { setCameraFocusOnBox } from '@ir-engine/spatial/src/camera/functions/CameraFunctions'
 import { MeshComponent } from '@ir-engine/spatial/src/renderer/components/MeshComponent'
 import { BackgroundComponent, SceneComponent } from '@ir-engine/spatial/src/renderer/components/SceneComponents'
+import mime from 'mime-types'
 import { uploadToFeathersService } from '../../util/upload'
 import { getCanvasBlob } from '../utils'
 
@@ -119,7 +120,8 @@ const uploadThumbnail = async (src: string, projectName: string, blob: Blob | nu
   if (!blob) return
   const thumbnailMode = 'automatic'
   const thumbnailKey = generateThumbnailKey(src, projectName)
-  const file = new File([blob], thumbnailKey)
+  const mimetype = mime.lookup(thumbnailKey) || 'application/octet-stream'
+  const file = new File([blob], thumbnailKey, { type: mimetype })
   try {
     const thumbnailURL = new URL(
       await uploadToFeathersService(fileBrowserUploadPath, [file], {

--- a/packages/server-core/src/media/FileUtil.test.ts
+++ b/packages/server-core/src/media/FileUtil.test.ts
@@ -28,12 +28,12 @@ import '../patchEngineNode'
 import assert from 'assert'
 import fs from 'fs'
 import path from 'path/posix'
-import { afterAll, beforeAll, describe, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { createEngine, destroyEngine } from '@ir-engine/ecs/src/Engine'
 
 import { projectsRootFolder } from './file-browser/file-browser.class'
-import { copyRecursiveSync, getIncrementalName } from './FileUtil'
+import { copyRecursiveSync, getIncrementalName, isValidFileType } from './FileUtil'
 import LocalStorage from './storageprovider/local.storage'
 
 const TEST_DIR = 'FileUtil-test-project'
@@ -193,6 +193,49 @@ describe('FileUtil functions', () => {
 
       fs.rmdirSync(path.join(STORAGE_PATH, singularDirName))
       fs.rmdirSync(path.join(STORAGE_PATH, pluralDirName))
+    })
+  })
+
+  describe('isValidFileType', () => {
+    it('returns true for valid image mime types', () => {
+      const fileType: string = 'image/png'
+      const fileName: string = 'file.png'
+      expect(isValidFileType(fileType, fileName)).toBe(true)
+    })
+
+    it('returns true for valid audio mime types', () => {
+      const fileType: string = 'audio/mpeg'
+      const fileName: string = 'song.mp3'
+      expect(isValidFileType(fileType, fileName)).toBe(true)
+    })
+
+    it('returns true for valid video mime types', () => {
+      const fileType: string = 'video/mp4'
+      const fileName: string = 'video.mp4'
+      expect(isValidFileType(fileType, fileName)).toBe(true)
+    })
+
+    it('returns true for application/octet-stream with valid extensions', () => {
+      expect(isValidFileType('application/octet-stream', 'model.gltf')).toBe(true)
+      expect(isValidFileType('application/octet-stream', 'model.glb')).toBe(true)
+      expect(isValidFileType('application/octet-stream', 'model.bin')).toBe(true)
+    })
+
+    it('returns true for application/macbinary with .bin extension', () => {
+      expect(isValidFileType('application/macbinary', 'macupload.bin')).toBe(true)
+    })
+
+    it('returns false for application/octet-stream with invalid extension', () => {
+      expect(isValidFileType('application/octet-stream', 'file.txt')).toBe(false)
+    })
+
+    it('returns false for application/macbinary with invalid extension', () => {
+      expect(isValidFileType('application/macbinary', 'file.doc')).toBe(false)
+    })
+
+    it('returns false for unrelated mime types', () => {
+      expect(isValidFileType('application/pdf', 'doc.pdf')).toBe(false)
+      expect(isValidFileType('text/plain', 'notes.txt')).toBe(false)
     })
   })
 

--- a/packages/server-core/src/media/FileUtil.ts
+++ b/packages/server-core/src/media/FileUtil.ts
@@ -71,3 +71,14 @@ export const getIncrementalName = async function (
 
   return filename
 }
+
+export const isValidFileType = function (fileType: string, fileName: string): boolean {
+  return (
+    fileType.startsWith('image/') ||
+    fileType.startsWith('audio/') ||
+    fileType.startsWith('video/') ||
+    (fileType === 'application/octet-stream' &&
+      (fileName.endsWith('.gltf') || fileName.endsWith('.glb') || fileName.endsWith('.bin'))) ||
+    (fileType === 'application/macbinary' && fileName.endsWith('.bin')) // Mac changes the mimetype to this when using browser document upload.
+  )
+}

--- a/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
+++ b/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
@@ -26,7 +26,10 @@ Infinite Reality Engine. All Rights Reserved.
 import { iff, isProvider } from 'feathers-hooks-common'
 import { SYNC } from 'feathers-sync'
 
+import { BadRequest } from '@feathersjs/errors'
+import { HookContext } from '../../../declarations'
 import verifyScope from '../../hooks/verify-scope'
+import { isValidFileType } from '../FileUtil'
 
 // An example of calculating the remaining space left on a hypothetical project max size
 // const projectNameRegex = /projects\/([^/]+)/
@@ -49,6 +52,15 @@ import verifyScope from '../../hooks/verify-scope'
 //   return context
 // }
 
+const validateFile = (context: HookContext) => {
+  const args = context.arguments
+  const file = args?.[1]?.files?.[0]
+
+  if (!isValidFileType(file.mimetype, file.originalname)) {
+    throw new BadRequest('Unsupported file type')
+  }
+}
+
 export default {
   before: {
     all: [iff(isProvider('external'), verifyScope('editor', 'write'))],
@@ -58,14 +70,16 @@ export default {
       (context) => {
         context[SYNC] = false
         return context
-      }
+      },
+      validateFile
     ],
     update: [],
     patch: [
       (context) => {
         context[SYNC] = false
         return context
-      }
+      },
+      validateFile
     ],
     remove: []
   },


### PR DESCRIPTION
* fix: Add server side validation for file upload

* fix: fixes validity checks for glb/gltf files

* fix: add comment

* fix error in OR logic

* fix: move mimetype validation function to utils file and add unittests

* fix: remove redundant unit test

* fix: remove empty unused file

* fix: Update uploadThumbnail call made from browser to include the mimetype to be compatible with the server side filetype checks

---------

## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
