### PR TITLE
fix(IR-8763): ensure scene file extension consistency

### DIFF
--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -74,7 +74,7 @@ export const saveSceneGLTF = async (
 
   const { rootEntity } = getState(EditorState)
 
-  const baseSceneName = cleanString(sceneFile!.replace('.scene.json', '').replace('.gltf', '').trim())
+  const baseSceneName = cleanString(sceneFile!.replace('.gltf', '').trim())
   const sceneName = baseSceneName.endsWith('.gltf') ? baseSceneName : `${baseSceneName}.gltf`
 
   let currentSceneDirectory = getState(EditorState).scenePath!.split('/').slice(0, -1).join('/')

--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -74,7 +74,9 @@ export const saveSceneGLTF = async (
 
   const { rootEntity } = getState(EditorState)
 
-  const sceneName = cleanString(sceneFile!.replace('.scene.json', '').replace('.gltf', '')) + '.gltf'
+  const baseSceneName = cleanString(sceneFile!.replace('.scene.json', '').replace('.gltf', '').trim())
+  const sceneName = baseSceneName.endsWith('.gltf') ? baseSceneName : `${baseSceneName}.gltf`
+
   let currentSceneDirectory = getState(EditorState).scenePath!.split('/').slice(0, -1).join('/')
   if (savePath) {
     currentSceneDirectory = savePath


### PR DESCRIPTION
- Add validation to guarantee .gltf extension in scene names
- Fix potential duplicate extension issue in scene saving
- Improve scene name handling in saveSceneGLTF function

## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
