### PR TITLE
Remove TransformGizmoTagComponent from gizmo plane heuristic consideration

### DIFF
--- a/packages/editor/src/classes/gizmo/transform/TransformGizmoControlComponent.ts
+++ b/packages/editor/src/classes/gizmo/transform/TransformGizmoControlComponent.ts
@@ -145,7 +145,7 @@ export const TransformGizmoControlComponent = defineComponent({
       )
 
       setComponent(gizmoPlaneEntity, MeshComponent, gizmoPlane)
-      setComponent(gizmoPlaneEntity, TransformGizmoTagComponent)
+      //setComponent(gizmoPlaneEntity, TransformGizmoTagComponent) remove the gizmo plane from being considered in theheuristic , we use TransformGizmoTagComponent query to collect gizmo entities for heuristic
       ObjectLayerMaskComponent.setLayer(gizmoPlaneEntity, ObjectLayers.TransformGizmo)
 
       const gizmoControlEntity = createEntity()


### PR DESCRIPTION
Eliminate the consideration of TransformGizmoTagComponent in the gizmo plane heuristic to streamline entity queries for gizmo entities.