### PR TITLE
[IR-9162] Add horizontal scroll to Files panel breadcrumb

### DIFF
--- a/packages/editor/src/panels/assets/topbar.tsx
+++ b/packages/editor/src/panels/assets/topbar.tsx
@@ -87,20 +87,22 @@ export function AssetsBreadcrumbs() {
   }
 
   return (
-    <div className="flex items-center gap-2" data-testid="assets-panel-breadcrumbs">
+    <div className="grid grid-cols-[auto_auto] items-center gap-2" data-testid="assets-panel-breadcrumbs">
       <FolderSm onClick={() => handleSelectParentCategory(0)} className="text-base text-text-secondary" />
-      {breadcrumbTrail.map((category, idx) => (
-        <div key={category.path} className="flex items-center">
-          <span
-            className="cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap text-base text-text-secondary"
-            data-testid={`assets-panel-breadcrumb-nested-level-${idx}`}
-            onClick={() => handleSelectParentCategory(idx)}
-          >
-            {category.name}
-          </span>
-          {idx < breadcrumbTrail.length - 1 && <BreadCrumbSlash />}
-        </div>
-      ))}
+      <div className="flex w-full items-center gap-2 overflow-x-auto">
+        {breadcrumbTrail.map((category, idx) => (
+          <div key={category.path} className="flex items-center">
+            <span
+              className="cursor-pointer whitespace-nowrap text-base text-text-secondary"
+              data-testid={`assets-panel-breadcrumb-nested-level-${idx}`}
+              onClick={() => handleSelectParentCategory(idx)}
+            >
+              {category.name}
+            </span>
+            {idx < breadcrumbTrail.length - 1 && <BreadCrumbSlash />}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/packages/editor/src/panels/files/toolbar.tsx
+++ b/packages/editor/src/panels/files/toolbar.tsx
@@ -110,35 +110,37 @@ function BreadcrumbItems() {
   breadcrumbDirectoryFiles = breadcrumbDirectoryFiles.filter((_, idx) => idx > nestedIndex + 1)
 
   return (
-    <div className="flex items-center gap-2">
-      <FolderSm className="text-base text-text-primary" />
-      {breadcrumbDirectoryFiles.map((file, index, arr) => (
-        <Fragment key={index}>
-          {index !== 0 && (
-            <span className="cursor-default items-center text-base text-text-primary">
-              <BreadCrumbSlash />
-            </span>
-          )}
-          {index === arr.length - 1 ? (
-            <span
-              className="cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap text-base text-text-secondary hover:underline"
-              data-testid={'files-panel-breadcrumb-current-directory'}
-            >
-              {file}
-            </span>
-          ) : (
-            <a
-              className="hover: focus: inline-flex cursor-pointer items-center overflow-hidden text-sm text-text-secondary hover:underline"
-              onClick={() => handleBreadcrumbDirectoryClick(file)}
-              data-testid={`files-panel-breadcrumb-nested-level-${index}`}
-            >
-              <span className="cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap text-base text-text-secondary hover:underline">
+    <div className="grid grid-cols-[auto_auto] items-center gap-2">
+      <FolderSm className="min-w-[1rem] text-base text-text-primary" />
+      <div className="flex w-full items-center gap-2 overflow-x-auto">
+        {breadcrumbDirectoryFiles.map((file, index, arr) => (
+          <Fragment key={index}>
+            {index !== 0 && (
+              <span className="cursor-default items-center text-base text-text-primary">
+                <BreadCrumbSlash />
+              </span>
+            )}
+            {index === arr.length - 1 ? (
+              <span
+                className="cursor-pointer whitespace-nowrap text-base text-text-secondary hover:underline"
+                data-testid={'files-panel-breadcrumb-current-directory'}
+              >
                 {file}
               </span>
-            </a>
-          )}
-        </Fragment>
-      ))}
+            ) : (
+              <a
+                className="hover: focus: flex cursor-pointer items-center text-sm text-text-secondary hover:underline"
+                onClick={() => handleBreadcrumbDirectoryClick(file)}
+                data-testid={`files-panel-breadcrumb-nested-level-${index}`}
+              >
+                <span className="cursor-pointer whitespace-nowrap text-base text-text-secondary hover:underline">
+                  {file}
+                </span>
+              </a>
+            )}
+          </Fragment>
+        ))}
+      </div>
     </div>
   )
 }
@@ -363,7 +365,7 @@ export function PanelToolbar({
 
   return (
     <div
-      className="mb-1 flex items-center justify-between gap-2 bg-[#1E1F22] bg-surface-4 px-2 py-1"
+      className="mb-1 grid grid-cols-[max-content_auto_max-content] items-center gap-2 bg-[#1E1F22] bg-surface-4 px-2 py-1"
       data-testid={dataTestIdJson?.topbarId}
     >
       {/* Tools */}
@@ -403,7 +405,7 @@ export function PanelToolbar({
       </div>
 
       {/* Breadcrumb */}
-      <div className="flex items-center justify-between">{breadcrumbComponent}</div>
+      <div className="grid">{breadcrumbComponent}</div>
 
       {/* Search */}
       <div>{searchbar}</div>


### PR DESCRIPTION
## Summary

The breadcrumb in the toolbar for the Assets and Files panel would break down with long breadcrumb lists. This change rearranges some of the toolbar elements and uses CSS Grid so everything in the toolbar stays visible regardless of the breadcrumb width. It also adds a horizontal scroll when the breadcrumb becomes to large, preventing the design from breaking.

![image](https://github.com/user-attachments/assets/0f3e35ff-8904-48e1-8422-02854451c43a)

## References

Closes https://tsu.atlassian.net/browse/IR-9162

## QA Steps
- In Asset panel go to Files
- Add or upload a folder with a deep folder structure
- Click into each folder
- The breadcrumb should update with the list of folder, as the breadcrumb gets too long for the design, a scroll bar should appear to horizontally scroll the breadcrumb list