### PR TITLE
[HOTFIX 1.0.2] IR-8493: limit follow camera's horizontal rotation range

### DIFF
--- a/packages/spatial/src/camera/components/FollowCameraComponent.test.tsx
+++ b/packages/spatial/src/camera/components/FollowCameraComponent.test.tsx
@@ -1,0 +1,111 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import {
+  createEngine,
+  createEntity,
+  destroyEngine,
+  getComponent,
+  getOptionalComponent,
+  removeEntity,
+  setComponent,
+  UndefinedEntity
+} from '@ir-engine/ecs'
+import assert from 'assert'
+import { afterEach, beforeEach, describe, it } from 'vitest'
+import { mockSpatialEngine } from '../../../tests/util/mockSpatialEngine'
+import { destroySpatialEngine } from '../../initializeEngine'
+import { TransformComponent } from '../../SpatialModule'
+import { FollowCameraComponent } from './FollowCameraComponent'
+
+type FollowCameraComponentData = { minPhi: number; maxPhi: number; minTheta?: number; maxTheta?: number }
+const FollowCameraComponentDefaults = {
+  minTheta: undefined,
+  maxTheta: undefined
+} as FollowCameraComponentData
+
+function assertFollowCameraComponentEqual(A: FollowCameraComponentData, B: FollowCameraComponentData): void {
+  assert.equal(A.minTheta, B.minTheta)
+  assert.equal(A.maxTheta, B.maxTheta)
+}
+function assertFollowCameraComponentNotEqual(A: FollowCameraComponentData, B: FollowCameraComponentData): void {
+  assert.notEqual(A.minTheta, B.minTheta)
+  assert.notEqual(A.maxTheta, B.maxTheta)
+}
+
+describe('FollowCameraComponent', () => {
+  describe('IDs', () => {
+    it('should initialize the FollowCameraComponent.name field with the expected value', () => {
+      assert.equal(FollowCameraComponent.name, 'FollowCameraComponent')
+    })
+  })
+
+  describe('onInit', () => {
+    let testEntity = UndefinedEntity
+
+    beforeEach(async () => {
+      createEngine()
+      testEntity = createEntity()
+      setComponent(testEntity, TransformComponent)
+      setComponent(testEntity, FollowCameraComponent)
+    })
+
+    afterEach(() => {
+      removeEntity(testEntity)
+      return destroyEngine()
+    })
+
+    it('should initialize the component with the expected default values', () => {
+      const data = getComponent(testEntity, FollowCameraComponent)
+      assertFollowCameraComponentEqual(data, FollowCameraComponentDefaults)
+    })
+  })
+
+  describe('onSet', () => {
+    let testEntity = UndefinedEntity
+
+    beforeEach(async () => {
+      createEngine()
+      mockSpatialEngine()
+      testEntity = createEntity()
+      setComponent(testEntity, TransformComponent)
+      setComponent(testEntity, FollowCameraComponent)
+    })
+
+    afterEach(() => {
+      removeEntity(testEntity)
+      destroySpatialEngine()
+      return destroyEngine()
+    })
+
+    it('should change the values of an initialized FollowCameraComponent', () => {
+      const before = getOptionalComponent(testEntity, FollowCameraComponent)
+      assertFollowCameraComponentEqual(before!, FollowCameraComponentDefaults)
+      setComponent(testEntity, FollowCameraComponent, { minTheta: 160, maxTheta: 170 })
+      const after = getComponent(testEntity, FollowCameraComponent)
+      assertFollowCameraComponentNotEqual(after, FollowCameraComponentDefaults)
+    })
+  })
+})

--- a/packages/spatial/src/camera/components/FollowCameraComponent.ts
+++ b/packages/spatial/src/camera/components/FollowCameraComponent.ts
@@ -98,6 +98,8 @@ export const FollowCameraComponent = defineComponent({
     phi: S.Number(10),
     minPhi: S.Number(0),
     maxPhi: S.Number(0),
+    minTheta: S.Optional(S.Number()),
+    maxTheta: S.Optional(S.Number()),
     locked: S.Bool(false),
     enabled: S.Bool(true),
     shoulderSide: S.Enum(FollowCameraShoulderSide, FollowCameraShoulderSide.Left),
@@ -414,6 +416,10 @@ const updateCameraTargetRotation = (cameraEntity: Entity) => {
   const epsilon = 0.001
 
   target.phi = Math.min(followCamera.maxPhi, Math.max(followCamera.minPhi, target.phi))
+
+  if (followCamera.maxTheta && followCamera.minTheta) {
+    target.theta = Math.min(followCamera.maxTheta, Math.max(followCamera.minTheta, target.theta))
+  }
 
   if (Math.abs(target.phi - followCamera.phi) < epsilon && Math.abs(target.theta - followCamera.theta) < epsilon) {
     removeComponent(followCamera.targetEntity, TargetCameraRotationComponent)


### PR DESCRIPTION
## Summary
Limit camera rotation range 
![Screen Recording 2025-04-02 at 12 56 43 p m](https://github.com/user-attachments/assets/aee12075-13da-4b28-aa66-0db559b88fb7)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
