### PR TITLE
Prevent Duplicating GLTF Children

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -359,6 +359,7 @@ const duplicateObject = (entities: Entity[]) => {
         deserializeComponent(newEntity, ComponentJSONIDMap.get(component.name)!, component.props)
       }
 
+      if (hasComponent(entity, GLTFComponent)) return
       const children = getComponent(entity, EntityTreeComponent).children as Entity[]
       duplicateEntities(children, newEntity)
     })

--- a/packages/engine/src/gltf/MaterialExtensionComponents.tsx
+++ b/packages/engine/src/gltf/MaterialExtensionComponents.tsx
@@ -480,11 +480,10 @@ export const KHRSpecularExtensionComponent = defineComponent({
   jsonID: 'KHR_materials_specular',
   schema: S.Object({
     specularFactor: S.Optional(S.Number()),
-    specularTexture: S.Optional(TextureInfoSchema),
+    specularTexture: S.Nullable(TextureInfoSchema),
     specularColorFactor: S.Optional(S.Tuple([S.Number(), S.Number(), S.Number()])),
-    specularColorTexture: S.Optional(TextureInfoSchema)
+    specularColorTexture: S.Nullable(TextureInfoSchema)
   }),
-
   getMaterialType() {
     return MeshPhysicalMaterial
   },
@@ -497,7 +496,7 @@ export const KHRSpecularExtensionComponent = defineComponent({
     >
     materialParams.specularIntensity = extension.specularFactor !== undefined ? extension.specularFactor : 1.0
 
-    if (extension.specularTexture !== undefined) {
+    if (extension?.specularTexture) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.specularTexture).then((map) => {
           materialParams.specularIntensityMap = map
@@ -508,7 +507,7 @@ export const KHRSpecularExtensionComponent = defineComponent({
     const colorArray = extension.specularColorFactor || [1, 1, 1]
     materialParams.specularColor = new Color().setRGB(colorArray[0], colorArray[1], colorArray[2], LinearSRGBColorSpace)
 
-    if (extension.specularColorTexture !== undefined) {
+    if (extension?.specularColorTexture) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.specularColorTexture).then((map) => {
           materialParams.specularColorMap = map


### PR DESCRIPTION
## Summary
When recursively duplicating children of an entity, prevent further recursion when duplicating a GLTF object. This is because the GLTFComponent procs its own hierarchy-forming logic when the root object is duplicated. 

Also prevent an error occurring when attempting to serialize MaterialExtensionComponent

## Subtasks Checklist

## Breaking Changes

## References
**Related to** [IR-8503]

## QA Steps


[IR-8503]: https://tsu.atlassian.net/browse/IR-8503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ