### PR TITLE
[HOTFIX 1.0.2] IR-8778: add transform component to media node

### DIFF
--- a/packages/editor/src/panels/files/contextmenu.tsx
+++ b/packages/editor/src/panels/files/contextmenu.tsx
@@ -216,10 +216,13 @@ export function FileContextMenu({
       condition: hasFiles,
       label: t('editor:layout.assetGrid.placeObjectAtOrigin'),
       action: () => {
+        const position = getSpawnPositionAtCenter(new Vector3())
         selectedFiles
           .filter((file) => !file.isFolder.value)
           .map((file) => {
-            addMediaNode(file.url.value)
+            addMediaNode(file.url.value, undefined, undefined, [
+              { name: TransformComponent.jsonID, props: { position } }
+            ])
           })
         setAnchorEvent(undefined)
       },


### PR DESCRIPTION
## Summary

Add missing transform component to media node 

![Screen Recording 2025-04-03 at 12 20 25 p m](https://github.com/user-attachments/assets/d68c30f7-64ba-4513-99f0-bb74b5fcc7e4)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
