### PR TITLE
Respect the provided branch of the manifest repo when cloning

### DIFF
--- a/scripts/install-manifest.ts
+++ b/scripts/install-manifest.ts
@@ -72,7 +72,9 @@ const fetchManifest = async () => {
       .split('/')
     const clonePath = path.resolve(appRootPath.path, '.temp', repo)
     // enforce ssh connection rather than deprecated http usr/pwd
-    await execPromise(`git clone git@github.com:${org}/${repo} ${clonePath}`, {
+    console.log(`Cloning ${org}/${repo} on branch ${branch} for manifests`)
+    // Clone from the specific branch provided in the URL
+    await execPromise(`git clone -b ${branch} git@github.com:${org}/${repo} ${clonePath}`, {
       cwd: appRootPath.path
     })
     console.log('manifest installed')


### PR DESCRIPTION
## Summary
The current install-manifest npm script does not fetch the manifest files from the provided branch in the CLI. This fixes the issue by including the branch when cloning the repo into the temp folder.

This is needed since the latest updates to the ir-pro manifest project are on the [dev branch](https://github.com/theinfinitereality/irpro-platform/tree/dev).

## Subtasks Checklist

## Breaking Changes

## References
https://github.com/theinfinitereality/irpro-platform/pull/1

## QA Steps
Using this branch, the following command should successfully install the ir-pro asset manifest:
`npm run install-manifest -- --manifestURL="https://github.com/theinfinitereality/irpro-platform/blob/v1-manifests/irpro-asset.manifest.json" --branch="dev"`