### PR TITLE
Hierarchy Tree Hotkeys

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1,4 +1,4 @@
-{ 
+{
   "loading": "Loading Project",
   "loadingNode": "Loading {{name}} Editor...",
   "loadingError": "Error loading Project",
@@ -86,7 +86,9 @@
     "unsupported-unknown-file": "Please upload a valid 3D, Image, Audio, or Video file."
   },
   "warnings": {
-    "sceneComplexity": "Scene complexity is {{sceneComplexity}}. Consider optimizing your Scene for better performance. Refer to our docs for optimization guidelines."
+    "addChildToGlbError": "Re-parenting was canceled - Adding children to glb model prefabs is currently not supported.",
+    "rigidbodyDropWarning": "Re-parenting was canceled - Entities with a rigidbody are not allowed to have an ancestor with a rigidbody. Please remove one of the rigidbodies and try again.",
+    "sceneComplexity": "Scene complexity is {{sceneComplexity}}. Consider optimizing your scene for better performance."
   },
   "viewport": {
     "title": "Viewport",
@@ -1462,6 +1464,8 @@
     "lbl-edited": "Edited",
     "lbl-duplicate": "Duplicate",
     "lbl-group": "Group",
+    "lbl-move-to-top": "Move To Top",
+    "lbl-move-to-bottom": "Move To Bottom",
     "lbl-copy": "Copy",
     "lbl-paste": "Paste",
     "lbl-delete": "Delete",
@@ -1684,4 +1688,3 @@
     "okay": "Okay"
   }
 }
-

--- a/packages/editor/src/panels/hierarchy/contextmenu.tsx
+++ b/packages/editor/src/panels/hierarchy/contextmenu.tsx
@@ -24,7 +24,7 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
-import { hasComponent } from '@ir-engine/ecs'
+import { EntityTreeComponent, getComponent, hasComponent, UndefinedEntity } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { DropdownItem } from '@ir-engine/ui'
 import { ContextMenu } from '@ir-engine/ui/src/components/tailwind/ContextMenu'
@@ -32,6 +32,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import CreatePrefabPanel from '../../components/dialogs/CreatePrefabPanelDialog'
 import SavePrefabPanel from '../../components/dialogs/SavePrefabDialog'
+import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 import { cmdOrCtrlString } from '../../functions/utils'
 import { copyNodes, deleteNode, duplicateNode, groupNodes, pasteNodes } from './helpers'
 import { useHierarchyNodes, useHierarchyTreeContextMenu, useNodeCollapseExpand, useRenamingNode } from './hooks'
@@ -69,6 +70,24 @@ export default function HierarchyTreeContextMenu() {
     deleteNode(entity)
   }
 
+  const onMoveToTop = () => {
+    const parent = getComponent(entity, EntityTreeComponent).parentEntity
+    const children = getComponent(parent, EntityTreeComponent).children
+    const firstChild = children.at(0)
+
+    EditorControlFunctions.reparentObject([entity], firstChild, UndefinedEntity, parent)
+    setMenu()
+  }
+
+  const onMoveToBottom = () => {
+    const parent = getComponent(entity, EntityTreeComponent).parentEntity
+    const children = getComponent(parent, EntityTreeComponent).children
+    const lastChild = children.at(-1)
+
+    EditorControlFunctions.reparentObject([entity], UndefinedEntity, lastChild, parent)
+    setMenu()
+  }
+
   return (
     <ContextMenu anchorEvent={anchorEvent} open={!!entity} onClose={() => setMenu()}>
       <div className="w-[220px]" data-testid="hierarchy-panel-scene-item-context-menu">
@@ -92,6 +111,16 @@ export default function HierarchyTreeContextMenu() {
           onClick={onGroupNodes}
           secondaryText={cmdOrCtrlString + ' + g'}
           label={t('editor:hierarchy.lbl-group')}
+        />
+        <DropdownItem
+          data-testid="hierarchy-panel-scene-item-context-menu-move-to-top-button"
+          onClick={onMoveToTop}
+          label={t('editor:hierarchy.lbl-move-to-top')}
+        />
+        <DropdownItem
+          data-testid="hierarchy-panel-scene-item-context-menu-move-to-bottom-button"
+          onClick={onMoveToBottom}
+          label={t('editor:hierarchy.lbl-move-to-bottom')}
         />
         <DropdownItem
           data-testid="hierarchy-panel-scene-item-context-menu-copy-button"

--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -67,7 +67,7 @@ export const uploadOptions = {
 
 /* NODE FUNCTIONALITIES */
 
-const getSelectedEntities = (entity?: Entity) => {
+export const getSelectedEntities = (entity?: Entity) => {
   const selected = entity
     ? getState(SelectionState).selectedEntities.includes(getComponent(entity, UUIDComponent))
     : true

--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -75,6 +75,10 @@ const getSelectedEntities = (entity?: Entity) => {
   return selectedEntities
 }
 
+export function getNodeElId(node: HierarchyTreeNodeType) {
+  return 'hierarchy-node-' + node.entity
+}
+
 export const deleteNode = (entity: Entity) => {
   EditorHistoryFunctions.removeEntity(getSelectedEntities(entity))
 }

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -336,7 +336,6 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         ref={drag}
         id={getNodeElId(node)}
         tabIndex={0}
-        onKeyDown={onKeyDown}
         onClick={onClickNode}
         onContextMenu={(event) => {
           event.preventDefault()

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -70,7 +70,7 @@ import { EditorHelperState, PlacementMode } from '../../services/EditorHelperSta
 import { EditorHistoryFunctions } from '../../services/EditorHistoryState'
 import { EditorState } from '../../services/EditorServices'
 import { HierarchyTreeState } from '../../services/HierarchyNodeState'
-import { deleteNode, HierarchyTreeNodeType } from './helpers'
+import { HierarchyTreeNodeType } from './helpers'
 import {
   useHierarchyNodes,
   useHierarchyTreeContextMenu,
@@ -186,76 +186,6 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
   useEffect(() => {
     preview(getEmptyImage(), { captureDraggingState: true })
   }, [preview])
-
-  const onKeyDown = (event: KeyboardEvent) => {
-    const nodeIndex = nodes.findIndex((node) => node.entity === entity)
-    const entityTree = getComponent(entity, EntityTreeComponent)
-    switch (event.key) {
-      case 'ArrowDown': {
-        event.preventDefault()
-        if (entity === rootEntity) return
-
-        const nextNode = nodeIndex !== -1 && nodes[nodeIndex + 1]
-        if (!nextNode) return
-
-        if (event.shiftKey) {
-          EditorControlFunctions.addToSelection([getComponent(nextNode.entity, UUIDComponent)])
-        }
-
-        const nextNodeEl = document.getElementById(getNodeElId(nextNode))
-        if (nextNodeEl) {
-          nextNodeEl.focus()
-        }
-        break
-      }
-      // case 'ArrowUp': {
-      //   event.preventDefault()
-      //   if (entity === rootEntity) return
-
-      //   const prevNode = nodeIndex !== -1 && nodes[nodeIndex - 1]
-      //   if (!prevNode) return
-
-      //   if (event.shiftKey) {
-      //     EditorControlFunctions.addToSelection([getComponent(prevNode.entity, UUIDComponent)])
-      //   }
-
-      //   const prevNodeEl = document.getElementById(getNodeElId(prevNode))
-      //   if (prevNodeEl) {
-      //     prevNodeEl.focus()
-      //   }
-      //   break
-      // }
-      case 'ArrowLeft': {
-        if (entityTree && (!entityTree.children || entityTree.children.length === 0)) return
-
-        if (event.shiftKey) collapseChildren(entity)
-        else collapseNode(entity)
-        break
-      }
-      case 'ArrowRight': {
-        if (entityTree && (!entityTree.children || entityTree.children.length === 0)) return
-
-        if (event.shiftKey) expandChildren(entity)
-        else expandNode(entity)
-        break
-      }
-      case 'Enter': {
-        if (entity === rootEntity) return
-        if (event.shiftKey) {
-          EditorControlFunctions.toggleSelection([getComponent(entity, UUIDComponent)])
-        } else {
-          EditorControlFunctions.replaceSelection([getComponent(entity, UUIDComponent)])
-        }
-        break
-      }
-      case 'Delete':
-      case 'Backspace': {
-        if (entity === rootEntity) return
-        if (selected && renamingNode.entity !== entity) deleteNode(entity)
-        break
-      }
-    }
-  }
 
   const onClickNode = (event: React.MouseEvent) => {
     if (renamingNode.entity !== entity) {

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -208,23 +208,23 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         }
         break
       }
-      case 'ArrowUp': {
-        event.preventDefault()
-        if (entity === rootEntity) return
+      // case 'ArrowUp': {
+      //   event.preventDefault()
+      //   if (entity === rootEntity) return
 
-        const prevNode = nodeIndex !== -1 && nodes[nodeIndex - 1]
-        if (!prevNode) return
+      //   const prevNode = nodeIndex !== -1 && nodes[nodeIndex - 1]
+      //   if (!prevNode) return
 
-        if (event.shiftKey) {
-          EditorControlFunctions.addToSelection([getComponent(prevNode.entity, UUIDComponent)])
-        }
+      //   if (event.shiftKey) {
+      //     EditorControlFunctions.addToSelection([getComponent(prevNode.entity, UUIDComponent)])
+      //   }
 
-        const prevNodeEl = document.getElementById(getNodeElId(prevNode))
-        if (prevNodeEl) {
-          prevNodeEl.focus()
-        }
-        break
-      }
+      //   const prevNodeEl = document.getElementById(getNodeElId(prevNode))
+      //   if (prevNodeEl) {
+      //     prevNodeEl.focus()
+      //   }
+      //   break
+      // }
       case 'ArrowLeft': {
         if (entityTree && (!entityTree.children || entityTree.children.length === 0)) return
 
@@ -280,6 +280,12 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         if (!selected) {
           EditorControlFunctions.replaceSelection([getComponent(entity, UUIDComponent)])
         }
+        const node = nodes.find((node) => node.entity === entity)
+        if (node) {
+          const nodeEl = document.getElementById(getNodeElId(node))
+          nodeEl?.focus()
+        }
+
         firstSelectedEntity.set(entity)
       }
     } else if (event.detail === 2) {

--- a/packages/editor/src/panels/hierarchy/hierarchytree.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchytree.tsx
@@ -23,21 +23,17 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { getComponent, UUIDComponent } from '@ir-engine/ecs'
 import { getMutableState, useHookstate } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import { Popup } from '@ir-engine/ui/src/components/tailwind/Popup'
 import SearchBar from '@ir-engine/ui/src/components/tailwind/SearchBar'
 import { PlusCircleSm } from '@ir-engine/ui/src/icons'
 import React, { useCallback, useEffect, useRef } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 import { useTranslation } from 'react-i18next'
 import { FixedSizeList, ListChildComponentProps } from 'react-window'
 import { twMerge } from 'tailwind-merge'
-import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 import { HierarchyTreeState } from '../../services/HierarchyNodeState'
 import ElementList from '../properties/elementlist'
-import { getNodeElId } from './helpers'
 import HierarchyTreeNode from './hierarchynode'
 import { useHierarchyNodes, useHierarchyTreeDrop, useHierarchyTreeHotkeys } from './hooks'
 
@@ -102,30 +98,6 @@ export function Contents() {
   }, [])
 
   useHierarchyTreeHotkeys()
-  useHotkeys('ArrowUp', () => {
-    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
-    const index = nodes.findIndex((node) => node.entity === selectedEntity)
-    if (index === -1) return
-    const upperNode = nodes.at(index - 1)
-    if (!upperNode) return
-    const upperNodeEl = document.getElementById(getNodeElId(upperNode))
-    upperNodeEl?.focus()
-    EditorControlFunctions.replaceSelection([getComponent(upperNode.entity, UUIDComponent)])
-    getMutableState(HierarchyTreeState).firstSelectedEntity.set(upperNode.entity)
-  })
-  useHotkeys('ArrowDown', () => {
-    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
-    const index = nodes.findIndex((node) => node.entity === selectedEntity)
-    if (index === -1) return
-    let lowerNode = nodes.at(index + 1)
-    if (!lowerNode) {
-      lowerNode = nodes.at(0)
-    }
-    const lowerNodeEl = document.getElementById(getNodeElId(lowerNode!))
-    lowerNodeEl?.focus()
-    EditorControlFunctions.replaceSelection([getComponent(lowerNode!.entity, UUIDComponent)])
-    getMutableState(HierarchyTreeState).firstSelectedEntity.set(lowerNode!.entity)
-  })
 
   return (
     <div

--- a/packages/editor/src/panels/hierarchy/hierarchytree.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchytree.tsx
@@ -23,17 +23,21 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+import { getComponent, UUIDComponent } from '@ir-engine/ecs'
 import { getMutableState, useHookstate } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import { Popup } from '@ir-engine/ui/src/components/tailwind/Popup'
 import SearchBar from '@ir-engine/ui/src/components/tailwind/SearchBar'
 import { PlusCircleSm } from '@ir-engine/ui/src/icons'
 import React, { useCallback, useEffect, useRef } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { useTranslation } from 'react-i18next'
 import { FixedSizeList, ListChildComponentProps } from 'react-window'
 import { twMerge } from 'tailwind-merge'
+import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 import { HierarchyTreeState } from '../../services/HierarchyNodeState'
 import ElementList from '../properties/elementlist'
+import { getNodeElId } from './helpers'
 import HierarchyTreeNode from './hierarchynode'
 import { useHierarchyNodes, useHierarchyTreeDrop, useHierarchyTreeHotkeys } from './hooks'
 
@@ -98,10 +102,35 @@ export function Contents() {
   }, [])
 
   useHierarchyTreeHotkeys()
+  useHotkeys('ArrowUp', () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const upperNode = nodes.at(index - 1)
+    if (!upperNode) return
+    const upperNodeEl = document.getElementById(getNodeElId(upperNode))
+    upperNodeEl?.focus()
+    EditorControlFunctions.replaceSelection([getComponent(upperNode.entity, UUIDComponent)])
+    getMutableState(HierarchyTreeState).firstSelectedEntity.set(upperNode.entity)
+  })
+  useHotkeys('ArrowDown', () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    let lowerNode = nodes.at(index + 1)
+    if (!lowerNode) {
+      lowerNode = nodes.at(0)
+    }
+    const lowerNodeEl = document.getElementById(getNodeElId(lowerNode!))
+    lowerNodeEl?.focus()
+    EditorControlFunctions.replaceSelection([getComponent(lowerNode!.entity, UUIDComponent)])
+    getMutableState(HierarchyTreeState).firstSelectedEntity.set(lowerNode!.entity)
+  })
 
   return (
     <div
       ref={ref}
+      tabIndex={0}
       className={twMerge('h-5/6 overflow-hidden', isOver && canDrop && 'border border-dotted')}
       data-testid="hierarchy-panel-scene-item-list"
     >

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -34,7 +34,8 @@ import {
   traverseEntityNode,
   UndefinedEntity,
   useComponent,
-  useQuery
+  useQuery,
+  UUIDComponent
 } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { SourceComponent } from '@ir-engine/engine/src/scene/components/SourceComponent'
@@ -57,6 +58,8 @@ import {
   copyNodes,
   duplicateNode,
   ecsHierarchyTreeWalker,
+  getNodeElId,
+  getSelectedEntities,
   groupNodes,
   HierarchyTreeNodeType,
   pasteNodes,
@@ -359,6 +362,8 @@ const useSimplifiedHotkey = (key: string, onAction: () => void) => {
 
 export const useHierarchyTreeHotkeys = () => {
   const renamingNode = useRenamingNode()
+  const nodes = useHierarchyNodes()
+  const { expandNode, collapseNode } = useNodeCollapseExpand()
   useSimplifiedHotkey('d', duplicateNode)
   useSimplifiedHotkey('g', groupNodes)
   useSimplifiedHotkey('c', copyNodes)
@@ -368,5 +373,67 @@ export const useHierarchyTreeHotkeys = () => {
     for (const entity of selectedEntities) {
       renamingNode.set(entity)
     }
+  })
+  useHotkeys('ArrowLeft', () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const node = nodes[index]
+    const entityTree = getComponent(node.entity, EntityTreeComponent)
+    if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
+    collapseNode(node.entity)
+  })
+  useHotkeys('ArrowRight', () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const node = nodes[index]
+    const entityTree = getComponent(node.entity, EntityTreeComponent)
+    if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
+    expandNode(node.entity)
+  })
+
+  useHotkeys(['ArrowUp', 'Shift + ArrowUp'], (event) => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const upperNode = nodes.at(index - 1)
+    if (!upperNode) return
+    const upperNodeEl = document.getElementById(getNodeElId(upperNode))
+    upperNodeEl?.focus()
+    if (event.shiftKey) {
+      const uuids = [
+        ...getSelectedEntities().map((e) => getComponent(e, UUIDComponent)),
+        getComponent(upperNode.entity, UUIDComponent)
+      ].filter((value, index, array) => array.indexOf(value) === index)
+
+      EditorControlFunctions.addToSelection([...uuids, getComponent(upperNode.entity, UUIDComponent)])
+    } else {
+      EditorControlFunctions.replaceSelection([getComponent(upperNode.entity, UUIDComponent)])
+    }
+    getMutableState(HierarchyTreeState).firstSelectedEntity.set(upperNode.entity)
+  })
+  useHotkeys(['ArrowDown', 'Shift + ArrowDown'], (event) => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    let lowerNode = nodes.at(index + 1)
+    if (!lowerNode) {
+      lowerNode = nodes.at(0)
+    }
+    lowerNode = lowerNode!
+    const lowerNodeEl = document.getElementById(getNodeElId(lowerNode))
+    lowerNodeEl?.focus()
+    if (event.shiftKey) {
+      const uuids = [
+        ...getSelectedEntities().map((e) => getComponent(e, UUIDComponent)),
+        getComponent(lowerNode!.entity, UUIDComponent)
+      ].filter((value, index, array) => array.indexOf(value) === index)
+
+      EditorControlFunctions.addToSelection([...uuids, getComponent(lowerNode.entity, UUIDComponent)])
+    } else {
+      EditorControlFunctions.replaceSelection([getComponent(lowerNode.entity, UUIDComponent)])
+    }
+    getMutableState(HierarchyTreeState).firstSelectedEntity.set(lowerNode.entity)
   })
 }

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -56,6 +56,7 @@ import { HierarchyTreeState } from '../../services/HierarchyNodeState'
 import { SelectionState } from '../../services/SelectionServices'
 import {
   copyNodes,
+  deleteNode,
   duplicateNode,
   ecsHierarchyTreeWalker,
   getNodeElId,
@@ -363,7 +364,9 @@ const useSimplifiedHotkey = (key: string, onAction: () => void) => {
 export const useHierarchyTreeHotkeys = () => {
   const renamingNode = useRenamingNode()
   const nodes = useHierarchyNodes()
-  const { expandNode, collapseNode } = useNodeCollapseExpand()
+  const { rootEntity } = useMutableState(EditorState)
+
+  const { expandNode, collapseNode, collapseChildren, expandChildren } = useNodeCollapseExpand()
   useSimplifiedHotkey('d', duplicateNode)
   useSimplifiedHotkey('g', groupNodes)
   useSimplifiedHotkey('c', copyNodes)
@@ -374,23 +377,48 @@ export const useHierarchyTreeHotkeys = () => {
       renamingNode.set(entity)
     }
   })
-  useHotkeys('ArrowLeft', () => {
+  useHotkeys(['Enter', 'Shift + Enter'], ({ shiftKey }) => {
     const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
-    const index = nodes.findIndex((node) => node.entity === selectedEntity)
-    if (index === -1) return
-    const node = nodes[index]
-    const entityTree = getComponent(node.entity, EntityTreeComponent)
-    if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
-    collapseNode(node.entity)
+    if (selectedEntity === rootEntity.value || !selectedEntity) return
+    if (shiftKey) {
+      EditorControlFunctions.toggleSelection([getComponent(selectedEntity, UUIDComponent)])
+    } else {
+      EditorControlFunctions.replaceSelection([getComponent(selectedEntity, UUIDComponent)])
+    }
   })
-  useHotkeys('ArrowRight', () => {
+
+  useHotkeys(['Delete', 'Backspace'], () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    if (selectedEntity === rootEntity.value || !selectedEntity) return
+    if (renamingNode.entity !== selectedEntity) deleteNode(selectedEntity)
+  })
+
+  useHotkeys(['ArrowLeft', 'Shift + ArrowLeft'], ({ shiftKey }) => {
     const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
     const index = nodes.findIndex((node) => node.entity === selectedEntity)
     if (index === -1) return
     const node = nodes[index]
     const entityTree = getComponent(node.entity, EntityTreeComponent)
     if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
-    expandNode(node.entity)
+    if (shiftKey) {
+      collapseChildren(node.entity)
+    } else {
+      collapseNode(node.entity)
+    }
+  })
+  useHotkeys(['ArrowRight', 'Shift + ArrowRight'], ({ shiftKey }) => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const node = nodes[index]
+    const entityTree = getComponent(node.entity, EntityTreeComponent)
+    if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
+
+    if (shiftKey) {
+      expandChildren(node.entity)
+    } else {
+      expandNode(node.entity)
+    }
   })
 
   useHotkeys(['ArrowUp', 'Shift + ArrowUp'], (event) => {


### PR DESCRIPTION
## Summary
Refactor hotkey logic for the hierarchy tree panel. Support multi-selection, up/down navigation, expanding/collapsing, move to top & bottom (context menu)

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-8909]

## QA Steps


[IR-8909]: https://tsu.atlassian.net/browse/IR-8909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ