### PR TITLE
IR-7949 rigidbody nesting issue

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -80,6 +80,8 @@
     "maxUploadFileSizeExceed": "That file size is too large. Please upload a file under {{maxFileSizeToUploadMB}}MB. The following files are too large: {{filesNames}}"
   },
   "warnings": {
+    "addChildToGlbError": "Re-parenting was canceled - Adding children to glb model prefabs is currently not supported.",
+    "rigidbodyDropWarning" : "Re-parenting was canceled - Entities with a rigidbody are not allowed to have an ancestor with a rigidbody. Please remove one of the rigidbodies and try again.",
     "sceneComplexity": "Scene complexity is {{sceneComplexity}}. Consider optimizing your scene for better performance."
   },
   "viewport": {

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -98,6 +98,7 @@ function toValidHierarchyNodeName(entity: Entity, name: string): string {
 
 export default React.memo(function HierarchyTreeNode(props: ListChildComponentProps<undefined>) {
   const showGlbChildrenFeatureFlag = useMutableState(EditorHelperState).showGlbChildren.value
+
   const { t } = useTranslation()
   const nodes = useHierarchyNodes()
   const node = nodes[props.index]
@@ -183,7 +184,13 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
     isOver: isOverAfter,
     dropTarget: afterDropTarget
   } = useHierarchyTreeDrop(node, 'After')
-  const { canDrop: canDropOn, isOver: isOverOn, dropTarget: onDropTarget } = useHierarchyTreeDrop(node, 'On')
+  const {
+    canDrop: canDropOn,
+    isOver: isOverOn,
+    dropTarget: onDropTarget,
+    rigidbodyParentingWarning
+  } = useHierarchyTreeDrop(node, 'On')
+  const showRedState = (!showGlbChildrenFeatureFlag || rigidbodyParentingWarning) && isOverOn && canDropOn
 
   useEffect(() => {
     preview(getEmptyImage(), { captureDraggingState: true })
@@ -393,7 +400,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         !visible ? 'text-text-inactive' : '',
         selected ? 'rounded-sm border border-ui-select-outline bg-ui-select-background text-text-primary' : '',
         isOverOn && canDropOn ? 'border border-dotted' : '',
-        !showGlbChildrenFeatureFlag && isOverOn && !canDropOn ? 'border border-dotted text-text-error' : ''
+        showRedState ? 'border border-dotted text-text-error' : ''
       )}
       data-testid="hierarchy-panel-scene-item"
     >
@@ -525,17 +532,9 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
               onClick={onHideUnhideNode}
             >
               {visible ? (
-                <PiEyeBold
-                  className={`${
-                    !showGlbChildrenFeatureFlag && isOverOn && !canDropOn ? 'text-text-inactive' : 'text-base'
-                  }`}
-                />
+                <PiEyeBold className={`${showRedState ? 'text-text-inactive' : 'text-base'}`} />
               ) : (
-                <PiEyeClosedBold
-                  className={`${
-                    !showGlbChildrenFeatureFlag && isOverOn && !canDropOn ? 'text-text-inactive' : 'text-base'
-                  }`}
-                />
+                <PiEyeClosedBold className={`${showRedState ? 'text-text-inactive' : 'text-base'}`} />
               )}
             </button>
           </div>

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -27,7 +27,10 @@ import {
   Entity,
   entityExists,
   EntityTreeComponent,
+  getAncestorWithComponents,
+  getChildrenWithComponents,
   getComponent,
+  hasComponent,
   isAncestor,
   Layers,
   QuerySubReactor,
@@ -40,6 +43,7 @@ import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { SourceComponent } from '@ir-engine/engine/src/scene/components/SourceComponent'
 import { getMutableState, none, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
+import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent.tsx'
 import React, { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
 import { DropTargetMonitor, useDrop } from 'react-dnd'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -67,6 +71,30 @@ type DragItemType = {
   type: (typeof ItemTypes)[keyof typeof ItemTypes]
   value: Entity | Entity[]
   multiple: boolean
+}
+
+function containsRigidbodyInChildren(entity: Entity): boolean {
+  return getChildrenWithComponents(entity, [RigidBodyComponent]).length > 0 || hasComponent(entity, RigidBodyComponent)
+}
+function containsRigidbodyInParent(entity: Entity): boolean {
+  return getAncestorWithComponents(entity, [RigidBodyComponent], true, true) !== UndefinedEntity
+}
+function bothContainsRigidbody(dragEntity: Entity | Entity[], targetEntity: Entity): boolean {
+  const targetHasRb = containsRigidbodyInParent(targetEntity)
+
+  //early out false for comparing against self target
+  if (
+    !targetHasRb ||
+    (!Array.isArray(dragEntity) && targetEntity === dragEntity) ||
+    (Array.isArray(dragEntity) && dragEntity.some((dragListEntity) => dragListEntity === targetEntity))
+  )
+    return false
+
+  return Array.isArray(dragEntity)
+    ? //if it is an array, check for any that violate this
+      targetHasRb && dragEntity.some((dragListEntity) => containsRigidbodyInChildren(dragListEntity))
+    : //otherwise only check single entity
+      targetHasRb && containsRigidbodyInChildren(dragEntity)
 }
 
 const didHierarchyChange = (prev: HierarchyTreeNodeType[], curr: HierarchyTreeNodeType[]) => {
@@ -240,7 +268,8 @@ export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' 
     if (item.type === ItemTypes.Node) {
       if (node?.entity) {
         const entityTreeComponent = getComponent(node.entity, EntityTreeComponent)
-        if (place === 'On' && isEntityGlb(node.entity)) return false
+
+        if ((place === 'On' && isEntityGlb(node.entity)) || bothContainsRigidbody(item.value, node.entity)) return false
         if (place === 'On' || !!entityTreeComponent.parentEntity) return true
       }
 

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -22,6 +22,7 @@ Original Code is the Infinite Reality Engine team.
 All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2023 
 Infinite Reality Engine. All Rights Reserved.
 */
+import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService.tsx'
 import { VALID_HEIRARCHY_SEARCH_REGEX } from '@ir-engine/common/src/regex'
 import {
   Entity,
@@ -47,6 +48,7 @@ import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/Ri
 import React, { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
 import { DropTargetMonitor, useDrop } from 'react-dnd'
 import { useHotkeys } from 'react-hotkeys-hook'
+import { useTranslation } from 'react-i18next'
 import useUpload from '../../components/assets/useUpload'
 import { DnDFileType, FileDataType, ItemTypes, SupportedFileTypes } from '../../constants/AssetTypes'
 import { addMediaNode } from '../../functions/addMediaNode'
@@ -95,6 +97,11 @@ function bothContainsRigidbody(dragEntity: Entity | Entity[], targetEntity: Enti
       targetHasRb && dragEntity.some((dragListEntity) => containsRigidbodyInChildren(dragListEntity))
     : //otherwise only check single entity
       targetHasRb && containsRigidbodyInChildren(dragEntity)
+}
+
+function isGlbIssue(entity: Entity): boolean {
+  //@todo update this when we support adding children to GLB based prefabs
+  return isEntityGlb(entity) //&& !getMutableState(EditorHelperState).showGlbChildren.value
 }
 
 const didHierarchyChange = (prev: HierarchyTreeNodeType[], curr: HierarchyTreeNodeType[]) => {
@@ -253,6 +260,9 @@ export const useNodeCollapseExpand = () => {
 export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' | 'Before' | 'After') => {
   const onUpload = useUpload(uploadOptions)
   const rootEntity = useMutableState(EditorState).rootEntity.value
+  const { t } = useTranslation()
+  const [rigidbodyParentingWarning, setRigidbodyParentingWarning] = useState(false)
+  const [lastTargetNode, setTargetNode] = useState(UndefinedEntity)
 
   const canDropItem = (item: DragItemType, monitor: DropTargetMonitor): boolean => {
     if (!monitor.isOver({ shallow: true })) {
@@ -269,8 +279,22 @@ export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' 
       if (node?.entity) {
         const entityTreeComponent = getComponent(node.entity, EntityTreeComponent)
 
-        if ((place === 'On' && isEntityGlb(node.entity)) || bothContainsRigidbody(item.value, node.entity)) return false
+        if (place === 'On') {
+          const updateRigidbodyCheck = node.entity !== lastTargetNode
+          setTargetNode(node.entity)
+
+          if (isGlbIssue(node.entity)) return true
+          // Check rigidbody condition and update state
+          const hasRigidbodyWarning =
+            (!updateRigidbodyCheck && rigidbodyParentingWarning) ||
+            (updateRigidbodyCheck && bothContainsRigidbody(item.value, node.entity))
+
+          setRigidbodyParentingWarning(hasRigidbodyWarning)
+          if (hasRigidbodyWarning) return true
+        }
         if (place === 'On' || !!entityTreeComponent.parentEntity) return true
+      } else {
+        setTargetNode(UndefinedEntity)
       }
 
       const entity = node?.entity || rootEntity
@@ -283,6 +307,22 @@ export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' 
   }
 
   const dropItem = (item: FileDataType | DnDFileType | DragItemType, monitor: DropTargetMonitor): void => {
+    if (node?.entity) {
+      //check for glb issue (adding child to glb prefab)
+      if (isGlbIssue(node.entity)) {
+        NotificationService.dispatchNotify(t('editor:warnings.addChildToGlbError'), { variant: 'warning' })
+        return
+      }
+      // Check if this is a rigidbody drop case that needs special handling
+      if ('type' in item && item.type === ItemTypes.Node && place === 'On') {
+        // If this is a rigidbody drop onto another rigidbody hierarchy, show warning and exit early
+        if (bothContainsRigidbody((item as DragItemType).value, node.entity)) {
+          NotificationService.dispatchNotify(t('editor:warnings.rigidbodyDropWarning'), { variant: 'warning' })
+          return // Exit early, don't process the drop
+        }
+      }
+    }
+
     let parentNode: Entity | undefined
     let beforeNode: Entity = UndefinedEntity
     let afterNode: Entity = UndefinedEntity
@@ -366,7 +406,7 @@ export const useHierarchyTreeDrop = (node?: HierarchyTreeNodeType, place?: 'On' 
     })
   })
 
-  return { canDrop, isOver, dropTarget }
+  return { canDrop, isOver, dropTarget, rigidbodyParentingWarning }
 }
 
 const useSimplifiedHotkey = (key: string, onAction: () => void) => {


### PR DESCRIPTION
## Summary
adding toast notification and disabling reparenting drag/drop in hierarchy when the result will mean a rigidbody entity is an ancestor of another rigidbody entity

also adding toast notification to the glb add child issue to match

## References
[https://tsu.atlassian.net/browse/IR-7949](https://tsu.atlassian.net/browse/IR-7949)

## QA Steps
Case: rigidbody parenting
1. create two entities, both with rigidbodies
2. drag one over the other
3. observe it turn red on the targeted entity
4. release over
5. observe the toast notification
6. try this with rigidbodies nested below your dragged entity hierarchy or above your targeted entity such that the result would have rigidbodies where one is the ancestor of the other

Case: attempting to add child to glb 
1. try to drag any entity onto the platform entity
OR
1. try to drag any entity onto a prefab you instantiated from a GLB file (not GLTF)
2. observe the hover behavior and the ondrop toast notification warning