### PR TITLE
[IR-9183] Fix Hierarchy panel item bg styling

### DIFF
--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -387,7 +387,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
       key={node.depth + ' ' + props.index + ' ' + entity}
       style={fixedSizeListStyles}
       className={twMerge(
-        'flex items-center',
+        'inline-flex w-auto min-w-full items-center',
         'cursor-pointer text-text-secondary hover:bg-ui-hover-background hover:text-text-primary',
         'bg-ui-background',
         !visible ? 'text-text-inactive' : '',
@@ -407,7 +407,10 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
           event.preventDefault()
           setMenu(event, entity)
         }}
-        className={twMerge('flex w-full justify-between bg-inherit', rootEntity === entity ? 'p-2' : 'py-1 pl-10 pr-2')}
+        className={twMerge(
+          'inline-flex h-full min-w-full justify-between bg-inherit',
+          rootEntity === entity ? 'px-2' : 'pl-10 pr-2'
+        )}
       >
         <div
           className={twMerge('h-1', isOverBefore && canDropBefore && 'bg-white')}
@@ -432,7 +435,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
             </button>
           )}
 
-          <div className="grid w-full grid-cols-[max-content_auto_max-content_max-content] items-center gap-2 bg-inherit">
+          <div className="grid h-full w-full grid-cols-[max-content_auto_max-content_max-content] items-center gap-2 bg-inherit">
             <IconComponent entity={entity} />
             {renamingNode.entity === entity ? (
               <Input

--- a/packages/editor/src/panels/hierarchy/hierarchytree.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchytree.tsx
@@ -102,7 +102,7 @@ export function Contents() {
   return (
     <div
       ref={ref}
-      className={twMerge('h-5/6 overflow-hidden', isOver && canDrop && 'border border-dotted')}
+      className={twMerge('h-5/6 overflow-hidden bg-ui-background', isOver && canDrop && 'border border-dotted')}
       data-testid="hierarchy-panel-scene-item-list"
     >
       <FixedSizeList


### PR DESCRIPTION
## Summary

The way the Hierarchy panel list items inherit their width breaks the background color styling when the panel is tiny. This removes the `width: 100%` from those items so they can span the full width of the panel as it extends from scroll.

![image](https://github.com/user-attachments/assets/00029bec-0aae-4457-8c90-da11ae3023c0)

## QA Steps

- Select a Scene
- In the Hierarchy panel, select an entity
- Resize the panel to a small width
- You should be able horizontal scroll the names of each entity