### PR TITLE
[IR-9743] Connect color scheme to system settings

### DIFF
--- a/packages/client-core/src/common/services/ThemeService.tsx
+++ b/packages/client-core/src/common/services/ThemeService.tsx
@@ -299,10 +299,16 @@ export const themes: Record<string, Partial<CSSClasses>> = {
   dark: darkTheme
 }
 
+export const checkDarkMode = () => window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+
 export const ThemeState = defineState({
   name: 'ThemeState',
-  initial: {
-    theme: 'dark' as 'light' | 'dark'
+  initial: () => {
+    const initialDarkMode = checkDarkMode()
+
+    return {
+      theme: (initialDarkMode ? 'dark' : 'light') as 'light' | 'dark'
+    }
   },
 
   setTheme: (theme: 'light' | 'dark') => {
@@ -324,6 +330,21 @@ export const updateTheme = (themeClasses: Partial<CSSClasses>) => {
 export const useThemeProvider = () => {
   const themeState = useMutableState(ThemeState)
   const themeClasses = themes[themeState.theme.value]
+
+  useEffect(() => {
+    const matchMedia = window.matchMedia('(prefers-color-scheme: dark)')
+    const listener = (event) => {
+      const newColorScheme = event.matches ? 'dark' : 'light'
+
+      ThemeState.setTheme(newColorScheme)
+    }
+
+    matchMedia.addEventListener('change', listener)
+
+    return () => {
+      matchMedia.removeEventListener('change', listener)
+    }
+  }, [])
 
   useEffect(() => {
     updateTheme(themeClasses)


### PR DESCRIPTION
## Summary

The color scheme options arent connected to the user's system settings. By using `window.matchMedia`, the preferred color scheme can be inherited directly into our theme service. This gives the user the correct color scheme initially, but also the color scheme stays in sync when the system settings change.

https://github.com/user-attachments/assets/43a18601-5e19-464a-815f-a64bb5faa70d

## QA Steps

- Open editor
- Open system settings for changing color scheme (On Mac: Settings -> Appearance)
- Toggle between Dark or Light mode in system settings. The editor should swap the UI colors.
