### PR TITLE
Fix avatar collider reactor

### DIFF
--- a/packages/engine/src/avatar/components/AvatarControllerComponent.ts
+++ b/packages/engine/src/avatar/components/AvatarControllerComponent.ts
@@ -30,6 +30,7 @@ import { entityExists, removeEntity, useEntityContext } from '@ir-engine/ecs'
 import {
   defineComponent,
   getComponent,
+  getOptionalComponent,
   hasComponent,
   removeComponent,
   setComponent,
@@ -159,14 +160,12 @@ export const AvatarColliderComponent = defineComponent({
   name: 'AvatarColliderComponent',
   schema: S.Object({ colliderEntity: S.Entity() }),
 
-  reactor() {
-    const entity = useEntityContext()
-    const avatarColliderComponent = getComponent(entity, AvatarColliderComponent)
+  reactor({ entity }) {
     useEffect(() => {
+      const avatarColliderComponent = getOptionalComponent(entity, AvatarColliderComponent)
       return () => {
-        removeEntity(
-          avatarColliderComponent.colliderEntity
-        ) /** @todo Aidan said to figure out why this isn't cleaned up with EntityTree */
+        if (!avatarColliderComponent?.colliderEntity) return
+        removeEntity(avatarColliderComponent.colliderEntity)
       }
     }, [])
   }


### PR DESCRIPTION
## Summary
A quick fix for the avatar collider component reactor cleanup - this will fix all avatars' colliders being removed when one user disconnects/has their avatar removed somehow, as well as multiple colliders building up in the studio.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
