### PR TITLE
fix text overflow on assets filebrowser

### DIFF
--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -205,7 +205,7 @@ export function FileCard({
             {name}
           </Text>
         </Tooltip>
-        <span className="max-w-24 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-[#375DAF]">{info}</span>
+        <span className="w-24 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-[#375DAF]">{info}</span>
       </div>
     </>
   )

--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -205,9 +205,7 @@ export function FileCard({
             {name}
           </Text>
         </Tooltip>
-        <span className="max-w-24 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-[#375DAF]">
-          {info + Date.now()}
-        </span>
+        <span className="max-w-24 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-[#375DAF]">{info}</span>
       </div>
     </>
   )

--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -205,7 +205,9 @@ export function FileCard({
             {name}
           </Text>
         </Tooltip>
-        <span className="text-xs text-[#375DAF]">{info}</span>
+        <span className="max-w-24 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-[#375DAF]">
+          {info + Date.now()}
+        </span>
       </div>
     </>
   )


### PR DESCRIPTION
## Summary

fix the misalignment issue caused by text overflow in my assets file browser resources

## References
closes https://tsu.atlassian.net/browse/IR-9082

## QA Steps

![image](https://github.com/user-attachments/assets/62ad8335-a849-43cd-a8ed-804a8b1b0a72)

