### PR TITLE
[IR-9163] Fix Files table heading z-index bug

### DIFF
--- a/packages/editor/src/panels/files/fileitem.tsx
+++ b/packages/editor/src/panels/files/fileitem.tsx
@@ -63,7 +63,7 @@ export function TableWrapper({
 
   return (
     <table className="w-full border-separate border-spacing-0">
-      <thead className="sticky top-0">
+      <thead className="sticky top-0 z-20">
         <tr className="h-8 divide-x divide-[#42454D] bg-ui-background text-left text-text-primary shadow-[inset_0_-1px_0_#42454D]">
           {availableTableColumns.map((header) => (
             <th
@@ -117,7 +117,7 @@ function FileItemRow({
       key={file?.key}
       ref={(ref) => drag(drop(ref))}
       className={twMerge(
-        'h-9 rounded text-text-primary',
+        'z-10 h-9 rounded text-text-primary',
         isOver && 'border-2 border-gray-400',
         className,
         !isSelected ? 'hover:bg-ui-hover-background' : 'bg-ui-primary'


### PR DESCRIPTION
## Summary

There was a bug with how the `z-index` was handled now that the table heading  in the Files panel has position sticky

<img width="828" alt="image" src="https://github.com/user-attachments/assets/4c08fa95-f66c-47ad-9b50-89804199ca3b" />

## QA Steps
- Open Files panel
- Switch to List view
- Navigate to a folder with a long list of files
- Scroll down the list
- The table heading should stay at the top of the list as the rest of the content scrolls