### PR TITLE
Fixed bug with Scene Save As [release1.0.2]

### DIFF
--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -93,7 +93,7 @@ export const saveSceneGLTF = async (
   }
 
   const blob = [new Blob([JSON.stringify(gltfData, null, 2)], { type: 'model/gltf+json' })]
-  const gltfFile = new File(blob, sceneFile, { type: 'model/gltf+json' })
+  const gltfFile = new File(blob, sceneName, { type: 'model/gltf+json' })
 
   const currentScene = await API.instance.service(staticResourcePath).get(sceneAssetID)
 


### PR DESCRIPTION
## Summary

Save As doesn't pass a sceneFile with `.gltf` on the end. This does get properly cleaned and appended in the generation of `sceneName`, but that wasn't being used when generating the new gltfFile - it was still using sceneFile for some reason.

Resolves IRCS-57

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
