### PR TITLE
 [IR-9042]: Fix iOS fullscreen bars with viewport-fit

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -11,7 +11,7 @@
     </style>
     <base href="/" />
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, shrink-to-fit=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, shrink-to-fit=no viewport-fit=cover" />
 
     <meta name="description" content="<%- description %>" />
     <title><%- title %></title>


### PR DESCRIPTION
## Summary

On iOS the html element doesnt scale to the full width of the viewport, showing white bars instead.

By adding `viewport-fit=cover` to the meta tags, iOS will scale the content to the viewport

![image](https://github.com/user-attachments/assets/788b8f35-979d-442f-8744-c8132ea0a456)

## References

- https://webkit.org/blog/7929/designing-websites-for-iphone-x/

## QA Steps

- On an iPhone, open Safari
- Go to a published project link
- Turn phone to landscape
- The app should stretch to both screen edges without white bars on either side.
