### PR TITLE
[IR-9187] Add grouping for file name upload errors

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -70,6 +70,8 @@
     "uploadAborted": "Upload aborted",
     "uploadFailed": "Upload failed {{reason}}",
     "fileUploadFailed": "File upload failed; {{reason}}",
+    "fileUploadFailedMultiple": "Mulitple file uploads failed.. {{reason}}",
+    "fileNameInvalidMultiple": "Mulitple invalid file names.. {{reason}}",
     "assetDeletionFail": "Asset deletion failed. {{reason}}",
     "projectAssetDeletionFail": "Project Asset deletion failed. {{reason}}",
     "networkError": "Network Error: {{status}}. {{text}}",

--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -110,6 +110,7 @@ function isValidFileType(file): { isValid: boolean; errorMessage?: string } {
 export function validatedFiles(files: FileList | File[]): File[] {
   const { maxFileSizeToUpload } = config.client
   const invalidSizeFiles: string[] = []
+  const invalidNameErrors: string[] = []
   const newFiles: File[] = []
 
   for (const file of files) {
@@ -132,8 +133,8 @@ export function validatedFiles(files: FileList | File[]): File[] {
     // Check filename
     const fileNameWithOutExtension = file.name.replace(/\.[^/.]+$/, '')
     const resultFileNameValid = isValidFileName(fileNameWithOutExtension)
-    if (!resultFileNameValid.isValid) {
-      NotificationService.dispatchNotify(resultFileNameValid.error, { variant: 'warning', autoHideDuration: 20000 })
+    if (!resultFileNameValid.isValid && resultFileNameValid.error) {
+      invalidNameErrors.push(resultFileNameValid.error)
       continue
     }
     newFiles.push(file)
@@ -147,6 +148,19 @@ export function validatedFiles(files: FileList | File[]): File[] {
       }) as string,
       { variant: 'warning' }
     )
+  }
+
+  if (invalidNameErrors.length) {
+    if (invalidNameErrors.length > 3) {
+      NotificationService.dispatchNotify(
+        i18n.t('editor:errors.fileNameInvalidMultiple', { reason: invalidNameErrors[0] }) as string,
+        { variant: 'warning', autoHideDuration: 20000 }
+      )
+    } else {
+      invalidNameErrors.map((error) => {
+        NotificationService.dispatchNotify(error, { variant: 'warning', autoHideDuration: 20000 })
+      })
+    }
   }
 
   return newFiles
@@ -226,6 +240,8 @@ export const handleUploadFiles = (
 ): Promise<string[]> => {
   const { ktx2: compressedImage } = CommonKnownContentTypes
   const importSettingsState = getMutableState(ImportSettingsState)
+  const errors: Error[] = []
+
   return Promise.all(
     Array.from(files).map(async (file) => {
       file = cleanFileNameFile(file)
@@ -313,14 +329,29 @@ export const handleUploadFiles = (
             return checkStaticResourceThumbnail(file)
           }
         })
-        .catch((e) => {
+        .catch((e: Error) => {
+          errors.push(e)
+        })
+    })
+  ).then((promise) => {
+    if (errors.length) {
+      if (errors.length > 3) {
+        NotificationService.dispatchNotify(
+          i18n.t('editor:errors.fileUploadFailedMultiple', { reason: errors[0] }) as string,
+          { variant: 'error', autoHideDuration: 20000 }
+        )
+      } else {
+        errors.map((e) => {
           NotificationService.dispatchNotify(i18n.t('editor:errors.fileUploadFailed', { reason: e }) as string, {
             variant: 'error',
             autoHideDuration: 20000
           })
         })
-    })
-  )
+      }
+    }
+
+    return promise
+  })
 }
 
 /**


### PR DESCRIPTION
## Summary

When uploading a folder with spaces in it's name multiple notifications are triggered because the directory name. There is no direct way to get the actual folder name and test it for spaces, so I added a way to group invalid file name errors and then only trigger notifications for the group or a few errors

![image](https://github.com/user-attachments/assets/9cc77ca6-e3e9-46a1-a46e-4b9d9094c272)

## QA Steps

- Open a project
- Go to files panel
- Download the project files
- Unzip files
- Rename folder something with spaces ("test folder")
- Upload folder
- There should be several warnings, but the last error should be 1 error mentioning that "Multiple invalid file names" threw errors