### PR TITLE
[IR-8895] Fix LoadingView z-index bug

### DIFF
--- a/packages/client/src/pages/location/location.tsx
+++ b/packages/client/src/pages/location/location.tsx
@@ -59,7 +59,7 @@ const LocationRoutes = () => {
         </Routes>
       )}
       {!ready && (
-        <div className="flex h-dvh w-dvw items-center justify-center bg-white" style={{ zIndex: 1000000 }}>
+        <div className="relative flex h-dvh w-dvw items-center justify-center bg-white" style={{ zIndex: 1000000 }}>
           <LoadingView fullScreen animated title={t('common:loader.loadingApp')} titleClassname="text-black" />
         </div>
       )}


### PR DESCRIPTION
## Summary

The LoadingView was rendering below some of the UI components. Even though it had `z-index: 1000000`, the element didnt have `relative`, `absolute`, or `fixed` to actually force the z-index to work. Added the `relative` class, because `fixed` shouldnt be required.

![image](https://github.com/user-attachments/assets/7fd538a5-c84b-427a-92d4-7a5b600a59f0)

## QA Steps
- Open a project location
- As the page load, the LoadingView with animation should appear alone without any UI elements above.
