### PR TITLE
Hoist AssetsQueryProvider

### DIFF
--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -56,6 +56,7 @@ import { useTranslation } from 'react-i18next'
 import { IoHelpCircleOutline } from 'react-icons/io5'
 import { onSaveScene, setCurrentEditorScene } from '../functions/sceneFunctions'
 import { AssetsPanelTab } from '../panels/assets'
+import { AssetsQueryProvider } from '../panels/assets/hooks'
 import { HierarchyPanelTab } from '../panels/hierarchy'
 import { MaterialsPanelTab } from '../panels/materials'
 import { PropertiesPanelTab } from '../panels/properties'
@@ -253,36 +254,42 @@ const EditorContainer = () => {
 
   return (
     <main className="pointer-events-auto">
-      <div id="editor-container" className="flex flex-col" style={scenePath.value ? { background: 'transparent' } : {}}>
-        {uiEnabled.value && (
-          <DndWrapper id="editor-container">
-            <DragLayer />
-            <Toolbar />
-            <div className="mt-1 flex overflow-hidden">
-              <DockContainer>
-                <DockLayout
-                  ref={dockPanelRef}
-                  defaultLayout={defaultLayout({ visualScriptPanelEnabled })}
-                  style={{ position: 'absolute', left: 5, top: 50, right: 5, bottom: 5 }}
-                />
-              </DockContainer>
-            </div>
-          </DndWrapper>
-        )}
-        {Object.entries(editorUIAddon.container.get(NO_PROXY)).map(([key, value]) => {
-          return value
-        })}
-      </div>
-      <PopupMenu />
-      {!isWidgetVisible && initialized && (
-        <div className="absolute bottom-3 right-4">
-          <Tooltip position="left" key={t('editor:help')} content={t('editor:help')}>
-            <Button size="sm" className="h-8 w-8 p-0" onClick={openChat}>
-              <IoHelpCircleOutline fontSize={24} />
-            </Button>
-          </Tooltip>
+      <AssetsQueryProvider>
+        <div
+          id="editor-container"
+          className="flex flex-col"
+          style={scenePath.value ? { background: 'transparent' } : {}}
+        >
+          {uiEnabled.value && (
+            <DndWrapper id="editor-container">
+              <DragLayer />
+              <Toolbar />
+              <div className="mt-1 flex overflow-hidden">
+                <DockContainer>
+                  <DockLayout
+                    ref={dockPanelRef}
+                    defaultLayout={defaultLayout({ visualScriptPanelEnabled })}
+                    style={{ position: 'absolute', left: 5, top: 50, right: 5, bottom: 5 }}
+                  />
+                </DockContainer>
+              </div>
+            </DndWrapper>
+          )}
+          {Object.entries(editorUIAddon.container.get(NO_PROXY)).map(([key, value]) => {
+            return value
+          })}
         </div>
-      )}
+        <PopupMenu />
+        {!isWidgetVisible && initialized && (
+          <div className="absolute bottom-3 right-4">
+            <Tooltip position="left" key={t('editor:help')} content={t('editor:help')}>
+              <Button size="sm" className="h-8 w-8 p-0" onClick={openChat}>
+                <IoHelpCircleOutline fontSize={24} />
+              </Button>
+            </Tooltip>
+          </div>
+        )}
+      </AssetsQueryProvider>
     </main>
   )
 }

--- a/packages/editor/src/components/dialogs/SavePrefabDialog.tsx
+++ b/packages/editor/src/components/dialogs/SavePrefabDialog.tsx
@@ -34,6 +34,7 @@ import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { exportRelativeGLTF } from '../../functions/exportGLTF'
+import { useAssetsQuery } from '../../panels/assets/hooks'
 import { EditorState } from '../../services/EditorServices'
 
 export default function SavePrefabPanel({ entity }) {
@@ -44,10 +45,12 @@ export default function SavePrefabPanel({ entity }) {
   const srcPath = useHookstate(STATIC_ASSET_REGEX.exec(gltfComponent.src)?.[3].replace(/\.[^.]*$/, ''))
   const fileName = (srcPath.value ?? '').split('/').pop() ?? ''
   const resultFileName = useHookstate(isValidFileName(fileName))
+  const { refetchResources } = useAssetsQuery()
 
   const onSavePrefab = async () => {
     const saveName = srcPath.value + '.gltf'
     await exportRelativeGLTF(entity, getState(EditorState).projectName!, saveName, false)
+    refetchResources(true)
     PopoverState.hidePopupover()
   }
 

--- a/packages/editor/src/panels/assets/index.tsx
+++ b/packages/editor/src/panels/assets/index.tsx
@@ -35,7 +35,6 @@ import FileBrowser from '../files/filebrowser'
 import { CurrentFilesQueryProvider } from '../files/helpers'
 import FilesToolbar from '../files/toolbar'
 import CategoriesList, { VerticalDivider } from './categories'
-import { AssetsQueryProvider } from './hooks'
 import Resources from './resources'
 import Topbar from './topbar'
 
@@ -88,13 +87,11 @@ function AssetsContainer() {
   return (
     <div className="flex h-full flex-col">
       <CurrentFilesQueryProvider>
-        <AssetsQueryProvider>
-          {toolbar}
-          <VerticalDivider
-            leftChildren={<CategoriesList selected={sidebarType.value} onClick={handleSidebarChange} />}
-            rightChildren={rightChildren}
-          />
-        </AssetsQueryProvider>
+        {toolbar}
+        <VerticalDivider
+          leftChildren={<CategoriesList selected={sidebarType.value} onClick={handleSidebarChange} />}
+          rightChildren={rightChildren}
+        />
       </CurrentFilesQueryProvider>
     </div>
   )


### PR DESCRIPTION
## Summary
 Because the AssetsQueryProvider was mounted so low in the DOM tree, only the assets panel had reference to it. 
 The SavePrefabDialog is mounted by another part of the DOM tree, and could not call the `refreshResources` method for updating state.
 
 The solution here is to move the AssetsQueryProvider up the DOM tree to a common ancestor between the assets panel and the hierarchy viewer.

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-8558]

## QA Steps


[IR-8558]: https://tsu.atlassian.net/browse/IR-8558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ