### PR TITLE
[HOTFIX 1.0.2] IR-7895: filter out invalid target options for interactable component

### DIFF
--- a/packages/ui/src/components/editor/properties/interact/index.tsx
+++ b/packages/ui/src/components/editor/properties/interact/index.tsx
@@ -73,7 +73,7 @@ export const InteractableComponentNodeEditor: EditorComponentType = (props) => {
   const targets = useHookstate<OptionsType>([
     { label: 'Self', value: getComponent(props.entity, NodeIDComponent), callbacks: [] }
   ])
-  const callbackQuery = useQuery([CallbackComponent])
+  const callbackQuery = useQuery([CallbackComponent, NodeIDComponent], Layers.Authoring)
 
   const interactableComponent = useComponent(props.entity, InteractableComponent)
 

--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -426,53 +426,55 @@ const Select = ({
       >
         {filteredOptions.length > 0 &&
           !disabled &&
-          filteredOptions.map(({ value: currentValue, ...optionProps }, index) => (
-            <DropdownItem
-              key={index}
-              {...optionProps}
-              selected={localValue.value === currentValue}
-              active={index === activeIndex}
-              onMouseDown={(e) => {
-                e.stopPropagation()
-                e.preventDefault()
-                closePopup()
-                localValue.set(currentValue)
-                setSelectedOptionIndex(index)
-                setDisplayText(optionProps.label)
-                onChange(currentValue)
-              }}
-              onMouseEnter={() => {
-                setActiveIndex(index)
-              }}
-              onMouseLeave={() => {
-                setActiveIndex(-1)
-              }}
-              onTouchMove={() => setTouchedMoved(true)}
-              onTouchEnd={() => {
-                if (!touchMoved) {
+          filteredOptions
+            .filter((option) => Boolean(option))
+            .map(({ value: currentValue, ...optionProps }, index) => (
+              <DropdownItem
+                key={index}
+                {...optionProps}
+                selected={localValue.value === currentValue}
+                active={index === activeIndex}
+                onMouseDown={(e) => {
+                  e.stopPropagation()
+                  e.preventDefault()
                   closePopup()
                   localValue.set(currentValue)
                   setSelectedOptionIndex(index)
                   setDisplayText(optionProps.label)
                   onChange(currentValue)
-                }
-                setTouchedMoved(false)
-              }}
-              onPointerUp={(e) => {
-                e.stopPropagation()
-                e.preventDefault()
-              }}
-              onKeyUp={(e) => {
-                if (e.code === 'Enter') {
-                  closePopup()
-                  localValue.set(currentValue)
-                  setSelectedOptionIndex(index)
-                  setDisplayText(optionProps.label)
-                  onChange(currentValue)
-                }
-              }}
-            />
-          ))}
+                }}
+                onMouseEnter={() => {
+                  setActiveIndex(index)
+                }}
+                onMouseLeave={() => {
+                  setActiveIndex(-1)
+                }}
+                onTouchMove={() => setTouchedMoved(true)}
+                onTouchEnd={() => {
+                  if (!touchMoved) {
+                    closePopup()
+                    localValue.set(currentValue)
+                    setSelectedOptionIndex(index)
+                    setDisplayText(optionProps.label)
+                    onChange(currentValue)
+                  }
+                  setTouchedMoved(false)
+                }}
+                onPointerUp={(e) => {
+                  e.stopPropagation()
+                  e.preventDefault()
+                }}
+                onKeyUp={(e) => {
+                  if (e.code === 'Enter') {
+                    closePopup()
+                    localValue.set(currentValue)
+                    setSelectedOptionIndex(index)
+                    setDisplayText(optionProps.label)
+                    onChange(currentValue)
+                  }
+                }}
+              />
+            ))}
 
         {filteredOptions.length === 0 && !disabled && (
           <div className="flex h-12 items-center justify-center bg-ui-background text-text-secondary">


### PR DESCRIPTION
## Summary

Interactable component breaks due to some entities without `NodeIDComponent` being listed as target options

- Updated query to get entities with `CallbackComponent` and `NodeIDComponent`
- Filter out options with invalid properties in Select Component

[IR-7895
](https://tsu.atlassian.net/browse/IR-7895)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Open a scene in the editor 
- Add a primitive geometry to the scene 
- Add an interactable component 
- Save changes 
- Select the entity and go properties, scroll down all the way to the interactable component 
- Enter preview mode 

**Expected result:** Interactable component should not break when entering preview mode 