### PR TITLE
[IR-8919] Add Info icon linking to component docs

### DIFF
--- a/packages/editor/src/panels/properties/common/NodeEditor.tsx
+++ b/packages/editor/src/panels/properties/common/NodeEditor.tsx
@@ -73,6 +73,41 @@ class NodeEditorErrorBoundary extends React.Component<INodeErrorProps, INodeErro
   }
 }
 
+const documentationMap = {
+  GLTFComponent: 'ModelComponent',
+  RigidBodyComponent: 'RigidbodyComponent',
+  TriggerCallbackComponent: 'TriggerComponent'
+}
+
+const documentationList = [
+  'ModelComponent',
+  'AudioComponent',
+  'VideoComponent',
+  'ImageComponent',
+  'PrimitiveGeometryComponent',
+  'GroundPlaneComponent',
+  'VariantComponent',
+  'ColliderComponent',
+  'RigidbodyComponent',
+  'TriggerComponent',
+  'SpawnPointComponent',
+  'LinkComponent',
+  'MountPointComponent',
+  'InterableComponent',
+  'InputComponent',
+  'ScreenshareTargetComponent',
+  'AmbientLightComponent',
+  'PointLightComponent',
+  'SpotLightComponent',
+  'DirectionalLightComponent',
+  'HemisphereLightComponent',
+  'LoopAnimationComponent',
+  'ShadowComponent',
+  'ParticleSystemComponent',
+  'EnvMapComponent',
+  'PostprocessingComponent'
+]
+
 const NodeEditor = ({
   description,
   children,
@@ -98,10 +133,21 @@ const NodeEditor = ({
     }
   }, [])
 
+  const _type = component?.name || ''
+  const componentType = documentationMap[_type] || _type
+  const hasDocs = componentType && documentationList.includes(componentType)
+  const slug = hasDocs
+    ? componentType
+        .replace(/([A-Z])/g, '-$1')
+        .toLowerCase()
+        .replace(/^-/, '')
+    : ''
+
   return (
     <ComponentDropdown
       name={name}
       description={description}
+      slug={slug}
       Icon={Icon}
       onClose={
         component && hasComponent(entity, component)

--- a/packages/ui/src/components/editor/ComponentDropdown/index.tsx
+++ b/packages/ui/src/components/editor/ComponentDropdown/index.tsx
@@ -25,6 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { Entity, UUIDComponent, getComponent } from '@ir-engine/ecs'
 import { useHookstate, useMutableState } from '@ir-engine/hyperflux'
+import { InfoCircleSm } from '@ir-engine/ui/src/icons'
 import React, { useEffect } from 'react'
 import { HiCube, HiMiniXMark, HiOutlineChevronRight } from 'react-icons/hi2'
 import { twMerge } from 'tailwind-merge'
@@ -33,6 +34,7 @@ import { ComponentDropdownState } from './ComponentDropdownState'
 
 export interface ComponentDropdownProps {
   name?: string
+  slug?: string
   description?: string
   /**icon for this component (by default: a cube icon will be shown) */
   Icon?: ({ className }: { className?: string }) => JSX.Element
@@ -47,6 +49,7 @@ export default function ComponentDropdown({
   minimizedDefault,
   Icon = HiCube,
   name,
+  slug,
   description,
   children,
   onClose,
@@ -95,12 +98,24 @@ export default function ComponentDropdown({
             </button>
           </Tooltip>
 
-          <button className="ml-2 text-text-secondary group-hover/component-dropdown:text-text-primary group-focus/component-dropdown:text-text-primary">
-            <Icon className="h-5 w-5" />
-          </button>
-          <span className="ml-1 text-sm leading-6 text-text-secondary group-hover/component-dropdown:text-text-primary group-focus/component-dropdown:text-text-primary">
-            {name}
-          </span>
+          <div className="flex items-center gap-x-2">
+            <button className="ml-2 text-text-secondary group-hover/component-dropdown:text-text-primary group-focus/component-dropdown:text-text-primary">
+              <Icon className="h-5 w-5" />
+            </button>
+            <span className="text-sm leading-6 text-text-secondary group-hover/component-dropdown:text-text-primary group-focus/component-dropdown:text-text-primary">
+              {name}
+            </span>
+            {slug && (
+              <a
+                className="text-text-secondary hover:text-text-primary"
+                target="_blank"
+                href={`https://docs.ir.world/${slug}`}
+                onClick={(ev) => ev.stopPropagation()}
+              >
+                <InfoCircleSm />
+              </a>
+            )}
+          </div>
           {onClose && (
             <button className="ml-auto text-text-inactive" onClick={onClose}>
               <HiMiniXMark className="h-4 w-4" />


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/c110fa57-cea2-46e1-8f91-2ffdd76a1fa8)

- Added an "i" icon next to each ComponentDropdown name that links to that Component's documentation.
- Added a `documentationList` array with the list of documented components
- Added a `documentationMap` object which maps some of the component types that dont match the syntax in the docs routing
- Had to use custom regex instead of slugify cus slugify assumes spaces between words

## QA Steps

- Select an Entity
- In the Properties Panel the components within the Entity should have an "i" icon next to the components with documentation
- Clicking the "i" icon should navigate to the appropriate documentation page
- There should be no icon next to components that don't have documentation
