### PR TITLE
IR-9467: CSS Regression between panels in studio

### DIFF
--- a/packages/editor/src/panels/viewport/index.tsx
+++ b/packages/editor/src/panels/viewport/index.tsx
@@ -154,7 +154,7 @@ function ViewportContainer() {
   return (
     <ViewportDnD>
       <div className="relative z-30 flex h-full w-full flex-col">
-        <div ref={toolbarRef} className="z-10 flex gap-1 bg-surface-4 px-1 py-0.5">
+        <div ref={toolbarRef} className="z-10 flex gap-1 bg-surface-4 px-1 py-1">
           <TransformSpaceTool />
           {transformPivotFeatureFlag && <TransformPivotTool />}
           <GridTool />

--- a/packages/editor/src/panels/viewport/tools/PlayModeTool.tsx
+++ b/packages/editor/src/panels/viewport/tools/PlayModeTool.tsx
@@ -40,7 +40,7 @@ const PlayModeTool: React.FC = () => {
   }
 
   return (
-    <div id="preview" className="flex items-center">
+    <div id="preview" className="flex items-center px-2">
       <Tooltip
         title={
           engineState.isEditing.value


### PR DESCRIPTION
## Summary
The current studio UI has a css regression where the panels have no padding or differentiation between them. 

## Subtasks Checklist

## Breaking Changes

## References
https://tsu.atlassian.net/browse/IR-9467

## QA Steps
Check the studio panels

![image](https://github.com/user-attachments/assets/2f774f1f-366e-4238-bab3-c1f310b6c976)

