### PR TITLE
[HOTFIX 1.0.2] IR-8411: Show notification when new window fails to open

### DIFF
--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -10,7 +10,8 @@
     "changesLostAlert": "If you proceed all your changes will be lost.",
     "discard": "Discard",
     "userBannedMessage": "You have been banned from joining this space.",
-    "userBannedMessageDescription": "If you feel like this is an error, please contact customer support."
+    "userBannedMessageDescription": "If you feel like this is an error, please contact customer support.",
+    "windowBlocked": "Your browser may have blocked the new tab. Check settings."
   },
   "auth": {
     "confirmEmail": {

--- a/packages/client-core/src/systems/LinkErrorSystem.test.tsx
+++ b/packages/client-core/src/systems/LinkErrorSystem.test.tsx
@@ -1,0 +1,103 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  Entity,
+  SystemDefinitions,
+  UndefinedEntity,
+  createEntity,
+  destroyEngine,
+  getOptionalComponent,
+  removeEntity,
+  setComponent
+} from '@ir-engine/ecs'
+import { createEngine } from '@ir-engine/ecs/src/Engine'
+import '@ir-engine/engine'
+import '@ir-engine/engine/src/avatar/state/AvatarNetworkState'
+import { ErrorComponent } from '@ir-engine/engine/src/scene/components/ErrorComponent'
+import { LinkComponent } from '@ir-engine/engine/src/scene/components/LinkComponent'
+import { addError } from '@ir-engine/engine/src/scene/functions/ErrorFunctions'
+import { startReactor } from '@ir-engine/hyperflux'
+import { NotificationService } from '../common/services/NotificationService'
+import { LinkErrorSystem } from './LinkErrorSystem'
+
+const system = SystemDefinitions.get(LinkErrorSystem)!
+
+describe('LinkErrorSystem', () => {
+  let linkEntity: Entity = UndefinedEntity
+
+  beforeAll(() => {
+    vi.mock('react-i18next', () => ({
+      useTranslation: () => {
+        return {
+          t: (i18nKey) => i18nKey
+        }
+      }
+    }))
+  })
+
+  beforeEach(() => {
+    createEngine()
+    linkEntity = createEntity()
+    setComponent(linkEntity, LinkComponent)
+  })
+
+  afterEach(() => {
+    removeEntity(linkEntity)
+    return destroyEngine()
+  })
+
+  it('should display error notification and remove error component', async () => {
+    const spy = vi.spyOn(NotificationService, 'dispatchNotify').mockImplementation(() => undefined)
+
+    addError(linkEntity, LinkComponent, 'WINDOW_BLOCKED', 'Unable to open link in new tab.')
+    const errorComponentBefore = getOptionalComponent(linkEntity, ErrorComponent)
+    expect(errorComponentBefore).toBeDefined()
+    expect(errorComponentBefore).toHaveProperty(LinkComponent.name)
+
+    startReactor(system.reactor!)
+    expect(spy).toHaveBeenCalled()
+
+    const errorComponentAfter = getOptionalComponent(linkEntity, ErrorComponent)
+    expect(errorComponentAfter).toBeUndefined()
+  })
+
+  it('should not display error notification', async () => {
+    const spy = vi.spyOn(NotificationService, 'dispatchNotify').mockImplementation(() => undefined)
+
+    addError(linkEntity, LinkComponent, 'INVALID_URL', 'Please enter a valid URL.')
+    const errorComponentBefore = getOptionalComponent(linkEntity, ErrorComponent)
+    expect(errorComponentBefore).toBeDefined()
+    expect(errorComponentBefore).toHaveProperty(LinkComponent.name)
+
+    startReactor(system.reactor!)
+    expect(spy).not.toHaveBeenCalled()
+
+    const errorComponentAfter = getOptionalComponent(linkEntity, ErrorComponent)
+    expect(errorComponentAfter).toBeDefined()
+  })
+})

--- a/packages/client-core/src/systems/LinkErrorSystem.tsx
+++ b/packages/client-core/src/systems/LinkErrorSystem.tsx
@@ -1,0 +1,32 @@
+import { defineSystem, useEntityContext, useOptionalComponent } from '@ir-engine/ecs'
+import { QueryReactor } from '@ir-engine/ecs/src/QueryFunctions'
+import { ErrorComponent } from '@ir-engine/engine/src/scene/components/ErrorComponent'
+import { LinkComponent } from '@ir-engine/engine/src/scene/components/LinkComponent'
+import { removeError } from '@ir-engine/engine/src/scene/functions/ErrorFunctions'
+import React, { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { NotificationService } from '../common/services/NotificationService'
+
+const LINK_ERROR_TYPE = 'WINDOW_BLOCKED'
+
+const LinkErrorReactor = () => {
+  const entity = useEntityContext()
+  const errorComponent = useOptionalComponent(entity, ErrorComponent)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    const linkErrors = errorComponent?.[LinkComponent.name].value
+    if (linkErrors?.[LINK_ERROR_TYPE]) {
+      NotificationService.dispatchNotify(t('user:common.windowBlocked'), { variant: 'error' })
+      removeError(entity, LinkComponent, LINK_ERROR_TYPE)
+    }
+  }, [errorComponent?.[LinkComponent.name].value])
+
+  return null
+}
+
+export const LinkErrorSystem = defineSystem({
+  uuid: 'ee.client.LinkErrorSystem',
+  insert: {},
+  reactor: () => <QueryReactor Components={[ErrorComponent, LinkComponent]} ChildEntityReactor={LinkErrorReactor} />
+})

--- a/packages/client-core/src/systems/LinkErrorSystem.tsx
+++ b/packages/client-core/src/systems/LinkErrorSystem.tsx
@@ -23,11 +23,12 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { defineSystem, useEntityContext, useOptionalComponent } from '@ir-engine/ecs'
+import { defineSystem, useComponent, useEntityContext } from '@ir-engine/ecs'
 import { QueryReactor } from '@ir-engine/ecs/src/QueryFunctions'
 import { ErrorComponent } from '@ir-engine/engine/src/scene/components/ErrorComponent'
 import { LinkComponent } from '@ir-engine/engine/src/scene/components/LinkComponent'
 import { removeError } from '@ir-engine/engine/src/scene/functions/ErrorFunctions'
+import { TransformDirtyUpdateSystem } from '@ir-engine/spatial/src/transform/systems/TransformSystem'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NotificationService } from '../common/services/NotificationService'
@@ -36,7 +37,7 @@ const LINK_ERROR_TYPE = 'WINDOW_BLOCKED'
 
 const LinkErrorReactor = () => {
   const entity = useEntityContext()
-  const errorComponent = useOptionalComponent(entity, ErrorComponent)
+  const errorComponent = useComponent(entity, ErrorComponent)
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -45,13 +46,13 @@ const LinkErrorReactor = () => {
       NotificationService.dispatchNotify(t('user:common.windowBlocked'), { variant: 'error' })
       removeError(entity, LinkComponent, LINK_ERROR_TYPE)
     }
-  }, [errorComponent?.[LinkComponent.name].value])
+  }, [errorComponent?.value])
 
   return null
 }
 
 export const LinkErrorSystem = defineSystem({
   uuid: 'ee.client.LinkErrorSystem',
-  insert: {},
+  insert: { before: TransformDirtyUpdateSystem },
   reactor: () => <QueryReactor Components={[ErrorComponent, LinkComponent]} ChildEntityReactor={LinkErrorReactor} />
 })

--- a/packages/client-core/src/systems/LinkErrorSystem.tsx
+++ b/packages/client-core/src/systems/LinkErrorSystem.tsx
@@ -1,3 +1,28 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
 import { defineSystem, useEntityContext, useOptionalComponent } from '@ir-engine/ecs'
 import { QueryReactor } from '@ir-engine/ecs/src/QueryFunctions'
 import { ErrorComponent } from '@ir-engine/engine/src/scene/components/ErrorComponent'

--- a/packages/client-core/src/world/ClientModule.ts
+++ b/packages/client-core/src/world/ClientModule.ts
@@ -28,6 +28,7 @@ import { WidgetAppServiceReceptorSystem } from '../systems/WidgetAppService'
 import { OverlaySystem } from '@ir-engine/client-core/src/systems/OverlaySystem'
 import { AvatarSpawnSystem } from '../networking/AvatarSpawnSystem'
 import { AvatarUISystem } from '../systems/AvatarUISystem'
+import { LinkErrorSystem } from '../systems/LinkErrorSystem'
 import { LoadingUISystem } from '../systems/LoadingUISystem'
 import { MediaControlSystem } from '../systems/MediaControlSystem'
 import { PositionalAudioSystem } from '../systems/PositionalAudioSystem'
@@ -42,6 +43,7 @@ import './ClientNetworkModule'
 export {
   AvatarSpawnSystem,
   AvatarUISystem,
+  LinkErrorSystem,
   LinkRedirectSystem,
   LoadingUISystem,
   MediaControlSystem,

--- a/packages/engine/src/scene/components/LinkComponent.ts
+++ b/packages/engine/src/scene/components/LinkComponent.ts
@@ -35,6 +35,7 @@ import { XRState } from '@ir-engine/spatial/src/xr/XRState'
 
 import { EngineState } from '@ir-engine/ecs'
 import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
+import { isMobile, isSafari } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { InputComponent } from '@ir-engine/spatial/src/input/components/InputComponent'
 import { addError, clearErrors } from '../functions/ErrorFunctions'
 
@@ -48,9 +49,15 @@ const linkLogic = (linkEntity: Entity, xrState) => {
   //   getMutableState(LinkState).location.set(linkComponent.location)
   // }
   xrState && xrState.session?.end()
-  typeof window === 'object' && window && linkComponent.newTab
-    ? window.open(linkComponent.url, '_blank')
-    : (window.location.href = linkComponent.url)
+  if (typeof window === 'object' && window && linkComponent.newTab) {
+    const windoOpen = window.open(linkComponent.url, '_blank')
+    //this error added when safari blocks new window
+    if (!windoOpen && isMobile && isSafari) {
+      addError(linkEntity, LinkComponent, 'WINDOW_BLOCKED', 'Unable to open link in new tab.')
+    }
+  } else {
+    window.location.href = linkComponent.url
+  }
 }
 const linkCallback = (linkEntity: Entity) => {
   console.log('linkCallback')


### PR DESCRIPTION
## Summary

Interactive components that open new windows such as link component might fail in mobile 
devices if the browser setting 'Block Pop-ups' is enabled. With this change user will see an error 
notification when they interact with a link component and it fails to open a window. 

![notification](https://github.com/user-attachments/assets/061baf01-10f0-45bd-b877-a17c7a1d6dc0)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Create a scene with a link component and publish it 
- Access the scene using an IOS device in safari 
- Interact with the link component 

**Expected result:** a toast notification is shown if the window fails to open
