### PR TITLE
[Release 1.0.2] IR-7891: Improve url error handling in GLTFComponent

### DIFF
--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -520,6 +520,8 @@ const useGLTFDocument = (entity: Entity) => {
       addError(entity, GLTFComponent, 'LOADING_ERROR', 'Error loading model')
     }
 
+    removeError(entity, GLTFComponent, 'LOADING_ERROR')
+
     loadGLTFFile(
       url,
       (gltf, body) => {

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -510,7 +510,6 @@ const useGLTFDocument = (entity: Entity) => {
     if (dynamicLoadAndNotEditing) return
 
     if (!url) {
-      addError(entity, GLTFComponent, 'INVALID_SOURCE', 'Invalid URL')
       return
     }
 

--- a/packages/ui/src/components/editor/properties/gltf/loader/index.tsx
+++ b/packages/ui/src/components/editor/properties/gltf/loader/index.tsx
@@ -81,7 +81,6 @@ const GLTFNodeEditor: EditorComponentType = (props) => {
   const validRootMesh = hasComponent(props.entity, MeshComponent)
   const validChildMeshes = childMeshEntities.length !== 0
   const showMeshError = isMeshOrConvexHull && !(validChildMeshes || validRootMesh)
-  const urlInputTouched = useHookstate(false)
 
   const errors = ErrorComponent.useComponentErrors(props.entity, GLTFComponent)?.value
   const srcProject = useHookstate(() => {
@@ -152,19 +151,12 @@ const GLTFNodeEditor: EditorComponentType = (props) => {
         <ModelInput
           value={gltfComponent.src.value}
           onRelease={(src) => {
-            urlInputTouched.set(true)
             if (src != gltfComponent.src.value) {
               removeError(props.entity, GLTFComponent, 'LOADING_ERROR')
-              removeError(props.entity, GLTFComponent, 'INVALID_SOURCE')
             }
             commitProperty(GLTFComponent, 'src')(src)
           }}
         />
-        {urlInputTouched.value && errors?.INVALID_SOURCE && (
-          <Text fontSize="xs" className="text-ui-error">
-            {t('editor:properties.model.error-url')}
-          </Text>
-        )}
         {!errors?.INVALID_SOURCE && !!errors?.LOADING_ERROR && (
           <Text fontSize="xs" className="text-ui-error">
             {errors?.LOADING_ERROR}

--- a/packages/ui/src/components/editor/properties/gltf/loader/index.tsx
+++ b/packages/ui/src/components/editor/properties/gltf/loader/index.tsx
@@ -27,7 +27,6 @@ import { ProjectService, ProjectState } from '@ir-engine/client-core/src/common/
 import config from '@ir-engine/common/src/config'
 import { camelCaseToSpacedString } from '@ir-engine/common/src/utils/camelCaseToSpacedString'
 import { hasComponent, useAncestorWithComponents, useChildrenWithComponents, useComponent } from '@ir-engine/ecs'
-import ErrorPopUp from '@ir-engine/editor/src/components/popup/ErrorPopUp'
 import { EditorComponentType, commitProperty } from '@ir-engine/editor/src/components/properties/Util'
 import { exportRelativeGLTF } from '@ir-engine/editor/src/functions/exportGLTF'
 import NodeEditor from '@ir-engine/editor/src/panels/properties/common/NodeEditor'
@@ -55,6 +54,7 @@ import SelectInput from '../../../input/Select'
 import { EditorControlFunctions } from '@ir-engine/editor/src/functions/EditorControlFunctions'
 import { EditorHistoryFunctions } from '@ir-engine/editor/src/services/EditorHistoryState'
 import { SelectionState } from '@ir-engine/editor/src/services/SelectionServices'
+import { removeError } from '@ir-engine/engine/src/scene/functions/ErrorFunctions'
 import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 import { HiPlus } from 'react-icons/hi2'
 import { OptionType } from '../../../../../primitives/tailwind/Select'
@@ -81,6 +81,7 @@ const GLTFNodeEditor: EditorComponentType = (props) => {
   const validRootMesh = hasComponent(props.entity, MeshComponent)
   const validChildMeshes = childMeshEntities.length !== 0
   const showMeshError = isMeshOrConvexHull && !(validChildMeshes || validRootMesh)
+  const urlInputTouched = useHookstate(false)
 
   const errors = ErrorComponent.useComponentErrors(props.entity, GLTFComponent)?.value
   const srcProject = useHookstate(() => {
@@ -147,15 +148,28 @@ const GLTFNodeEditor: EditorComponentType = (props) => {
       Icon={GLTFNodeEditor.iconComponent}
       {...props}
     >
-      <InputGroup name="Model Url" label={t('editor:properties.model.lbl-modelurl')}>
+      <InputGroup name="Model Url" className="flex flex-col gap-y-2" label={t('editor:properties.model.lbl-modelurl')}>
         <ModelInput
           value={gltfComponent.src.value}
           onRelease={(src) => {
+            urlInputTouched.set(true)
+            if (src != gltfComponent.src.value) {
+              removeError(props.entity, GLTFComponent, 'LOADING_ERROR')
+              removeError(props.entity, GLTFComponent, 'INVALID_SOURCE')
+            }
             commitProperty(GLTFComponent, 'src')(src)
           }}
         />
-        {errors?.LOADING_ERROR ||
-          (errors?.INVALID_SOURCE && ErrorPopUp({ message: t('editor:properties.model.error-url') }))}
+        {urlInputTouched.value && errors?.INVALID_SOURCE && (
+          <Text fontSize="xs" className="text-ui-error">
+            {t('editor:properties.model.error-url')}
+          </Text>
+        )}
+        {!errors?.INVALID_SOURCE && !!errors?.LOADING_ERROR && (
+          <Text fontSize="xs" className="text-ui-error">
+            {errors?.LOADING_ERROR}
+          </Text>
+        )}
       </InputGroup>
 
       <InputGroup name="Camera Occlusion" label={t('editor:properties.model.lbl-cameraOcclusion')}>

--- a/packages/ui/src/components/editor/properties/gltf/loader/index.tsx
+++ b/packages/ui/src/components/editor/properties/gltf/loader/index.tsx
@@ -54,7 +54,6 @@ import SelectInput from '../../../input/Select'
 import { EditorControlFunctions } from '@ir-engine/editor/src/functions/EditorControlFunctions'
 import { EditorHistoryFunctions } from '@ir-engine/editor/src/services/EditorHistoryState'
 import { SelectionState } from '@ir-engine/editor/src/services/SelectionServices'
-import { removeError } from '@ir-engine/engine/src/scene/functions/ErrorFunctions'
 import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 import { HiPlus } from 'react-icons/hi2'
 import { OptionType } from '../../../../../primitives/tailwind/Select'
@@ -151,9 +150,6 @@ const GLTFNodeEditor: EditorComponentType = (props) => {
         <ModelInput
           value={gltfComponent.src.value}
           onRelease={(src) => {
-            if (src != gltfComponent.src.value) {
-              removeError(props.entity, GLTFComponent, 'LOADING_ERROR')
-            }
             commitProperty(GLTFComponent, 'src')(src)
           }}
         />


### PR DESCRIPTION
## Summary

This change prevents the INVALID_SOURCE error from showing when the component is just added to the scene and doesn't have a value. 

Show both type of errors as inline errors to consolidate the UI 

![Screen Recording 2025-04-14 at 3 32 08 p m](https://github.com/user-attachments/assets/591b6db9-c33e-48de-b208-828e4b9def13)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

 - Open an scene in the studio
 - Add an entity
 - Add a model component to the entity 
 - Observe there's no errors shown after the component was added 
 - Enter an invalid url 
 - Observe the errors added to the component 
 - Enter a valid url 
 - Observe the errors dissappear from the component 
