### PR TITLE
Video visible / invisible callbacks missing

### DIFF
--- a/packages/engine/src/scene/components/VideoComponent.tsx
+++ b/packages/engine/src/scene/components/VideoComponent.tsx
@@ -31,7 +31,6 @@ import {
   LinearFilter,
   Mesh,
   MirroredRepeatWrapping,
-  Object3D,
   PlaneGeometry,
   RepeatWrapping,
   ShaderMaterial,
@@ -257,7 +256,8 @@ function VideoReactor() {
     )
     const authEntity = getAuthoringCounterpart(entity)
     if (authEntity !== UndefinedEntity) {
-      setComponent(authEntity, ObjectComponent, new Object3D())
+      const mesh = getComponent(videoMeshEntity, MeshComponent)
+      setComponent(authEntity, ObjectComponent, mesh)
     }
     return videoMeshEntity
   }).value

--- a/packages/engine/src/scene/components/VideoComponent.tsx
+++ b/packages/engine/src/scene/components/VideoComponent.tsx
@@ -44,7 +44,6 @@ import {
 import { createEntity, EntityTreeComponent, removeEntity, useEntityContext } from '@ir-engine/ecs'
 import {
   defineComponent,
-  getAuthoringCounterpart,
   getComponent,
   getOptionalComponent,
   removeComponent,
@@ -53,7 +52,7 @@ import {
   useHasComponent,
   useOptionalComponent
 } from '@ir-engine/ecs/src/ComponentFunctions'
-import { Entity, UndefinedEntity } from '@ir-engine/ecs/src/Entity'
+import { Entity } from '@ir-engine/ecs/src/Entity'
 import { defineState, NO_PROXY, State, useHookstate, useState } from '@ir-engine/hyperflux'
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { createPriorityQueue } from '@ir-engine/spatial/src/common/functions/PriorityQueue'
@@ -65,9 +64,9 @@ import { isMobileXRHeadset } from '@ir-engine/spatial/src/xr/XRState'
 
 import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
 import { TransformComponent } from '@ir-engine/spatial'
+import { setCallback } from '@ir-engine/spatial/src/common/CallbackComponent'
 import { Vector2_One } from '@ir-engine/spatial/src/common/constants/MathConstants'
 import { HighlightComponent } from '@ir-engine/spatial/src/renderer/components/HighlightComponent'
-import { ObjectComponent } from '@ir-engine/spatial/src/renderer/components/ObjectComponent'
 import { T } from '@ir-engine/spatial/src/schema/schemaFunctions'
 import { NodeFunctions } from '../../gltf/NodeFunctions'
 import { NodeID, NodeIDSchema } from '../../gltf/NodeIDComponent'
@@ -254,11 +253,6 @@ function VideoReactor() {
         })
       )
     )
-    const authEntity = getAuthoringCounterpart(entity)
-    if (authEntity !== UndefinedEntity) {
-      const mesh = getComponent(videoMeshEntity, MeshComponent)
-      setComponent(authEntity, ObjectComponent, mesh)
-    }
     return videoMeshEntity
   }).value
 
@@ -281,6 +275,10 @@ function VideoReactor() {
     setComponent(videoEntity, EntityTreeComponent, { parentEntity: entity })
     setComponent(videoEntity, NameComponent, `video-group-${entity}`)
     setComponent(videoEntity, MediaComponent)
+
+    setCallback(entity, 'setVisible', () => setComponent(videoEntity, VisibleComponent))
+    setCallback(entity, 'setInvisible', () => removeComponent(videoEntity, VisibleComponent))
+
     video.mediaUUID.set('' as NodeID)
 
     return () => {

--- a/packages/engine/src/scene/components/VideoComponent.tsx
+++ b/packages/engine/src/scene/components/VideoComponent.tsx
@@ -31,6 +31,7 @@ import {
   LinearFilter,
   Mesh,
   MirroredRepeatWrapping,
+  Object3D,
   PlaneGeometry,
   RepeatWrapping,
   ShaderMaterial,
@@ -44,6 +45,7 @@ import {
 import { createEntity, EntityTreeComponent, removeEntity, useEntityContext } from '@ir-engine/ecs'
 import {
   defineComponent,
+  getAuthoringCounterpart,
   getComponent,
   getOptionalComponent,
   removeComponent,
@@ -52,7 +54,7 @@ import {
   useHasComponent,
   useOptionalComponent
 } from '@ir-engine/ecs/src/ComponentFunctions'
-import { Entity } from '@ir-engine/ecs/src/Entity'
+import { Entity, UndefinedEntity } from '@ir-engine/ecs/src/Entity'
 import { defineState, NO_PROXY, State, useHookstate, useState } from '@ir-engine/hyperflux'
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { createPriorityQueue } from '@ir-engine/spatial/src/common/functions/PriorityQueue'
@@ -66,6 +68,7 @@ import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
 import { TransformComponent } from '@ir-engine/spatial'
 import { Vector2_One } from '@ir-engine/spatial/src/common/constants/MathConstants'
 import { HighlightComponent } from '@ir-engine/spatial/src/renderer/components/HighlightComponent'
+import { ObjectComponent } from '@ir-engine/spatial/src/renderer/components/ObjectComponent'
 import { T } from '@ir-engine/spatial/src/schema/schemaFunctions'
 import { NodeFunctions } from '../../gltf/NodeFunctions'
 import { NodeID, NodeIDSchema } from '../../gltf/NodeIDComponent'
@@ -252,6 +255,10 @@ function VideoReactor() {
         })
       )
     )
+    const authEntity = getAuthoringCounterpart(entity)
+    if (authEntity !== UndefinedEntity) {
+      setComponent(authEntity, ObjectComponent, new Object3D())
+    }
     return videoMeshEntity
   }).value
 

--- a/packages/ui/src/components/editor/properties/interact/index.tsx
+++ b/packages/ui/src/components/editor/properties/interact/index.tsx
@@ -202,6 +202,7 @@ export const InteractableComponentNodeEditor: EditorComponentType = (props) => {
       <div id={`callback-list`}>
         {interactableComponent.callbacks.map((callback, index) => {
           const targetOption = targets.value.find((o) => o.value === callback.target.value)
+          if (!targetOption) return null
           const target = targetOption ? targetOption.value : 'Self'
           return (
             <div key={'callback' + index} className="space-y-2">
@@ -210,7 +211,7 @@ export const InteractableComponentNodeEditor: EditorComponentType = (props) => {
                   key={props.entity}
                   value={callback.target.value ?? 'Self'}
                   onChange={commitProperty(InteractableComponent, `callbacks.${index}.target` as any)}
-                  options={targets.value as OptionsType}
+                  options={targets.value.filter((o) => o.value !== undefined) as OptionsType}
                   disabled={props.multiEdit}
                 />
               </InputGroup>


### PR DESCRIPTION


## Summary
https://tsu.atlassian.net/browse/IR-8906

The setVisible / setInvisible callbacks are missing because, are missing because there is no ObjectComponent on the video’s Entity. 
The  ObjectComponent is needed to access the  setVisible / setInvisible callbacks

set the ObjectComponent on the auth layer when creating the mesh for a video, so its setVisible, setInvisible callbacks will be accessible for triggers

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
