### PR TITLE
IR-8171 follow up fix issues with server side file type validations

### DIFF
--- a/packages/common/src/utils/cleanFileName.ts
+++ b/packages/common/src/utils/cleanFileName.ts
@@ -23,6 +23,8 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+import mime from 'mime-types'
+
 /**
  * This method takes a filename (with or without included path) and returns a cleaned version of it.
  * Ensures toLower file extension, truncates a file name if too long, and sanitizes special characters
@@ -71,8 +73,11 @@ export const cleanFileNameString = (fullFileName: string, useStorageProviderLeng
  * @param file
  */
 export function cleanFileNameFile(file: File): File {
+  // Ensure File object contains correct mimetype.
+  const mimeType = mime.lookup(file.name) || 'application/octet-stream'
+
   const newFile = new File([file], cleanFileNameString(file.name), {
-    type: file.type,
+    type: mimeType,
     lastModified: file.lastModified
   })
   //overwrite the webkitRelativePath property to preserve directory structure

--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -92,8 +92,8 @@ export const saveSceneGLTF = async (
     logger.error('Failed to save scene, no gltf data found')
   }
 
-  const blob = [new Blob([JSON.stringify(gltfData, null, 2)], { type: 'application/gltf+json' })]
-  const gltfFile = new File(blob, sceneFile)
+  const blob = [new Blob([JSON.stringify(gltfData, null, 2)], { type: 'model/gltf+json' })]
+  const gltfFile = new File(blob, sceneFile, { type: 'model/gltf+json' })
 
   const currentScene = await API.instance.service(staticResourcePath).get(sceneAssetID)
 

--- a/packages/editor/src/panels/viewport/index.tsx
+++ b/packages/editor/src/panels/viewport/index.tsx
@@ -29,7 +29,7 @@ import { uploadToFeathersService } from '@ir-engine/client-core/src/util/upload'
 import { useFind } from '@ir-engine/common'
 import { FeatureFlags } from '@ir-engine/common/src/constants/FeatureFlags'
 import { clientSettingPath, fileBrowserUploadPath } from '@ir-engine/common/src/schema.type.module'
-import { cleanFileNameString } from '@ir-engine/common/src/utils/cleanFileName'
+import { cleanFileNameFile } from '@ir-engine/common/src/utils/cleanFileName'
 import { useComponent, useQuery } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { ResourcePendingComponent } from '@ir-engine/engine/src/gltf/ResourcePendingComponent'
@@ -87,12 +87,12 @@ const ViewportDnD = ({ children }: { children: React.ReactNode }) => {
         Promise.all(
           Array.from(dropDataTransfer.files).map(async (file) => {
             try {
-              const name = cleanFileNameString(file.name)
+              file = cleanFileNameFile(file)
               return uploadToFeathersService(fileBrowserUploadPath, [file], {
                 args: [
                   {
                     project: projectName.value,
-                    path: `assets/` + name,
+                    path: `assets/` + file.name,
                     contentType: file.type
                   }
                 ]

--- a/packages/editor/src/services/SceneThumbnailState.tsx
+++ b/packages/editor/src/services/SceneThumbnailState.tsx
@@ -28,6 +28,7 @@ import { uploadToFeathersService } from '@ir-engine/client-core/src/util/upload'
 import { API } from '@ir-engine/common'
 import config from '@ir-engine/common/src/config'
 import { fileBrowserUploadPath, staticResourcePath } from '@ir-engine/common/src/schema.type.module'
+import { CommonKnownContentTypes } from '@ir-engine/common/src/utils/CommonKnownContentTypes'
 import { getComponent } from '@ir-engine/ecs'
 import {
   blurAndScaleImageData,
@@ -73,7 +74,8 @@ export const SceneThumbnailState = defineState({
       fileNameArray = fileNameArray.slice(0, -1)
     }
     const fileName = fileNameArray.join('.')
-    const file = new File([thumbnailBlob!], fileName + '.thumbnail.jpg')
+    CommonKnownContentTypes['jpg']
+    const file = new File([thumbnailBlob!], fileName + '.thumbnail.jpg', { type: CommonKnownContentTypes['jpg'] })
     const sceneThumbnail = getMutableState(SceneThumbnailState)
     sceneThumbnail.merge({
       oldThumbnailURL: sceneThumbnail.thumbnailURL.value,

--- a/packages/editor/src/services/SceneThumbnailState.tsx
+++ b/packages/editor/src/services/SceneThumbnailState.tsx
@@ -74,7 +74,6 @@ export const SceneThumbnailState = defineState({
       fileNameArray = fileNameArray.slice(0, -1)
     }
     const fileName = fileNameArray.join('.')
-    CommonKnownContentTypes['jpg']
     const file = new File([thumbnailBlob!], fileName + '.thumbnail.jpg', { type: CommonKnownContentTypes['jpg'] })
     const sceneThumbnail = getMutableState(SceneThumbnailState)
     sceneThumbnail.merge({

--- a/packages/server-core/src/media/FileUtil.test.ts
+++ b/packages/server-core/src/media/FileUtil.test.ts
@@ -215,6 +215,14 @@ describe('FileUtil functions', () => {
       expect(isValidFileType(fileType, fileName)).toBe(true)
     })
 
+    it('returns true for valid model mime types', () => {
+      expect(isValidFileType('model/gltf+json', 'model.gltf')).toBe(true)
+      expect(isValidFileType('model/gltf-binary', 'model.glb')).toBe(true)
+      expect(isValidFileType('model/vrm', 'model.vrm')).toBe(true)
+      expect(isValidFileType('model/fbx', 'model.fbx')).toBe(true)
+      expect(isValidFileType('model/usdz', 'model.usdz')).toBe(true)
+    })
+
     it('returns true for application/octet-stream with valid extensions', () => {
       expect(isValidFileType('application/octet-stream', 'model.gltf')).toBe(true)
       expect(isValidFileType('application/octet-stream', 'model.glb')).toBe(true)

--- a/packages/server-core/src/media/FileUtil.ts
+++ b/packages/server-core/src/media/FileUtil.ts
@@ -77,6 +77,7 @@ export const isValidFileType = function (fileType: string, fileName: string): bo
     fileType.startsWith('image/') ||
     fileType.startsWith('audio/') ||
     fileType.startsWith('video/') ||
+    fileType.startsWith('model/') ||
     (fileType === 'application/octet-stream' &&
       (fileName.endsWith('.gltf') || fileName.endsWith('.glb') || fileName.endsWith('.bin'))) ||
     (fileType === 'application/macbinary' && fileName.endsWith('.bin')) // Mac changes the mimetype to this when using browser document upload.


### PR DESCRIPTION
## Summary
Server side validations was breaking thumbnail upload, scene save, and scene publish due to frontend code not setting correct mimetype on File object defaulting the mime to application/octet-stream for all files.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
