### PR TITLE
Stop Wheel Event Propogation

### DIFF
--- a/packages/spatial/src/input/functions/ClientInputHooks.tsx
+++ b/packages/spatial/src/input/functions/ClientInputHooks.tsx
@@ -346,7 +346,7 @@ export const CanvasInputReactor = () => {
       axes[MouseScroll.HorizontalScroll] = normalizedValues.spinX
       axes[MouseScroll.VerticalScroll] = normalizedValues.spinY
       event.preventDefault()
-      event.stopPropogation()
+      event.stopPropagation()
     }
 
     canvas.addEventListener('dragstart', ClientInputFunctions.preventDefault, false)

--- a/packages/spatial/src/input/functions/ClientInputHooks.tsx
+++ b/packages/spatial/src/input/functions/ClientInputHooks.tsx
@@ -346,6 +346,7 @@ export const CanvasInputReactor = () => {
       axes[MouseScroll.HorizontalScroll] = normalizedValues.spinX
       axes[MouseScroll.VerticalScroll] = normalizedValues.spinY
       event.preventDefault()
+      event.stopPropogation()
     }
 
     canvas.addEventListener('dragstart', ClientInputFunctions.preventDefault, false)


### PR DESCRIPTION
## Summary
Stop the wheel event from bubbling up to the parent scroll panel. 

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-7606]

## QA Steps


[IR-7606]: https://tsu.atlassian.net/browse/IR-7606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ