### PR TITLE
IR-8469 fixing removal of isEditor which broke wizard's worldinjection, which…

### DIFF
--- a/packages/ecs/src/EngineState.ts
+++ b/packages/ecs/src/EngineState.ts
@@ -33,6 +33,8 @@ export const EngineState = defineState({
      */
     userID: '' as UserID,
 
+    /** non-reactive, never updates, use isEditing for that */
+    isEditor: false,
     isEditing: false
   })
 })

--- a/packages/editor/src/functions/EditorControlFunctions.test.tsx
+++ b/packages/editor/src/functions/EditorControlFunctions.test.tsx
@@ -75,6 +75,7 @@ describe('EditorControlFunctions', () => {
     Cache.enabled = true
     createEngine()
     getMutableState(EngineState).isEditing.set(true)
+    getMutableState(EngineState).isEditor.set(true)
     getMutableState(EngineState).userID.set('user' as UserID)
     mockSpatialEngine()
     await Physics.load()

--- a/packages/editor/src/pages/EditorPage.tsx
+++ b/packages/editor/src/pages/EditorPage.tsx
@@ -39,6 +39,7 @@ export const useStudioEditor = () => {
   const engineReady = useEngineInjection()
 
   useEffect(() => {
+    getMutableState(EngineState).isEditor.set(true)
     getMutableState(EngineState).isEditing.set(true)
   }, [])
 


### PR DESCRIPTION
## Summary
fixing removal of isEditor which broke wizard's worldinjection, which broke video playback because isEditing would get overwritten by wizard system being loaded when it shouldn't be

## References
[https://tsu.atlassian.net/browse/IR-8469](https://tsu.atlassian.net/browse/IR-8469)

## QA Steps
add a video, check toggle media controls
save and publish scene
visit published location
see media controls show up