### PR TITLE
IR-8398 filetype errors hotfix 1.0.2

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -77,7 +77,12 @@
     "CORS": "Possibly a CORS error",
     "urlFetchError": "Failed to fetch \"{{url}}\"",
     "invalidSceneName": "Scene name must be 4-64 characters long, using only alphanumeric characters, underscores, hyphens, and periods, and begin and end with an alphanumeric.",
-    "maxUploadFileSizeExceed": "That file size is too large. Please upload a file under {{maxFileSizeToUploadMB}}MB. The following files are too large: {{filesNames}}"
+    "maxUploadFileSizeExceed": "That file size is too large. Please upload a file under {{maxFileSizeToUploadMB}}MB. The following files are too large: {{filesNames}}",
+    "unsupported-3D-file": "Please upload either a .gltf or a .glb.",
+    "unsupported-image-file": "Please upload a .png, .jpg, .jpeg, or .ktx2.",
+    "unsupported-audio-file": "Please upload a .mp3, .mpeg, .m4a, or .wav.",
+    "unsupported-video-file": "Please upload a .mp4, .mkv, or .avi.",
+    "unsupported-unknown-file": "Please upload a valid 3D, Image, Audio, or Video file."
   },
   "warnings": {
     "sceneComplexity": "Scene complexity is {{sceneComplexity}}. Consider optimizing your scene for better performance."

--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -59,16 +59,16 @@ enum FileType {
 }
 
 const unsupportedFileMessage = {
-  [FileType.THREE_D]: 'Please upload either a .gltf or a .glb.',
-  [FileType.IMAGE]: 'Please upload a .png, .tiff, .jpg, .jpeg, .gif, or .ktx2.',
-  [FileType.AUDIO]: 'Please upload a .mp3, .mpeg, .m4a, or .wav.',
-  [FileType.VIDEO]: 'Please upload a .mp4, .mkv, or .avi.',
-  [FileType.UNKNOWN]: 'Please upload a valid 3D, Image, Audio, or Video file.'
+  [FileType.THREE_D]: 'editor:errors.unsupported-3D-file',
+  [FileType.IMAGE]: 'editor:errors.unsupported-image-file',
+  [FileType.AUDIO]: 'editor:errors.unsupported-audio-file',
+  [FileType.VIDEO]: 'editor:errors.unsupported-video-file',
+  [FileType.UNKNOWN]: 'editor:errors.unsupported-unknown-file'
 }
 
 const supportedFiles = {
   [FileType.THREE_D]: new Set(['.gltf', '.glb', '.bin']),
-  [FileType.IMAGE]: new Set(['.png', '.tiff', '.jpg', '.jpeg', '.gif', '.ktx2']),
+  [FileType.IMAGE]: new Set(['.png', '.jpg', '.jpeg', '.ktx2']),
   [FileType.AUDIO]: new Set(['.mp3', '.mpeg', '.m4a', '.wav']),
   [FileType.VIDEO]: new Set(['.mp4', '.mkv', '.avi'])
 }
@@ -103,7 +103,7 @@ function isValidFileType(file): { isValid: boolean; errorMessage?: string } {
 
   return {
     isValid: false,
-    errorMessage: unsupportedFileMessage[mimeType]
+    errorMessage: i18n.t(unsupportedFileMessage[mimeType])
   }
 }
 


### PR DESCRIPTION
## Summary
updating localization and text of error messages related to unsupported file type uploads. Removing reference to tiff any any unsupported file types in the error message so we don't confuse users

## References
[https://tsu.atlassian.net/browse/IR-8398](https://tsu.atlassian.net/browse/IR-8398)

## QA Steps
1. go to the files tab and try to upload unsupported file types. 
2. observe toast notification error in the top right - related to the type of file with this text as a reason at the end of the message:
![image](https://github.com/user-attachments/assets/468abab2-d995-4afc-8afb-a99e793893ef)

(this should also happen for wizard file uploads)