### PR TITLE
add .aiexclude for AI indexing integration; IR-9112

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,9 @@
+packages/server/upload/
+packages/server/upload_test/
+packages/projects/projects/
+packages/matchmaking/
+**/node_modules/**
+packages/*/dist/
+packages/*/coverage/
+**/.env
+**/.env.local


### PR DESCRIPTION
## Summary

- Create `.aiexclude` file so third party indexing (specifically Gemini in this case) knows what paths to exclude when creating an index. More info here: https://cloud.google.com/gemini/docs/codeassist/create-aiexclude-file

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-9112]

## QA Steps


[IR-9112]: https://tsu.atlassian.net/browse/IR-9112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ