### PR TITLE
Fix avatar animation reactor suspending

### DIFF
--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.tsx
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.tsx
@@ -31,9 +31,9 @@ import {
   defineSystem,
   ECSState,
   Entity,
+  entityExists,
   getComponent,
   setComponent,
-  useComponent,
   useOptionalComponent,
   useQuery
 } from '@ir-engine/ecs'
@@ -242,9 +242,9 @@ const RigReactor = (props: { entity: Entity }) => {
 
   const rig = useOptionalComponent(entity, AvatarRigComponent)
   useEffect(() => {
+    if (!entityExists(entity)) return
     setVisibleComponent(entity, !!rig?.bonesToEntities?.hips?.value && gltfComponent?.progress.value === 100)
   }, [rig?.bonesToEntities.hips, gltfComponent?.progress])
-
   return null
 }
 
@@ -252,14 +252,14 @@ const AnimationReactor = (props: { entity: Entity }) => {
   const entity = props.entity
   const avatarObject = useOptionalComponent(entity, ObjectComponent)
   const loadedAnimations = useMutableState(AnimationState).loadedAnimations
-  const avatarRigComponent = useComponent(entity, AvatarRigComponent)
+  const avatarRigComponent = useOptionalComponent(entity, AvatarRigComponent)
   useEffect(() => {
-    if (!avatarRigComponent.bonesToEntities?.hips.value) return
+    if (!avatarRigComponent?.bonesToEntities?.hips.value) return
     setComponent(entity, AnimationComponent, {
       animations: getAllLoadedAnimations(),
       mixer: new AnimationMixer(getComponent(entity, ObjectComponent) as Group)
     })
-  }, [avatarRigComponent.bonesToEntities?.hips, avatarObject?.value, loadedAnimations])
+  }, [avatarRigComponent?.bonesToEntities?.hips, avatarObject?.value, loadedAnimations])
   return null
 }
 


### PR DESCRIPTION
## Summary
Sometimes removing network entities that posess avatar animation/rig components can cause the reactor to error and suspend. This prevents that from happening so we don't get tposing avatars/npcs.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
