### PR TITLE
fix(IR-8529): avoiding refreshing constantly when thumbnails are being generated

### DIFF
--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -71,7 +71,11 @@ export function Browser() {
   }
 
   useEffect(() => {
-    refreshDirectory()
+    const timeoutId = setTimeout(() => {
+      refreshDirectory()
+    }, 3500) // Debounce refresh to prevent rapid re-renders
+
+    return () => clearTimeout(timeoutId)
   }, [thumbnailJobState.jobs.length])
 
   const staticResourceDataQuery = useFind(staticResourcePath, {

--- a/packages/editor/src/panels/files/loaders.tsx
+++ b/packages/editor/src/panels/files/loaders.tsx
@@ -118,7 +118,7 @@ export function ProjectDownloadProgress() {
   return (
     <>
       {isDownloading && (
-        <div className="flex h-auto w-full justify-center pb-2 pt-2">
+        <div className="flex h-auto w-full justify-center pb-1 pt-1">
           <div className="flex w-1/2">
             <span className="inline-block pr-2 text-xs font-normal leading-none ">
               {t('editor:layout.filebrowser.downloadingProject', { completed, total })}
@@ -146,7 +146,7 @@ export function FileUploadProgress() {
   const { completed, total, progress } = useUploadingFiles()
 
   return total ? (
-    <div className="flex h-auto w-full justify-center pb-2 pt-2">
+    <div className="flex h-auto w-full justify-center pb-1 pt-1">
       <div className="flex w-1/2">
         <span className="inline-block pr-2 text-xs font-normal leading-none ">
           {t('editor:layout.filebrowser.uploadingFiles', { completed, total })}
@@ -181,17 +181,22 @@ function FilesLoading() {
   const isLoading = filesQuery?.status === 'pending'
 
   return isLoading ? (
-    <LoadingView title={t('editor:layout.filebrowser.loadingFiles')} fullSpace className="block h-12 w-12" />
+    <LoadingView
+      title={t('editor:layout.filebrowser.loadingFiles')}
+      titleClassname="mt-0"
+      containerClassName="flex-row mt-1"
+      className="mx-2 my-auto h-6 w-6"
+    />
   ) : null
 }
 
 export default function Loaders() {
   return (
-    <>
+    <div className="flex h-[60px] flex-col py-1">
       <FileUploadProgress />
       <ProjectDownloadProgress />
       <FilesLoading />
       <GeneratingThumbnailsProgress />
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
fix(IR-8529): avoiding refreshing constantly meanwhitle thumbnails are being generated
also prevent ui shifting on file browser loaders and improve ux

## Summary


https://github.com/user-attachments/assets/8223a8d6-4d63-43c2-9772-b372f6c68a73



## Subtasks Checklist


## Breaking Changes

## References
related to Jira ticket [IR-8529](https://tsu.atlassian.net/issues/IR-8529?filter=-1)

## QA Steps


[IR-8529]: https://tsu.atlassian.net/browse/IR-8529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ