### PR TITLE
[IR-9435] Fix Files list view table styling

### DIFF
--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -140,34 +140,32 @@ export function Browser() {
           filesQuery?.setLimit(filesQuery.limit + FILES_PAGE_LIMIT)
         }}
       >
-        <div className="relative mt-auto flex h-full w-full flex-wrap gap-2">
-          {sortedFiles.map((file, idx) => {
-            const backgroundColor = idx % 2 === 0 ? 'bg-surface-1' : 'bg-surface-0'
-            return (
-              <FileItem
-                file={{ ...file, ...staticResourceData.value[file?.key] }}
-                onContextMenu={(event) => {
-                  event.preventDefault()
-                  event.stopPropagation()
-                  if (!selectedFiles.value.find((selectedFile) => selectedFile.key === file.key)) {
-                    selectedFiles.set([file])
-                  }
-                  setAnchorEvent(event)
-                }}
-                key={file.key}
-                data-testid="files-panel-file-item"
-                className={`${isListView ? `${backgroundColor}` : ''}`}
-              />
-            )
-          })}
-        </div>
+        {sortedFiles.map((file, idx) => {
+          const backgroundColor = idx % 2 === 0 ? 'bg-surface-1' : 'bg-surface-0'
+          return (
+            <FileItem
+              file={{ ...file, ...staticResourceData.value[file?.key] }}
+              onContextMenu={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                if (!selectedFiles.value.find((selectedFile) => selectedFile.key === file.key)) {
+                  selectedFiles.set([file])
+                }
+                setAnchorEvent(event)
+              }}
+              key={file.key}
+              data-testid="files-panel-file-item"
+              className={`${isListView ? `${backgroundColor}` : ''}`}
+            />
+          )
+        })}
       </InfiniteScroll>
     </>
   )
 
   return (
     <div
-      className={twMerge('h-full overflow-y-scroll bg-surface-1', isFileDropOver ? 'border-2 border-gray-300' : '')}
+      className={twMerge('h-full overflow-y-auto bg-surface-1', isFileDropOver ? 'border-2 border-gray-300' : '')}
       ref={fileDropRef}
       onContextMenu={(event) => {
         event.preventDefault()

--- a/packages/editor/src/panels/files/fileitem.tsx
+++ b/packages/editor/src/panels/files/fileitem.tsx
@@ -72,7 +72,7 @@ export function TableWrapper({
               className="table-cell p-2 text-xs font-normal dark:text-[#A3A3A3]"
             >
               <div className="flex items-center justify-between">
-                <span>{t(`editor:layout.filebrowser.table-list.headers.${header}`)}</span>
+                <span className="whitespace-nowrap">{t(`editor:layout.filebrowser.table-list.headers.${header}`)}</span>
                 <MdKeyboardArrowDown />
               </div>
             </th>

--- a/packages/ui/src/components/tailwind/InfiniteScroll/index.tsx
+++ b/packages/ui/src/components/tailwind/InfiniteScroll/index.tsx
@@ -65,9 +65,9 @@ export default function InfiniteScroll({
   }, [disableEvent])
 
   return (
-    <div style={{ all: 'unset' }}>
+    <>
       {children}
       <span ref={observerRef} style={{ all: 'unset' }} />
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

The `InfiniteScroll` component adds an extra div element to the list of items, which breaks the styling in tables. This breaks the styling in the Files List view

By removing the extra div and using a React fragment `<></>` this problem is avoided.

<img width="836" alt="image" src="https://github.com/user-attachments/assets/64e0c106-fe93-4774-b97c-61e91338d5b6" />

## QA Steps

- Open Files panel
- Select List view
- Each list item should span the full width of the table
