### PR TITLE
IR-8904(fix): make blue locked icon to improve ux

### DIFF
--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -504,7 +504,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
               onClick={onLockUnlockNode}
             >
               {locked ? (
-                <PiLockBold className="font-small text-[#6B7280]" />
+                <PiLockBold className="font-small text-ui-primary" />
               ) : (
                 <PiLockOpenBold className="font-small text-[#42454d]" />
               )}


### PR DESCRIPTION
## Summary
IR-8904(fix): make blue locked icon to improve ux
Currently in IR Studio, users have the ability to “lock” objects in the hierarchy which prevents transforms from occurring to them. This is great, however, the difference between locks and unlocked states is too similar.  The icon currently becomes a light gray color, but is not enough of a visual change to clearly disambiguate between the two states. 

Darker grey (what is present now) as "lock turned off" (so keep this the same) and make the “lock turned on” (what is light gray now) primary ui blue 

## Subtasks Checklist
<img width="326" alt="Screenshot 2025-04-10 at 13 11 14" src="https://github.com/user-attachments/assets/f2bf43ee-01ff-40e5-a364-bc46634869f0" />

## Breaking Changes

## References
ticket in Jira related: https://tsu.atlassian.net/issues/IR-8904
## QA Steps
