### PR TITLE
IR-8500 HOTFIX 1.0.2 input stuck when losing focus

### DIFF
--- a/packages/spatial/src/input/systems/ClientInputSystem.tsx
+++ b/packages/spatial/src/input/systems/ClientInputSystem.tsx
@@ -135,8 +135,12 @@ const reactor = () => {
   if (!isClient) return null
 
   useEffect(() => {
+    document.addEventListener('visibilitychange', cleanupInputs)
     InputHeuristicState.addHeuristic(-1, meshHeuristic)
     InputHeuristicState.addHeuristic(0, boundingBoxHeuristic)
+    return () => {
+      document.removeEventListener('visibilitychange', cleanupInputs)
+    }
   }, [])
 
   ClientInputHooks.useNonSpatialInputSources()


### PR DESCRIPTION
## Summary
adding a listener that will clear inputs when the tab loses focus (preventing keys getting stuck as active when losing focus)

## References
[https://tsu.atlassian.net/browse/IR-8500](https://tsu.atlassian.net/browse/IR-8500)

## QA Steps
Create a scene with the following elements:

a Collider (box) with an attached Trigger component

an Empty object with an attached Link component

Link component has 'New Tab' enabled, and a URL entered (I used [Google](http://google.com/) )

Trigger component has Empty object in 'Target Object', and the 'linkCallback' action enabled on 'On Enter'

With the above setup, perform the following steps:

Enable 'Toggle Helpers' to see the collider created above

Enter Preview mode

Using Left click hold + WASD, move the avatar around the scene

Moving the avatar into the collider created above, browser should open a new tab and switch to it

Returning to the studio tab you should see the avatar no longer moving
