### PR TITLE
IR-9113: Add engine version to product surfaces

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -452,6 +452,7 @@
       "webmanifestLink": "Webmanifest",
       "swScriptLink": "service-worker.js",
       "releaseName": "Release Name",
+      "releaseVersion": "Release",
       "email": {
         "header": "Email",
         "subtitle": "Edit Email Settings"

--- a/packages/client-core/src/common/components/ProfilePill/index.tsx
+++ b/packages/client-core/src/common/components/ProfilePill/index.tsx
@@ -30,7 +30,7 @@ import { Button } from '@ir-engine/ui'
 import { Popup } from '@ir-engine/ui/src/components/tailwind/Popup'
 import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import ThemeToggle from '@ir-engine/ui/src/primitives/tailwind/ThemeToggle'
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiPencil } from 'react-icons/hi2'
 import { MdOutlineKeyboardArrowDown } from 'react-icons/md'
@@ -38,7 +38,7 @@ import { useUserAvatarThumbnail } from '../../../hooks/useUserAvatarThumbnail'
 import AvatarSelectMenu from '../../../user/menus/avatar/AvatarSelectMenu'
 import { AuthState } from '../../../user/services/AuthService'
 import { ModalState } from '../../services/ModalState'
-import { ProjectService, ProjectState } from '../../services/ProjectService'
+import { ProjectState } from '../../services/ProjectService'
 import { ThemeState } from '../../services/ThemeService'
 
 const ProfilePill = () => {
@@ -54,11 +54,6 @@ const ProfilePill = () => {
   } | null>(null)
 
   const projectState = useMutableState(ProjectState)
-  ProjectService.useAPIListeners()
-
-  useEffect(() => {
-    ProjectService.getBuilderInfo()
-  }, [])
 
   const onAvatarSelectClose = () => {
     if (avatarSelectMenuRef.current) {

--- a/packages/client-core/src/common/components/ProfilePill/index.tsx
+++ b/packages/client-core/src/common/components/ProfilePill/index.tsx
@@ -28,17 +28,21 @@ import { identityProviderPath } from '@ir-engine/common/src/schema.type.module'
 import { getMutableState, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import { Popup } from '@ir-engine/ui/src/components/tailwind/Popup'
+import Text from '@ir-engine/ui/src/primitives/tailwind/Text'
 import ThemeToggle from '@ir-engine/ui/src/primitives/tailwind/ThemeToggle'
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { HiPencil } from 'react-icons/hi2'
 import { MdOutlineKeyboardArrowDown } from 'react-icons/md'
 import { useUserAvatarThumbnail } from '../../../hooks/useUserAvatarThumbnail'
 import AvatarSelectMenu from '../../../user/menus/avatar/AvatarSelectMenu'
 import { AuthState } from '../../../user/services/AuthService'
 import { ModalState } from '../../services/ModalState'
+import { ProjectService, ProjectState } from '../../services/ProjectService'
 import { ThemeState } from '../../services/ThemeService'
 
 const ProfilePill = () => {
+  const { t } = useTranslation()
   const user = getMutableState(AuthState).user
   const avatarThumbnail = useUserAvatarThumbnail(user.value.id)
   const identityProvidersQuery = useFind(identityProviderPath)
@@ -48,6 +52,13 @@ const ProfilePill = () => {
   const avatarSelectMenuRef = useRef<{
     handleClose: () => Promise<void>
   } | null>(null)
+
+  const projectState = useMutableState(ProjectState)
+  ProjectService.useAPIListeners()
+
+  useEffect(() => {
+    ProjectService.getBuilderInfo()
+  }, [])
 
   const onAvatarSelectClose = () => {
     if (avatarSelectMenuRef.current) {
@@ -111,6 +122,11 @@ const ProfilePill = () => {
           </div>
         </div>
         <hr className="mb-1 mt-4 w-full border border-ui-outline" />
+        <div className="flex-1 text-right">
+          <Text className="text-sm">
+            {t('admin:components.setting.releaseVersion')}: {projectState.builderInfo.engineVersion.value}
+          </Text>
+        </div>
       </div>
     </Popup>
   )

--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -68,7 +68,7 @@ export const ProjectState = defineState({
     failed: false,
     builderTags: [] as Array<ProjectBuilderTagsType>,
     builderInfo: {
-      engineVersion: '',
+      engineVersion: '1.0.2',
       engineCommit: ''
     },
     refreshingGithubRepoAccess: false

--- a/packages/client-core/src/user/menus/ProfileMenu.test.tsx
+++ b/packages/client-core/src/user/menus/ProfileMenu.test.tsx
@@ -29,9 +29,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { API } from '@ir-engine/common'
 import {
   avatarPath,
+  builderInfoPath,
   clientSettingPath,
   engineSettingPath,
   identityProviderPath,
+  projectPath,
   projectSettingPath,
   scopePath,
   staticResourcePath,
@@ -97,6 +99,12 @@ describe('ProfileMenu component', () => {
             }
           ]
         }
+      ],
+      [builderInfoPath]: [
+        {
+          engineVersion: '1.0.0',
+          engineCommit: '1234567890'
+        }
       ]
     }
 
@@ -141,7 +149,9 @@ describe('ProfileMenu component', () => {
       [scopePath]: createService(scopePath),
       [clientSettingPath]: createService(clientSettingPath),
       [identityProviderPath]: createService(identityProviderPath),
-      [engineSettingPath]: createService(engineSettingPath)
+      [engineSettingPath]: createService(engineSettingPath),
+      [projectPath]: createService(projectPath),
+      [builderInfoPath]: createService(builderInfoPath)
     }
     eventDispatcher = new EventDispatcher()
     ;(API.instance as any) = {

--- a/packages/client-core/src/user/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/menus/ProfileMenu.tsx
@@ -82,6 +82,7 @@ import { twMerge } from 'tailwind-merge'
 import { initialAuthState, initialOAuthConnectedState } from '../../common/initialAuthState'
 import { ModalState } from '../../common/services/ModalState'
 import { NotificationService } from '../../common/services/NotificationService'
+import { ProjectService, ProjectState } from '../../common/services/ProjectService'
 import { useUserAvatarThumbnail } from '../../hooks/useUserAvatarThumbnail'
 import { useZendesk } from '../../hooks/useZendesk'
 import { LocationState } from '../../social/services/LocationService'
@@ -156,6 +157,13 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
   const originallyAgeVerified = useHookstate(checked18OrOver)
   const originallyAcceptedTOS = useHookstate(acceptedTOS).value
   const currentLocation = getState(LocationState).currentLocation.location
+
+  const projectState = useMutableState(ProjectState)
+  ProjectService.useAPIListeners()
+
+  useEffect(() => {
+    ProjectService.getBuilderInfo()
+  }, [])
 
   const projectSettings = useFind(projectSettingPath, {
     query: {
@@ -877,24 +885,32 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
         </div>
       )}
 
-      <div className="mt-1 flex w-full items-center justify-center gap-x-2 smh:mt-5">
-        <a href={clientSetting?.privacyPolicy} data-testid="profile-menu-privacy-policy-link" target="_blank">
-          <Text className="text-center text-text-primary" fontSize="sm">
-            {t('user:usermenu.profile.privacyPolicy')}
-          </Text>
-        </a>
-        {creatorPrivacyPolicyUrl?.value && (
-          <>
+      <div className="mt-1 flex w-full items-center justify-evenly gap-x-2 smh:mt-5">
+        <div className="flex-1"></div>
+        <div className="flex-1">
+          <a href={clientSetting?.privacyPolicy} data-testid="profile-menu-privacy-policy-link" target="_blank">
             <Text className="text-center text-text-primary" fontSize="sm">
-              |
+              {t('user:usermenu.profile.privacyPolicy')}
             </Text>
-            <a href={creatorPrivacyPolicyUrl.value} target="_blank">
+          </a>
+          {creatorPrivacyPolicyUrl?.value && (
+            <>
               <Text className="text-center text-text-primary" fontSize="sm">
-                {t('user:usermenu.profile.creatorPrivacyPolicy')}
+                |
               </Text>
-            </a>
-          </>
-        )}
+              <a href={creatorPrivacyPolicyUrl.value} target="_blank">
+                <Text className="text-center text-text-primary" fontSize="sm">
+                  {t('user:usermenu.profile.creatorPrivacyPolicy')}
+                </Text>
+              </a>
+            </>
+          )}
+        </div>
+        <div className="flex-1 text-right">
+          <Text className="text-sm">
+            {t('admin:components.setting.releaseVersion')}: {projectState.builderInfo.engineVersion.value}
+          </Text>
+        </div>
       </div>
     </div>
   )

--- a/packages/client-core/src/user/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/menus/ProfileMenu.tsx
@@ -82,7 +82,7 @@ import { twMerge } from 'tailwind-merge'
 import { initialAuthState, initialOAuthConnectedState } from '../../common/initialAuthState'
 import { ModalState } from '../../common/services/ModalState'
 import { NotificationService } from '../../common/services/NotificationService'
-import { ProjectService, ProjectState } from '../../common/services/ProjectService'
+import { ProjectState } from '../../common/services/ProjectService'
 import { useUserAvatarThumbnail } from '../../hooks/useUserAvatarThumbnail'
 import { useZendesk } from '../../hooks/useZendesk'
 import { LocationState } from '../../social/services/LocationService'
@@ -159,11 +159,6 @@ const ProfileMenu = ({ hideLogin, onClose }: Props): JSX.Element => {
   const currentLocation = getState(LocationState).currentLocation.location
 
   const projectState = useMutableState(ProjectState)
-  ProjectService.useAPIListeners()
-
-  useEffect(() => {
-    ProjectService.getBuilderInfo()
-  }, [])
 
   const projectSettings = useFind(projectSettingPath, {
     query: {


### PR DESCRIPTION
## Summary
Devs and QA often have disconnects when it comes to what version of the engine any given Multitenancy environments are using during our rapid iterative processes. Displaying the version number for the engine that is currently deployed to an environment will help to relieve this and eliminate confusion across teams.

Per Slack discussion w/Josh Field and Daniel Belmes we are going to hard code current version of 1.0.2 in the meantime.

## Subtasks Checklist

## Breaking Changes

## References
https://tsu.atlassian.net/browse/IR-9113
https://github.com/theinfinitereality/irpro-multitenancy/pull/969

## QA Steps
- Go to Dashboard, Location viewer, and Editor to view Engine Version

Studio editor:
![image](https://github.com/user-attachments/assets/c3dce7ed-cd7a-4a02-89ea-4c7d5c1891ea)

Dashboard:
![image](https://github.com/user-attachments/assets/f625ee77-a24f-452e-8dc0-38973a8cda60)

Viewer:
![image](https://github.com/user-attachments/assets/2c625fc4-3df6-450d-9af5-9d75c8e24bc2)
