### PR TITLE
IR-9060 - Remove stripe-client-setting service from stripe project and use project-setting service directly

### DIFF
--- a/packages/common/src/schemas/setting/project-setting.schema.ts
+++ b/packages/common/src/schemas/setting/project-setting.schema.ts
@@ -83,7 +83,12 @@ export const projectSettingQuerySchema = Type.Intersect(
   [
     querySyntax(projectSettingQueryProperties),
     // Add additional query properties here
-    Type.Object({}, { additionalProperties: false })
+    Type.Object(
+      {
+        projectName: Type.Optional(Type.String())
+      },
+      { additionalProperties: false }
+    )
   ],
   { additionalProperties: false }
 )

--- a/packages/common/src/schemas/setting/project-setting.schema.ts
+++ b/packages/common/src/schemas/setting/project-setting.schema.ts
@@ -85,6 +85,7 @@ export const projectSettingQuerySchema = Type.Intersect(
     // Add additional query properties here
     Type.Object(
       {
+        paginate: Type.Optional(Type.Boolean()),
         projectName: Type.Optional(Type.String())
       },
       { additionalProperties: false }

--- a/packages/server-core/src/setting/project-setting/project-setting.hooks.ts
+++ b/packages/server-core/src/setting/project-setting/project-setting.hooks.ts
@@ -25,17 +25,21 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { hooks as schemaHooks } from '@feathersjs/schema'
 import setLoggedInUserInData from '@ir-engine/server-core/src/hooks/set-loggedin-user-in-body'
-import { iff, iffElse, isProvider } from 'feathers-hooks-common'
+import { discardQuery, iff, iffElse, isProvider } from 'feathers-hooks-common'
 
 import {
   projectSettingDataValidator,
   projectSettingPatchValidator,
+  projectSettingPath,
   projectSettingQueryValidator
 } from '@ir-engine/common/src/schemas/setting/project-setting.schema'
 
+import { projectPath } from '@ir-engine/common/src/schemas/projects/project.schema'
+import { HookContext } from '../../../declarations'
 import checkProjectPermission from '../../hooks/check-project-permission'
 import checkScope from '../../hooks/check-scope'
 import enableClientPagination from '../../hooks/enable-client-pagination'
+import makeQueryJoinable from '../../hooks/make-query-joinable'
 import setInContext from '../../hooks/set-in-context'
 import verifyProjectPermission from '../../hooks/verify-project-permission'
 import {
@@ -45,6 +49,28 @@ import {
   projectSettingQueryResolver,
   projectSettingResolver
 } from './project-setting.resolvers'
+
+/**
+ * Hook used to handle project name in find query.
+ * @param context
+ * @returns
+ */
+export const handleProjectName = async (context: HookContext) => {
+  const projectName = context.params.query?.projectName
+
+  if (!projectName) return context
+
+  discardQuery('projectName')(context)
+
+  await makeQueryJoinable(projectSettingPath)(context)
+
+  const query = context.service.createQuery(context.params)
+
+  query.join(projectPath, `${projectPath}.id`, '=', `${projectSettingPath}.projectId`)
+  query.where(`${projectPath}.name`, '=', projectName)
+
+  context.params.knex = query
+}
 
 export default {
   around: {
@@ -68,7 +94,8 @@ export default {
           [],
           [iffElse(checkProjectPermission(['owner', 'editor']), [], setInContext('type', 'public')) as any]
         )
-      )
+      ),
+      handleProjectName
     ],
     get: [],
     create: [

--- a/packages/server-core/src/setting/project-setting/project-setting.hooks.ts
+++ b/packages/server-core/src/setting/project-setting/project-setting.hooks.ts
@@ -35,6 +35,7 @@ import {
 
 import checkProjectPermission from '../../hooks/check-project-permission'
 import checkScope from '../../hooks/check-scope'
+import enableClientPagination from '../../hooks/enable-client-pagination'
 import setInContext from '../../hooks/set-in-context'
 import verifyProjectPermission from '../../hooks/verify-project-permission'
 import {
@@ -59,6 +60,7 @@ export default {
       schemaHooks.resolveQuery(projectSettingQueryResolver)
     ],
     find: [
+      iff(isProvider('external'), enableClientPagination()),
       iff(
         isProvider('external'),
         iffElse(


### PR DESCRIPTION
## Summary

Use project-setting service instead of stripe-client-setting service, which has been removed.

## Jira

[IR-9060] (https://tsu.atlassian.net/browse/IR-9060)

[IR-9060]: https://tsu.atlassian.net/browse/IR-9060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ