### PR TITLE
fixed issue with the logic for the property editor useExecute to work…

### DIFF
--- a/packages/editor/src/panels/properties/propertyeditor.tsx
+++ b/packages/editor/src/panels/properties/propertyeditor.tsx
@@ -25,7 +25,13 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { calculateAndApplyYOffset } from '@ir-engine/common/src/utils/offsets'
 import { Entity, EntityUUID, PresentationSystemGroup, UUIDComponent, useExecute } from '@ir-engine/ecs'
-import { Component, Layers, getAllComponents, useHasComponent } from '@ir-engine/ecs/src/ComponentFunctions'
+import {
+  Component,
+  ComponentJSONIDMap,
+  Layers,
+  getAllComponents,
+  useHasComponent
+} from '@ir-engine/ecs/src/ComponentFunctions'
 import { ComponentEditorsState } from '@ir-engine/editor/src/services/ComponentEditors'
 import { EditorState } from '@ir-engine/editor/src/services/EditorServices'
 import { SelectionState } from '@ir-engine/editor/src/services/SelectionServices'
@@ -67,13 +73,20 @@ const EntityEditor = ({ entityUUID, multiEdit }: { entityUUID: EntityUUID; multi
 
   const entity = UUIDComponent.getEntityByUUID(entityUUID, Layers.Authoring)
   const componentEditors = useHookstate(getMutableState(ComponentEditorsState)).get(NO_PROXY)
-  const components = useHookstate([] as Component[])
+  const components = useHookstate([] as string[])
 
   useExecute(
     () => {
-      const entityComponents = getAllComponents(entity).filter(
-        (component) => component.name && componentEditors[component.name] && component.name !== TransformComponent.name
-      )
+      const entityComponents = getAllComponents(entity)
+        .filter(
+          (component) =>
+            component.name &&
+            componentEditors[component.name] &&
+            component.name !== TransformComponent.name &&
+            component.jsonID !== undefined
+        )
+        .map((component) => component.jsonID!)
+
       if (JSON.stringify(entityComponents) !== JSON.stringify(components.get(NO_PROXY))) {
         components.set(entityComponents)
       }
@@ -136,16 +149,19 @@ const EntityEditor = ({ entityUUID, multiEdit }: { entityUUID: EntityUUID; multi
           </Suspense>
         </ErrorBoundary>
       )}
-      {components.get(NO_PROXY).map((c) => (
-        <ErrorBoundary
-          key={`${entityUUID + entity}-${c.name}`}
-          fallback={<div>Error occured displaying properties for {c.name}</div>}
-        >
-          <Suspense>
-            <EntityComponentEditor multiEdit={multiEdit} entity={entity} component={c as Component} />
-          </Suspense>
-        </ErrorBoundary>
-      ))}
+      {components.get(NO_PROXY).map((c) => {
+        const component = ComponentJSONIDMap.get(c)
+        return component ? (
+          <ErrorBoundary
+            key={`${entityUUID + entity}-${component.name}`}
+            fallback={<div>Error occured displaying properties for {component.name}</div>}
+          >
+            <Suspense>
+              <EntityComponentEditor multiEdit={multiEdit} entity={entity} component={component as Component} />
+            </Suspense>
+          </ErrorBoundary>
+        ) : null
+      })}
     </>
   )
 }


### PR DESCRIPTION
… with just the component's json if for serialization instead of the entire component definition

## Summary
https://tsu.atlassian.net/browse/IR-8926


traced the issue to be in packages/editor/src/panels/properties/propertyeditor.tsx
introduced in the commit  
- c9f1b979a5	Mar 28, 2025 at 12:09 AM Use useExecute in entity properties to keep components list updated (#1529)	

The useExecute, which was caching the list of components, was using an array for component definitions, and not instances, which are not setup to be stringify into JSON. 

I updated the cache array to use an array of just the components jsonID value, and then fetched the corresponding component for the jsonID when needed 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
