### PR TITLE
Remove TransformGizmoTagComponent to prevent interference with heuristic access

### DIFF
--- a/packages/editor/src/classes/gizmo/transform/TransformGizmoControlComponent.ts
+++ b/packages/editor/src/classes/gizmo/transform/TransformGizmoControlComponent.ts
@@ -145,7 +145,7 @@ export const TransformGizmoControlComponent = defineComponent({
       )
 
       setComponent(gizmoPlaneEntity, MeshComponent, gizmoPlane)
-      setComponent(gizmoPlaneEntity, TransformGizmoTagComponent)
+      //setComponent(gizmoPlaneEntity, TransformGizmoTagComponent) we dont want this to be a tagged , as it interferes with heuristic, access via control entity
       ObjectLayerMaskComponent.setLayer(gizmoPlaneEntity, ObjectLayers.TransformGizmo)
 
       const gizmoControlEntity = createEntity()


### PR DESCRIPTION
Eliminate the TransformGizmoTagComponent to avoid conflicts with heuristic 
