### PR TITLE
IR-8335 close profile menu hotfix 1.0.2

### DIFF
--- a/packages/client-core/src/user/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/menus/ProfileMenu.tsx
@@ -71,7 +71,8 @@ import {
   ReportWebsiteDefaullg,
   Send01Lg,
   Trash04Lg,
-  TwitterOriginalFalse
+  TwitterOriginalFalse,
+  XCloseMd
 } from '@ir-engine/ui/src/icons'
 import AvatarImage from '@ir-engine/ui/src/primitives/tailwind/AvatarImage'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
@@ -433,17 +434,30 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
         </div>
 
         <div className="col-span-2 grid grid-cols-[auto_136px] gap-x-6 lg:grid-cols-[auto_auto]">
-          <button
-            className={twMerge(
-              'flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full bg-ui-secondary p-2 text-text-primary-button hover:bg-ui-hover-secondary focus:bg-ui-select-secondary',
-              initialized ? 'justify-self-end' : 'col-start-3'
-            )}
-            onClick={() => {
-              PopoverState.showPopupover(<SettingsMenu />)
-            }}
-          >
-            <CogLg className="h-[1.875rem] w-[1.875rem]" />
-          </button>
+          <div className="col-start-2 flex items-end gap-x-2 justify-self-end">
+            <button
+              className={twMerge(
+                'flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full bg-ui-secondary p-2 text-text-primary-button hover:bg-ui-hover-secondary focus:bg-ui-select-secondary',
+                initialized ? 'justify-self-end' : 'col-start-3'
+              )}
+              onClick={() => {
+                PopoverState.showPopupover(<SettingsMenu />)
+              }}
+            >
+              <CogLg className="h-[1.875rem] w-[1.875rem]" />
+            </button>
+            <button
+              className={twMerge(
+                'flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full bg-ui-secondary p-2 text-text-primary-button hover:bg-ui-hover-secondary focus:bg-ui-select-secondary',
+                initialized ? 'justify-self-end' : 'col-start-3'
+              )}
+              onClick={() => {
+                PopoverState.hidePopupover()
+              }}
+            >
+              <XCloseMd className="h-[1.2rem] w-[1.2rem]" />
+            </button>
+          </div>
 
           {initialized && (
             <div className="flex w-full flex-col items-end gap-y-4">

--- a/packages/client-core/src/user/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/menus/ProfileMenu.tsx
@@ -387,6 +387,18 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
 
   return (
     <div className="absolute z-50 h-fit max-h-[90dvh] w-[50vw] min-w-[720px] max-w-2xl overflow-y-auto rounded-2xl bg-surface-4 p-6 smh:max-h-[60dvh] smh:px-8 smh:py-6">
+      <div className="items-end">
+        <button
+          className={twMerge(
+            'text-text-secondary-button flex h-[2rem] w-[2rem] items-center justify-center justify-self-end rounded-full hover:bg-ui-hover-primary hover:text-text-primary-button focus:bg-ui-select-primary'
+          )}
+          onClick={() => {
+            PopoverState.hidePopupover()
+          }}
+        >
+          <XCloseMd className="h-[1.5rem] w-[1.5rem]" />
+        </button>
+      </div>
       <div className="relative grid w-full grid-cols-5 gap-x-2">
         <div className="col-span-3 grid grid-cols-[auto,1fr] gap-x-6">
           <div className="relative h-20 w-20">
@@ -434,31 +446,17 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
         </div>
 
         <div className="col-span-2 grid grid-cols-[auto_136px] gap-x-6 lg:grid-cols-[auto_auto]">
-          <div className="col-start-2 flex items-end gap-x-2 justify-self-end">
-            <button
-              className={twMerge(
-                'flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full bg-ui-secondary p-2 text-text-primary-button hover:bg-ui-hover-secondary focus:bg-ui-select-secondary',
-                initialized ? 'justify-self-end' : 'col-start-3'
-              )}
-              onClick={() => {
-                PopoverState.showPopupover(<SettingsMenu />)
-              }}
-            >
-              <CogLg className="h-[1.875rem] w-[1.875rem]" />
-            </button>
-            <button
-              className={twMerge(
-                'flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full bg-ui-secondary p-2 text-text-primary-button hover:bg-ui-hover-secondary focus:bg-ui-select-secondary',
-                initialized ? 'justify-self-end' : 'col-start-3'
-              )}
-              onClick={() => {
-                PopoverState.hidePopupover()
-              }}
-            >
-              <XCloseMd className="h-[1.2rem] w-[1.2rem]" />
-            </button>
-          </div>
-
+          <button
+            className={twMerge(
+              'flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full bg-ui-secondary p-2 text-text-primary-button hover:bg-ui-hover-secondary focus:bg-ui-select-secondary',
+              initialized ? 'justify-self-end' : 'col-start-3'
+            )}
+            onClick={() => {
+              PopoverState.showPopupover(<SettingsMenu />)
+            }}
+          >
+            <CogLg className="h-[1.875rem] w-[1.875rem]" />
+          </button>
           {initialized && (
             <div className="flex w-full flex-col items-end gap-y-4">
               <Button variant="secondary" className="w-[136px] rounded-[10px] lg:w-full" onClick={openChat}>


### PR DESCRIPTION
## Summary
Adding a close button to the profile menu so that mobile users can't get stuck when the menu is fullscreen (old method to close was clicking outside the menu)

## References
[https://tsu.atlassian.net/browse/IR-8335](https://tsu.atlassian.net/browse/IR-8335)

## QA Steps
go to location, click profile button:
![image](https://github.com/user-attachments/assets/03803463-d8c7-4253-be77-fe9658e32e49)
observe/use the close button in the top right
![image](https://github.com/user-attachments/assets/1e310285-c2f1-4729-a3f8-768bba19e9ef)
