### PR TITLE
[IR-9183] [IR-9185] Fix overlapping styles in Hierarchy panel

### DIFF
--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -387,6 +387,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
       key={node.depth + ' ' + props.index + ' ' + entity}
       style={fixedSizeListStyles}
       className={twMerge(
+        'flex items-center',
         'cursor-pointer text-text-secondary hover:bg-ui-hover-background hover:text-text-primary',
         'bg-ui-background',
         !visible ? 'text-text-inactive' : '',
@@ -431,7 +432,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
             </button>
           )}
 
-          <div className="flex w-full items-center gap-2 bg-inherit">
+          <div className="grid w-full grid-cols-[max-content_auto_max-content_max-content] items-center gap-2 bg-inherit">
             <IconComponent entity={entity} />
             {renamingNode.entity === entity ? (
               <Input
@@ -453,8 +454,12 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
                 maxLength={64}
               />
             ) : (
-              <div className="min-w-0 flex-1 text-nowrap rounded bg-transparent px-0.5 py-0 ">
-                <span className="text-nowrap text-sm" data-testid="hierarchy-panel-scene-item-name">
+              <div className="grid min-w-0 text-nowrap rounded bg-transparent px-0.5 py-0 ">
+                <span
+                  className="overflow-x-auto text-nowrap text-sm"
+                  style={{ scrollbarWidth: `none` }}
+                  data-testid="hierarchy-panel-scene-item-name"
+                >
                   {currentRenameNode.value}
                 </span>
               </div>


### PR DESCRIPTION
## Summary

The Hierarchy panel has some issues where the styling would breakdown if the panel was smaller width than text length of the children within.

- By changing the layout to use `grid`, the design stays intact when the text overflows and doesnt cause any overlap with the other elements.
- Added horizontal scroll to the text labels so that they can be scrolled when the panel is small

![image](https://github.com/user-attachments/assets/ed149e0a-71a3-4cce-9412-73c44be945d6)

## QA Steps

- Select a Scene
- In the Hierarchy panel, select an entity
- Resize the panel to a small width
- You should be able horizontal scroll the names of each entity
