### PR TITLE
fixed Thumbnail generation causes massive re renders and flashes

### DIFF
--- a/packages/client-core/src/hooks/useLoadingThumbnails.tsx
+++ b/packages/client-core/src/hooks/useLoadingThumbnails.tsx
@@ -1,0 +1,60 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import { State, useMutableState } from '@ir-engine/hyperflux'
+import { useEffect, useRef } from 'react'
+import { FileThumbnailJobState } from '../common/services/FileThumbnailJobState'
+
+const useLoadingThumbnails = (isLoading: State<boolean>) => {
+  const thumbnailJobs = useMutableState(FileThumbnailJobState).jobs
+  const debouncedStatusRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    clearTimeout(debouncedStatusRef.current)
+  }, [])
+
+  useEffect(() => {
+    if (debouncedStatusRef) {
+      clearTimeout(debouncedStatusRef.current)
+    }
+
+    const isThumbnailsLoading = thumbnailJobs.length > 0
+    if (isThumbnailsLoading) {
+      isLoading.set(true)
+    } else {
+      debouncedStatusRef.current = setTimeout(() => {
+        isLoading.set(false)
+      }, 1000)
+    }
+
+    return () => {
+      clearTimeout(debouncedStatusRef.current)
+    }
+  }, [thumbnailJobs.length])
+
+  return
+}
+
+export default useLoadingThumbnails

--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -22,11 +22,9 @@ Original Code is the Infinite Reality Engine team.
 All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
 Infinite Reality Engine. All Rights Reserved.
 */
-import {
-  FileThumbnailJobState,
-  removeFromFileThumbnailsSeen
-} from '@ir-engine/client-core/src/common/services/FileThumbnailJobState'
+import { removeFromFileThumbnailsSeen } from '@ir-engine/client-core/src/common/services/FileThumbnailJobState'
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
+import useLoadingThumbnails from '@ir-engine/client-core/src/hooks/useLoadingThumbnails'
 import ProgressBar from '@ir-engine/client-core/src/systems/ui/LoadingDetailView/SimpleProgressBar'
 import { AuthState } from '@ir-engine/client-core/src/user/services/AuthService'
 import { StaticResourceType } from '@ir-engine/common/src/schema.type.module'
@@ -404,21 +402,13 @@ function ResourceItems() {
     fileIconsLoaded.set(fileIconsLoaded.get() + 1)
   }
 
-  const thumbnailJobState = useMutableState(FileThumbnailJobState)
-  const debouncedRefetchResourcesRef = useRef<ReturnType<typeof setTimeout>>()
+  const isLoading = useHookstate(false)
+  useLoadingThumbnails(isLoading)
 
   useEffect(() => {
-    clearTimeout(debouncedRefetchResourcesRef.current)
-  }, [])
-
-  useEffect(() => {
-    if (debouncedRefetchResourcesRef) {
-      clearTimeout(debouncedRefetchResourcesRef.current)
-    }
-    debouncedRefetchResourcesRef.current = setTimeout(() => {
-      refetchResources()
-    }, 1000)
-  }, [thumbnailJobState.jobs.length])
+    if (isLoading.value) return
+    refetchResources()
+  }, [isLoading.value])
 
   useEffect(() => {
     fileIconsLoaded.set(0)

--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -417,7 +417,7 @@ function ResourceItems() {
     }
     debouncedRefetchResourcesRef.current = setTimeout(() => {
       refetchResources()
-    }, 500)
+    }, 1000)
   }, [thumbnailJobState.jobs.length])
 
   useEffect(() => {

--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -71,12 +71,10 @@ export function Browser() {
   }, [])
 
   useEffect(() => {
-    console.log('mbf', thumbnailJobState.jobs.length)
     if (debouncedRefetchDirectoryRef) {
       clearTimeout(debouncedRefetchDirectoryRef.current)
     }
     debouncedRefetchDirectoryRef.current = setTimeout(() => {
-      console.log('mbf', 'refreshDirectory')
       refreshDirectory()
     }, 1000)
   }, [thumbnailJobState.jobs.length])

--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -27,7 +27,7 @@ import { FileThumbnailJobState } from '@ir-engine/client-core/src/common/service
 import { useFind } from '@ir-engine/common'
 import { StaticResourceType, staticResourcePath } from '@ir-engine/common/src/schema.type.module'
 import { useHookstate, useMutableState } from '@ir-engine/hyperflux'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useDrop } from 'react-dnd'
 import { twMerge } from 'tailwind-merge'
 import { SupportedFileTypes } from '../../constants/AssetTypes'
@@ -64,8 +64,21 @@ export function Browser() {
     })
   }
 
+  const debouncedRefetchDirectoryRef = useRef<ReturnType<typeof setTimeout>>()
+
   useEffect(() => {
-    refreshDirectory()
+    clearTimeout(debouncedRefetchDirectoryRef.current)
+  }, [])
+
+  useEffect(() => {
+    console.log('mbf', thumbnailJobState.jobs.length)
+    if (debouncedRefetchDirectoryRef) {
+      clearTimeout(debouncedRefetchDirectoryRef.current)
+    }
+    debouncedRefetchDirectoryRef.current = setTimeout(() => {
+      console.log('mbf', 'refreshDirectory')
+      refreshDirectory()
+    }, 1000)
   }, [thumbnailJobState.jobs.length])
 
   const staticResourceDataQuery = useFind(staticResourcePath, {

--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -24,10 +24,11 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { FileThumbnailJobState } from '@ir-engine/client-core/src/common/services/FileThumbnailJobState'
+import useLoadingThumbnails from '@ir-engine/client-core/src/hooks/useLoadingThumbnails'
 import { useFind } from '@ir-engine/common'
 import { StaticResourceType, staticResourcePath } from '@ir-engine/common/src/schema.type.module'
 import { useHookstate, useMutableState } from '@ir-engine/hyperflux'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useDrop } from 'react-dnd'
 import { twMerge } from 'tailwind-merge'
 import { SupportedFileTypes } from '../../constants/AssetTypes'
@@ -64,20 +65,13 @@ export function Browser() {
     })
   }
 
-  const debouncedRefetchDirectoryRef = useRef<ReturnType<typeof setTimeout>>()
+  const isLoading = useHookstate(false)
+  useLoadingThumbnails(isLoading)
 
   useEffect(() => {
-    clearTimeout(debouncedRefetchDirectoryRef.current)
-  }, [])
-
-  useEffect(() => {
-    if (debouncedRefetchDirectoryRef) {
-      clearTimeout(debouncedRefetchDirectoryRef.current)
-    }
-    debouncedRefetchDirectoryRef.current = setTimeout(() => {
-      refreshDirectory()
-    }, 1000)
-  }, [thumbnailJobState.jobs.length])
+    if (isLoading.value) return
+    refreshDirectory()
+  }, [isLoading.value])
 
   const staticResourceDataQuery = useFind(staticResourcePath, {
     query: {

--- a/packages/editor/src/panels/files/loaders.tsx
+++ b/packages/editor/src/panels/files/loaders.tsx
@@ -31,10 +31,10 @@ import config from '@ir-engine/common/src/config'
 import { archiverPath } from '@ir-engine/common/src/schema.type.module'
 import { bytesToSize } from '@ir-engine/common/src/utils/btyesToSize'
 import { downloadBlobAsZip } from '@ir-engine/editor/src/functions/assetFunctions'
-import { defineState, getMutableState, useMutableState } from '@ir-engine/hyperflux'
+import { defineState, getMutableState, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import LoadingView from '@ir-engine/ui/src/primitives/tailwind/LoadingView'
 import Progress from '@ir-engine/ui/src/primitives/tailwind/Progress'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCurrentFiles } from './helpers'
 
@@ -144,7 +144,6 @@ export function ProjectDownloadProgress() {
 export function FileUploadProgress() {
   const { t } = useTranslation()
   const { completed, total, progress } = useUploadingFiles()
-
   return total ? (
     <div className="flex h-auto w-full justify-center pb-2 pt-2">
       <div className="flex w-1/2">
@@ -163,24 +162,64 @@ function GeneratingThumbnailsProgress() {
   const { t } = useTranslation()
   const thumbnailJobs = useMutableState(FileThumbnailJobState).jobs
 
-  if (!thumbnailJobs.length) return null
+  const isLoading = useHookstate(false)
+  const debouncedStatusRef = useRef<ReturnType<typeof setTimeout>>()
 
-  return (
+  useEffect(() => {
+    clearTimeout(debouncedStatusRef.current)
+  }, [])
+
+  useEffect(() => {
+    if (debouncedStatusRef) {
+      clearTimeout(debouncedStatusRef.current)
+    }
+
+    const isThumbnailsLoading = thumbnailJobs.length > 0
+    if (isThumbnailsLoading) {
+      isLoading.set(true)
+    } else {
+      debouncedStatusRef.current = setTimeout(() => {
+        isLoading.set(false)
+      }, 1000)
+    }
+  }, [thumbnailJobs.length])
+
+  return isLoading.value ? (
     <LoadingView
       titleClassname="mt-0"
       containerClassName="flex-row mt-1"
       className="mx-2 my-auto h-6 w-6"
       title={t('editor:layout.filebrowser.generatingThumbnails', { count: thumbnailJobs.length })}
     />
-  )
+  ) : null
 }
 
 function FilesLoading() {
   const { t } = useTranslation()
   const { filesQuery } = useCurrentFiles()
-  const isLoading = filesQuery?.status === 'pending'
+  const isLoading = useHookstate(false)
+  const debouncedStatusRef = useRef<ReturnType<typeof setTimeout>>()
 
-  return isLoading ? (
+  useEffect(() => {
+    clearTimeout(debouncedStatusRef.current)
+  }, [])
+
+  useEffect(() => {
+    if (debouncedStatusRef) {
+      clearTimeout(debouncedStatusRef.current)
+    }
+
+    const isFilesLoading = filesQuery?.status === 'pending'
+    if (isFilesLoading) {
+      isLoading.set(true)
+    } else {
+      debouncedStatusRef.current = setTimeout(() => {
+        isLoading.set(false)
+      }, 1000)
+    }
+  }, [filesQuery?.status])
+
+  return isLoading.value ? (
     <LoadingView title={t('editor:layout.filebrowser.loadingFiles')} fullSpace className="block h-12 w-12" />
   ) : null
 }
@@ -188,10 +227,10 @@ function FilesLoading() {
 export default function Loaders() {
   return (
     <>
+      <GeneratingThumbnailsProgress />
       <FileUploadProgress />
       <ProjectDownloadProgress />
       <FilesLoading />
-      <GeneratingThumbnailsProgress />
     </>
   )
 }

--- a/packages/editor/src/panels/files/loaders.tsx
+++ b/packages/editor/src/panels/files/loaders.tsx
@@ -25,6 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { FileThumbnailJobState } from '@ir-engine/client-core/src/common/services/FileThumbnailJobState'
 import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
+import useLoadingThumbnails from '@ir-engine/client-core/src/hooks/useLoadingThumbnails'
 import { useUploadingFiles } from '@ir-engine/client-core/src/util/upload'
 import { API } from '@ir-engine/common'
 import config from '@ir-engine/common/src/config'
@@ -163,30 +164,7 @@ function GeneratingThumbnailsProgress() {
   const thumbnailJobs = useMutableState(FileThumbnailJobState).jobs
 
   const isLoading = useHookstate(false)
-  const debouncedStatusRef = useRef<ReturnType<typeof setTimeout>>()
-
-  useEffect(() => {
-    clearTimeout(debouncedStatusRef.current)
-  }, [])
-
-  useEffect(() => {
-    if (debouncedStatusRef) {
-      clearTimeout(debouncedStatusRef.current)
-    }
-
-    const isThumbnailsLoading = thumbnailJobs.length > 0
-    if (isThumbnailsLoading) {
-      isLoading.set(true)
-    } else {
-      debouncedStatusRef.current = setTimeout(() => {
-        isLoading.set(false)
-      }, 1000)
-    }
-
-    return () => {
-      clearTimeout(debouncedStatusRef.current)
-    }
-  }, [thumbnailJobs.length])
+  useLoadingThumbnails(isLoading)
 
   return isLoading.value ? (
     <LoadingView

--- a/packages/editor/src/panels/files/loaders.tsx
+++ b/packages/editor/src/panels/files/loaders.tsx
@@ -182,6 +182,10 @@ function GeneratingThumbnailsProgress() {
         isLoading.set(false)
       }, 1000)
     }
+
+    return () => {
+      clearTimeout(debouncedStatusRef.current)
+    }
   }, [thumbnailJobs.length])
 
   return isLoading.value ? (


### PR DESCRIPTION
## Summary
https://tsu.atlassian.net/browse/IR-8954

Added debounce methods to prevent the loading ui from being turned off if it being turned back on within 1 sec
Moved the generate Thumbnail loading to above the loading spinner so it can be seen

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
