### PR TITLE
[IR-8914] Add Documentation link to Files menu

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -41,6 +41,7 @@
     "importSettings": "Import Settings",
     "exportGLB": "Export as binary glTF (.glb) ...",
     "exportLookdev": "Export Lookdev Prefab",
+    "documentation": "Documentation",
     "importScene": "Import scene",
     "exportScene": "Export scene",
     "quit": "Quit to Dashboard"

--- a/packages/editor/src/components/toolbar/Toolbar.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar.tsx
@@ -139,6 +139,10 @@ const generateToolbarMenu = () => {
       action: () => ModalState.openModal(<CreatePrefabPanel isExportLookDev={true} />)
     },
     {
+      name: t('editor:menubar.documentation'),
+      href: 'https://docs.ir.world'
+    },
+    {
       name: t('editor:menubar.quit'),
       action: onCloseProject
     }
@@ -248,10 +252,11 @@ export default function Toolbar() {
         onClose={() => anchorEvent.set(null)}
       >
         <div className="w-[180px]" tabIndex={0}>
-          {toolbarMenu.map(({ name, action, hotkey }, index) => (
+          {toolbarMenu.map(({ name, href, action = () => {}, hotkey }, index) => (
             <DropdownItem
               key={name + '' + index}
               label={name}
+              href={href}
               secondaryText={hotkey}
               onClick={() => {
                 action()

--- a/packages/ui/src/primitives/tailwind/Dropdown/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Dropdown/index.tsx
@@ -27,7 +27,7 @@ import React from 'react'
 import { HiCheck } from 'react-icons/hi2'
 import { twMerge } from 'tailwind-merge'
 
-export interface DropdownItemProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'className'> {
+export interface DropdownItemProps extends Omit<React.HTMLAttributes<HTMLDivElement | HTMLAnchorElement>, 'className'> {
   /**text shown on the left end */
   label: string
   Icon?: ({ className }: { className?: string }) => JSX.Element
@@ -36,6 +36,7 @@ export interface DropdownItemProps extends Omit<React.HTMLAttributes<HTMLDivElem
   disabled?: boolean
   selected?: boolean
   className?: string
+  href?: string
 
   /**
    * Whether the item is hovered (or navigated through arrow keys)
@@ -54,29 +55,36 @@ export function DropdownItem({
   secondaryText,
   className,
   truncate = true,
-  ...props
+  href,
+  ...rest
 }: DropdownItemProps) {
-  return (
-    <div
-      tabIndex={0}
-      className={twMerge(
-        'h-[38px] w-full cursor-pointer bg-ui-background px-4 py-2.5 text-sm text-text-tertiary outline-none',
-        'flex items-center',
-        active ? 'bg-ui-hover-background' : '',
-        selected ? 'bg-ui-select-background text-text-primary' : '',
-        disabled
-          ? 'text-ui-inactive-primary-outline cursor-not-allowed bg-ui-inactive-background'
-          : 'hover:bg-ui-hover-background',
-        className
-      )}
-      {...props}
-    >
+  const children = (
+    <>
       <span className="flex min-w-0 flex-1 items-center gap-2">
         {Icon && <Icon className="h-3 w-3" />}
         <span className={truncate ? 'truncate' : ''}>{label}</span>
       </span>
       {secondaryText && <span className="ml-auto">{secondaryText}</span>}
       {selected && <HiCheck className="ml-auto h-3 w-3 stroke-2" />}
-    </div>
+    </>
   )
+
+  const props = {
+    className: twMerge(
+      'h-[38px] w-full cursor-pointer bg-ui-background px-4 py-2.5 text-sm text-text-tertiary outline-none',
+      'flex items-center',
+      active ? 'bg-ui-hover-background' : '',
+      selected ? 'bg-ui-select-background text-text-primary' : '',
+      disabled
+        ? 'text-ui-inactive-primary-outline cursor-not-allowed bg-ui-inactive-background'
+        : 'hover:bg-ui-hover-background',
+      className
+    ),
+    tabIndex: 0,
+    children,
+    href,
+    ...rest
+  }
+
+  return !href ? <div {...props} /> : <a target="_blank" rel="noopener noreferrer" {...props} />
 }


### PR DESCRIPTION
## Summary

- Updated `DropdownItem` to accept `href` prop. Added logic to use an anchor tag if an href is present.
- Added a link to the Files menu for the Documentation

<img width="398" alt="image" src="https://github.com/user-attachments/assets/b3e87c48-c339-49a3-9fef-95845aa65e50" />

## QA Steps

- Open Files menu
- Click on Documentation link
- Should open a new tab with Documentation
