### PR TITLE
[Release1.0.2] IR-9129 Add support to show users email in moderation details  (#1685)

### DIFF
--- a/packages/client-core/src/admin/components/moderation/ModerationDetail.tsx
+++ b/packages/client-core/src/admin/components/moderation/ModerationDetail.tsx
@@ -211,7 +211,11 @@ export const ModerationDetail = ({
           {isUserModeration && (
             <>
               <Text className="mb-4 text-text-primary">{t('admin:components.moderation.usernameBeingReported')}</Text>
-              <UserInfo userId={moderation.reportedUserId} usersQuery={usersQuery} />
+              <UserInfo
+                userId={moderation.reportedUserId}
+                userEmail={moderation.reportedUserEmail}
+                usersQuery={usersQuery}
+              />
               <Text className="mb-4 text-text-primary">{t('admin:components.moderation.accountType')}</Text>
               <Text className="mb-4">
                 {locationAdminQuery && locationAdminQuery.status == 'success' && locationAdminQuery.data.length > 0
@@ -225,7 +229,7 @@ export const ModerationDetail = ({
           <Text className="mb-4 text-text-primary">{t('admin:components.moderation.dateReported')}</Text>
           <Text className="mb-4">{toDisplayDateTimeUtc(moderation?.reportedAt)} UTC</Text>
           <Text className="mb-4 text-text-primary">{t('admin:components.moderation.reporter')}</Text>
-          <UserInfo userId={moderation.createdBy} usersQuery={usersQuery} />
+          <UserInfo userId={moderation.createdBy} userEmail={moderation.createdByEmail} usersQuery={usersQuery} />
           <Text className="mb-4 text-text-primary">{t('admin:components.moderation.space')}</Text>
           <Text className="mb-4">
             {moderation.reportedLocationId && (

--- a/packages/client-core/src/admin/components/moderation/common/UserInfo.tsx
+++ b/packages/client-core/src/admin/components/moderation/common/UserInfo.tsx
@@ -27,12 +27,13 @@ import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import React from 'react'
 import { UserLastLoginInfo } from './UserLastLoginInfo'
 
-export const UserInfo = ({ userId, usersQuery }) => {
+export const UserInfo = ({ userId, userEmail, usersQuery }) => {
   const user = usersQuery.data.find((user) => user.id == userId)
   return (
     <Text>
       {userId} <br />
-      {user?.name}
+      {user?.name} <br />
+      {userEmail}
       <UserLastLoginInfo userId={userId} />
     </Text>
   )

--- a/packages/common/src/schemas/moderation/moderation.schema.ts
+++ b/packages/common/src/schemas/moderation/moderation.schema.ts
@@ -73,6 +73,8 @@ export const moderationSchema = Type.Object(
       format: 'uuid'
     }),
     referenceNumber: Type.Integer(),
+    reportedUserEmail: Type.Optional(Type.String()),
+    createdByEmail: Type.Optional(Type.String()),
     createdAt: Type.String({ format: 'date-time' }),
     updatedAt: Type.String({ format: 'date-time' })
   },

--- a/packages/server-core/src/moderation/moderation/moderation.resolvers.ts
+++ b/packages/server-core/src/moderation/moderation/moderation.resolvers.ts
@@ -32,14 +32,36 @@ import {
   ModerationQuery,
   ModerationType
 } from '@ir-engine/common/src/schemas/moderation/moderation.schema'
+import { identityProviderPath } from '@ir-engine/common/src/schemas/user/identity-provider.schema'
+import { UserID } from '@ir-engine/common/src/schemas/user/user.schema'
 import { fromDateTimeSql, getDateTimeSql } from '@ir-engine/common/src/utils/datetime-sql'
 import type { HookContext } from '@ir-engine/server-core/declarations'
+
+const resolveUserEmail = async (userId: UserID | undefined, context: HookContext) => {
+  if (!userId) return undefined
+
+  const identityProvider = await context.app.service(identityProviderPath)._find({
+    query: {
+      userId: userId,
+      $limit: 1
+    }
+  })
+  return identityProvider?.data[0]?.email || undefined
+}
 
 export const moderationResolver = resolve<ModerationType, HookContext>({
   createdAt: virtual(async (moderation) => fromDateTimeSql(moderation.createdAt)),
   updatedAt: virtual(async (moderation) => fromDateTimeSql(moderation.updatedAt))
 })
-export const moderationExternalResolver = resolve<ModerationType, HookContext>({})
+
+export const moderationExternalResolver = resolve<ModerationType, HookContext>({
+  reportedUserEmail: virtual(async (moderation: ModerationType, context: HookContext) => {
+    if (context.method === 'find') return resolveUserEmail(moderation.reportedUserId, context)
+  }),
+  createdByEmail: virtual(async (moderation: ModerationType, context: HookContext) => {
+    if (context.method === 'find') return resolveUserEmail(moderation.createdBy, context)
+  })
+})
 export const moderationDataResolver = resolve<ModerationType, HookContext>({
   id: async () => {
     return uuidv4() as ModerationID


### PR DESCRIPTION
* Add user email display in UserInfo component

* use moderation resolver to fetch user email from identity provider and update moderation detail and user info component

* Add user email resolution to moderationExternalResolver

* refactor(moderation): streamline email resolution in moderationResolver

* prevent email resolution for non-find methods in moderationExternalResolver

* refactor(moderation): simplify email resolution logic in moderationExternalResolver

* use _find for fetching user email in report resolver and updated paths

## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
