### PR TITLE
[IR-9163] Make table heading sticky in Files panel

### DIFF
--- a/packages/editor/src/panels/files/fileitem.tsx
+++ b/packages/editor/src/panels/files/fileitem.tsx
@@ -64,7 +64,7 @@ export function TableWrapper({ children, handleSort }: { children: React.ReactNo
   return (
     <table className="w-full border-separate border-spacing-0">
       <thead className="sticky top-0">
-        <tr className="h-8 divide-x divide-[#42454D] bg-ui-background text-left text-text-primary shadow-[inset_0_-1px_0_hsla(224,8%,28%,0.6)]">
+        <tr className="h-8 divide-x divide-[#42454D] bg-ui-background text-left text-text-primary shadow-[inset_0_-1px_0_#42454D]">
           {availableTableColumns
             .filter((header) => selectedTableColumns[header])
             .map((header) => (

--- a/packages/editor/src/panels/files/fileitem.tsx
+++ b/packages/editor/src/panels/files/fileitem.tsx
@@ -62,9 +62,9 @@ export function TableWrapper({ children, handleSort }: { children: React.ReactNo
   const selectedTableColumns = useHookstate(getMutableState(FilesViewModeSettings).list.selectedTableColumns).value
 
   return (
-    <table className="w-full">
-      <thead>
-        <tr className="h-8 divide-x divide-[#42454D] border-b-[0.5px] border-[#42454D] bg-ui-background text-left text-text-primary">
+    <table className="w-full border-separate border-spacing-0">
+      <thead className="sticky top-0">
+        <tr className="h-8 divide-x divide-[#42454D] bg-ui-background text-left text-text-primary shadow-[inset_0_-1px_0_hsla(224,8%,28%,0.6)]">
           {availableTableColumns
             .filter((header) => selectedTableColumns[header])
             .map((header) => (


### PR DESCRIPTION
## Summary

The table heading would scroll with the content, making it hard to know what heading the metadata is associated with. By making the table heading `position: sticky`, it floats the heading above the rest of the content allowing the content to scroll while keeping the heading fixed. Adding `sticky` breaks table borders and the design for the heading, so adding `border-collapse: separate` fixes the issue. Since the bottom border doesnt work with table headings after that, an inset box shadow is used to create the same effect.

![image](https://github.com/user-attachments/assets/8138b06c-429b-4526-b945-4a7934cc075e)

## Reference
- [Stackoverflow: position sticky with border, border-collapse](https://stackoverflow.com/a/61412922/30241587)

## QA Steps
- Open Files panel
- Switch to List view
- Navigate to a folder with a long list of files
- Scroll down the list
- The table heading should stay at the top of the list as the rest of the content scrolls