### PR TITLE
[IR-9203] Fix Download container shaking while progress

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1366,7 +1366,7 @@
       "uploadFolder": "Upload Folder",
       "uploadingFiles": "Uploading Files ({{completed}}/{{total}})",
       "fetchingProject": "Fetching Project",
-      "downloadingProject": "Downloading Project ({{completed}}/{{total}})",
+      "downloadingProject": "Downloading Project",
       "search-placeholder": "Search",
       "generatingThumbnails": "Generating Thumbnails ({{count}} remaining)",
       "file": "File",

--- a/packages/editor/src/panels/files/loaders.tsx
+++ b/packages/editor/src/panels/files/loaders.tsx
@@ -118,11 +118,16 @@ export function ProjectDownloadProgress() {
   return (
     <>
       {isDownloading && (
-        <div className="flex h-auto w-full justify-center pb-2 pt-2">
-          <div className="flex w-1/2">
-            <span className="inline-block pr-2 text-xs font-normal leading-none ">
-              {t('editor:layout.filebrowser.downloadingProject', { completed, total })}
-            </span>
+        <div className="flex h-auto w-full justify-center pb-2 pt-1">
+          <div className="flex w-1/2 items-center gap-x-3">
+            <div className="flex gap-x-1 whitespace-nowrap text-center text-xs font-normal leading-none">
+              <div>{t('editor:layout.filebrowser.downloadingProject')}</div>
+              <div className="flex gap-x-1">
+                <span className="min-w-[6em] text-right">{completed}</span>
+                {`/`}
+                <span>{total}</span>
+              </div>
+            </div>
             <div className="basis-1/2">
               <Progress value={progress} />
             </div>


### PR DESCRIPTION
## Summary

The way the Download Project progress container was structured caused the entire container to shake every time the progress text was updated. This PR restructures the elements so that the changing text element doesnt affect the others.

By giving the text a `min-width` based on text size the progress text doesnt force the layout to change.

https://github.com/user-attachments/assets/9b69e9a0-225c-41fe-a19f-85968b15a15a

## QA Steps

- Open a scene
- Open Files or Assets panel
- OPTIONAL: DevTools throttling
  - Open DevTools ("Inspect Element")
  - Go to Performance tab
  - On the right side, under "Environment Settings", set CPU and set Network throttling (4x or more)
- Press Download button in Files/Assets panel
- The "Downloading Project" progress should appear. The progress text should be the only element that resizes
