### PR TITLE
Fixed issue with browser extension breaking login

### DIFF
--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -249,7 +249,7 @@ async function _resetToGuestToken(options = { reset: true }) {
   })
   const accessToken = newProvider.accessToken!
   await API.instance.authentication.setAccessToken(accessToken as string)
-  writeAuthUserToIframe()
+  await writeAuthUserToIframe()
   return accessToken
 }
 
@@ -303,7 +303,7 @@ export const AuthService = {
         const authUser = resolveAuthUser(res)
         // authUser is now { accessToken, authentication, identityProvider }
         authState.merge({ authUser })
-        writeAuthUserToIframe()
+        await writeAuthUserToIframe()
         await AuthService.loadUserData(authUser.identityProvider.userId)
       } else {
         logger.warn('No response received from reAuthenticate()!')
@@ -312,7 +312,7 @@ export const AuthService = {
     } catch (err) {
       logger.error(err, 'Error on resolving auth user in doLoginAuto, logging out')
       authState.merge({ user: UserSeed, authUser: AuthUserSeed })
-      writeAuthUserToIframe()
+      await writeAuthUserToIframe()
 
       // if (window.location.pathname !== '/') {
       //   window.location.href = '/';
@@ -489,7 +489,7 @@ export const AuthService = {
 
       const authUser = resolveAuthUser(res)
       authState.merge({ authUser })
-      writeAuthUserToIframe()
+      await writeAuthUserToIframe()
       await AuthService.loadUserData(authUser.identityProvider?.userId)
       authState.merge({ isProcessing: false, error: '' })
       let timeoutTimer = 0
@@ -505,7 +505,10 @@ export const AuthService = {
         }
         // After 3 seconds without the token getting updated, send the user back anyway - something seems to have
         // gone wrong, and we don't want them stuck on the page they were on indefinitely.
-        if (timeoutTimer > 3000) window.location.href = redirectSuccess
+        if (timeoutTimer > 3000) {
+          clearInterval(waitForTokenStored)
+          window.location.href = redirectSuccess
+        }
       }, TIMEOUT_INTERVAL)
     } catch (err) {
       authState.merge({ error: i18n.t('common:error.login-error') })


### PR DESCRIPTION
## Summary

Some browser extensions, Metamask being one example, were breaking login. The issue was related to not `await`ing calls to writeAuthUserToIframe - this was not completing before loginUserByJwt was redirecting the user back to redirectSuccess, and therefore their new logged-in credentials were not being saved and retrieved.

Resolves IRCS-31 and IR-8562

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
