### PR TITLE
[IR-9031] Fix VideoComponent autoplay on iOS

### DIFF
--- a/packages/engine/src/scene/components/VideoComponent.tsx
+++ b/packages/engine/src/scene/components/VideoComponent.tsx
@@ -460,8 +460,30 @@ function VideoReactor() {
     const sourceTexture = sourceVideoComponent?.texture
 
     if (video.texture.value) {
+      const videoEl = mediaElement.element as HTMLVideoElement
+
+      const resetMuted = () => {
+        videoEl.muted = false
+        document.removeEventListener('pointerdown', resetMuted)
+      }
+
+      if (videoEl.paused) {
+        videoEl.pause()
+      } else {
+        videoEl.play().catch((error) => {
+          if (error.name === 'NotAllowedError') {
+            videoEl.muted = true
+            videoEl.play()
+
+            document.addEventListener('pointerdown', resetMuted)
+          } else {
+            console.error(error)
+          }
+        })
+      }
+
       //needed to set up the self-referencing source video texture
-      ;(video.texture.value.image as HTMLVideoElement) = mediaElement.element as HTMLVideoElement
+      ;(video.texture.value.image as HTMLVideoElement) = videoEl
       clearErrors(entity, VideoComponent)
     } else {
       if (sourceTexture && sourceMeshComponent) {


### PR DESCRIPTION
## Summary

The VideoComponent doesnt show a first frame and doesn't autoplay on iOS because of how iOS handles video autoplay works. iOS requires `muted` to be set to allow autoplay on mobile.

![image](https://github.com/user-attachments/assets/222b840f-9138-4bd7-85be-66f6b9b95239)


## References
- https://developer.apple.com/documentation/webkit/delivering-video-content-for-safari#Enable-Video-Autoplay

## QA Steps

- Open safari on iPhone
- Go to a published project with an autoplaying video in it
- Video should autoplay on iOS
