### PR TITLE
[HOTFIX 1.0.2] IR-9441: fixed scroll in materials properties panel

### DIFF
--- a/packages/editor/src/panels/properties/propertyeditor.tsx
+++ b/packages/editor/src/panels/properties/propertyeditor.tsx
@@ -177,7 +177,7 @@ const PropertiesEditor = () => {
   const uuid = lockedNode.value ? lockedNode.value : selectedEntities[selectedEntities.length - 1]
 
   return (
-    <div className="flex h-full flex-col gap-0.5 bg-surface-1">
+    <div className="flex h-full flex-col gap-0.5 overflow-y-auto bg-surface-1">
       {materialUUID && materialEntity ? (
         <ErrorBoundary fallback={<div>Error occured displaying material properties</div>}>
           <Suspense>


### PR DESCRIPTION
## Summary

fixed scroll in properties panel for materials
![Screen Recording 2025-04-30 at 12 40 21 p m](https://github.com/user-attachments/assets/c82bee07-6aed-4771-b149-7b87e7206b07)

https://tsu.atlassian.net/browse/IR-9441


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Open any existing scene.
- Go to the Materials tab
- Select any material
- Try to scroll within Properties tab
