### PR TITLE
[IR-9042] Remove unneeded viewport attr and fix syntax

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -11,7 +11,7 @@
     </style>
     <base href="/" />
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, shrink-to-fit=no viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover" />
 
     <meta name="description" content="<%- description %>" />
     <title><%- title %></title>


### PR DESCRIPTION
## Summary

After noticing a syntax error in the viewport tag, I realized the `shrink-to-fit=no` attribute wasnt doing anything. Looks like the use case for it was slim and Apple stopped supporting it a while ago.

From 2019:

> As stats on iOS usage, indicating that iOS 9.0-9.2.x usage is currently at 0.17%. If these numbers are truly indicative of global use of these versions, then it’s even more likely to be safe to remove shrink-to-fit from your viewport meta tag.
>
> After 9.2.x. IOS remove this tag check on its' browser.

[Stackoverflow](https://stackoverflow.com/a/55739412/30241587)
