### PR TITLE
Remove TransformGizmoTag from gizmoPlane to avoid heuristic interference

### DIFF
--- a/packages/editor/src/classes/gizmo/transform/TransformGizmoControlComponent.ts
+++ b/packages/editor/src/classes/gizmo/transform/TransformGizmoControlComponent.ts
@@ -145,7 +145,7 @@ export const TransformGizmoControlComponent = defineComponent({
       )
 
       setComponent(gizmoPlaneEntity, MeshComponent, gizmoPlane)
-      setComponent(gizmoPlaneEntity, TransformGizmoTagComponent)
+      //setComponent(gizmoPlaneEntity, TransformGizmoTagComponent)
       ObjectLayerMaskComponent.setLayer(gizmoPlaneEntity, ObjectLayers.TransformGizmo)
 
       const gizmoControlEntity = createEntity()


### PR DESCRIPTION
Eliminate the TransformGizmoTag component from the gizmoPlane to prevent conflicts with heuristics.