### PR TITLE
Resolve errors when changing graphics quality settings to 0

### DIFF
--- a/packages/engine/src/scene/materials/systems/MaterialLibrarySystem.tsx
+++ b/packages/engine/src/scene/materials/systems/MaterialLibrarySystem.tsx
@@ -89,7 +89,20 @@ const ChildMaterialReactor = () => {
   const forceBasicMaterials = useMutableState(RendererState).forceBasicMaterials
   const materialComponent = useComponent(entity, MaterialStateComponent)
   useEffect(() => {
-    if (!materialComponent.material.value || !materialComponent.instances.length) return
+    try {
+      if (
+        !materialComponent ||
+        !materialComponent.material ||
+        !materialComponent.material.value ||
+        !materialComponent.instances.length
+      ) {
+        console.warn('Material Component properties are invalid')
+        return
+      }
+    } catch (error) {
+      console.warn('Error accessing Material Component properties:', error)
+      return
+    }
     convertMaterials(entity, forceBasicMaterials.value)
   }, [
     materialComponent.material,

--- a/packages/engine/src/scene/materials/systems/MaterialLibrarySystem.tsx
+++ b/packages/engine/src/scene/materials/systems/MaterialLibrarySystem.tsx
@@ -89,20 +89,12 @@ const ChildMaterialReactor = () => {
   const forceBasicMaterials = useMutableState(RendererState).forceBasicMaterials
   const materialComponent = useComponent(entity, MaterialStateComponent)
   useEffect(() => {
-    try {
-      if (
-        !materialComponent ||
-        !materialComponent.material ||
-        !materialComponent.material.value ||
-        !materialComponent.instances.length
-      ) {
-        console.warn('Material Component properties are invalid')
-        return
-      }
-    } catch (error) {
-      console.warn('Error accessing Material Component properties:', error)
+    if (materialComponent.promised || materialComponent.material.promised) {
+      // The material is still loading; don't access its value yet.
+      // This happens when setting graphics quality to 0, in many cases. HookState will throw a 103 error. see https://tsu.atlassian.net/browse/IR-8475
       return
     }
+    if (!materialComponent.material.value || !materialComponent.instances.length) return
     convertMaterials(entity, forceBasicMaterials.value)
   }, [
     materialComponent.material,


### PR DESCRIPTION
## Summary
Resolve error (HookState 103) when changing graphics quality setting to 0. Requires we check for promised status of the material component hook state before accessing values on material component. 

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-8475](https://tsu.atlassian.net/browse/IR-8475) 

## QA Steps
* Open a published scene
* Open the developer console in the browser
* Go to graphics settings (User Profile button > Settings Button > Graphics tab > Change quality preset to 0)
* Clear your developer tools console
* Observe no errors when changing the quality to 0
* Repeat a few more times. You should not see errors related to changing graphics quality.


[IR-8475]: https://tsu.atlassian.net/browse/IR-8475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ