### PR TITLE
IR-8209: fixed files & folders search

### DIFF
--- a/packages/editor/src/panels/files/helpers.tsx
+++ b/packages/editor/src/panels/files/helpers.tsx
@@ -97,7 +97,7 @@ export const CurrentFilesQueryProvider = ({ children }: { children?: ReactNode }
   useSearch(
     filesQuery,
     {
-      key: {
+      name: {
         $like: `%${filesState.searchText.value}%`
       }
     },

--- a/packages/server-core/src/media/storageprovider/gcs.storage.ts
+++ b/packages/server-core/src/media/storageprovider/gcs.storage.ts
@@ -347,10 +347,13 @@ export class GCSStorage implements StorageProviderInterface {
     const prefix = folderName.endsWith('/') || !isDirectory ? folderName : folderName + '/'
     const response = await this.provider.bucket(this.bucket).getFiles({
       prefix,
-      delimiter: recursive ? undefined : '/'
+      delimiter: recursive ? undefined : '/',
+      includeFoldersAsPrefixes: !recursive
     })
 
     const promises: Promise<FileBrowserContentType>[] = []
+    // Track folders we've already added to avoid duplicates
+    const addedFolders = new Set<string>()
 
     const files = response[2] as {
       items?: { mediaLink: string; name: string; size: string }[]
@@ -359,22 +362,60 @@ export class GCSStorage implements StorageProviderInterface {
     if (!files.items) files.items = []
     if (!files.prefixes) files.prefixes = []
 
-    // Folders
-    for (let i = 0; i < files.prefixes!.length; i++) {
-      promises.push(
-        new Promise(async (resolve) => {
-          const key = files.prefixes![i].slice(0, -1)
-          const size = await this.getFolderSize(key)
-          const cont: FileBrowserContentType = {
-            key,
-            url: `${this.bucketAssetURL}/${key}`,
-            name: key.split('/').pop()!,
-            type: 'folder',
-            size
-          }
-          resolve(cont)
-        })
-      )
+    if (!recursive) {
+      // Folders
+      for (let i = 0; i < files.prefixes!.length; i++) {
+        promises.push(
+          new Promise(async (resolve) => {
+            const key = files.prefixes![i].slice(0, -1)
+            // Add to our tracking set
+            addedFolders.add(key)
+            const size = await this.getFolderSize(key)
+            const cont: FileBrowserContentType = {
+              key,
+              url: `${this.bucketAssetURL}/${key}`,
+              name: key.split('/').pop()!,
+              type: 'folder',
+              size
+            }
+            resolve(cont)
+          })
+        )
+      }
+    }
+
+    // When doing recursive search, we need an additional request to get folder prefixes at the current level
+    // since recursive search only returns files, not folder structures
+    if (recursive) {
+      const getFilesResponse = await this.provider.bucket(this.bucket).getFiles({
+        prefix,
+        delimiter: '/',
+        includeFoldersAsPrefixes: true
+      })
+      const filesResponse = getFilesResponse[2] as {
+        items?: { mediaLink: string; name: string; size: string }[]
+        prefixes?: string[]
+      }
+      if (filesResponse?.prefixes) {
+        for (let i = 0; i < filesResponse.prefixes!.length; i++) {
+          promises.push(
+            new Promise(async (resolve) => {
+              const key = filesResponse.prefixes![i].slice(0, -1)
+              // Add to our tracking set
+              addedFolders.add(key)
+              const size = await this.getFolderSize(key)
+              const cont: FileBrowserContentType = {
+                key,
+                url: `${this.bucketAssetURL}/${key}`,
+                name: key.split('/').pop()!,
+                type: 'folder',
+                size
+              }
+              resolve(cont)
+            })
+          )
+        }
+      }
     }
 
     // Files
@@ -395,6 +436,30 @@ export class GCSStorage implements StorageProviderInterface {
             resolve(cont)
           })
         )
+      } else if (recursive && !query && key !== folderName) {
+        // when doing recursive search, we need to add x-empty type files that represent folders
+        // these are tipically in subfolders and cannot be extracted from prefixes
+
+        // Normalize the key by removing trailing slash if present
+        const normalizedKey = key.endsWith('/') ? key.slice(0, -1) : key
+
+        // Only add if we haven't already added this folder
+        if (!addedFolders.has(normalizedKey)) {
+          // Add to our tracking set
+          addedFolders.add(normalizedKey)
+          promises.push(
+            new Promise(async (resolve) => {
+              const cont: FileBrowserContentType = {
+                key: normalizedKey,
+                url: `${this.bucketAssetURL}/${normalizedKey}`,
+                name: normalizedKey.split('/').filter(Boolean).pop()!,
+                type: 'folder',
+                size: await this.getFolderSize(normalizedKey)
+              }
+              resolve(cont)
+            })
+          )
+        }
       }
     }
 

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -679,22 +679,46 @@ export class S3Provider implements StorageProviderInterface {
 
     const promises: Promise<FileBrowserContentType>[] = []
 
+    if (recursive) {
+      // When doing recursive search, we need an additional request to get folder prefixes at the current level
+      // since recursive search only returns files, not folder structures
+      const listObjectsResponse = await this.listObjects(folderName, false)
+      for (let i = 0; i < listObjectsResponse.CommonPrefixes!.length; i++) {
+        promises.push(
+          new Promise(async (resolve) => {
+            const key = listObjectsResponse.CommonPrefixes![i].Prefix.slice(0, -1)
+            const size = await this.getFolderSize(key)
+            const cont: FileBrowserContentType = {
+              key,
+              url: `${this.bucketAssetURL}/${key}`,
+              name: key.split('/').pop()!,
+              type: 'folder',
+              size
+            }
+            resolve(cont)
+          })
+        )
+      }
+    }
+
     // Folders
-    for (let i = 0; i < folderContent.CommonPrefixes!.length; i++) {
-      promises.push(
-        new Promise(async (resolve) => {
-          const key = folderContent.CommonPrefixes![i].Prefix.slice(0, -1)
-          const size = await this.getFolderSize(key)
-          const cont: FileBrowserContentType = {
-            key,
-            url: `${this.bucketAssetURL}/${key}`,
-            name: key.split('/').pop()!,
-            type: 'folder',
-            size
-          }
-          resolve(cont)
-        })
-      )
+    if (!recursive) {
+      for (let i = 0; i < folderContent.CommonPrefixes!.length; i++) {
+        promises.push(
+          new Promise(async (resolve) => {
+            const key = folderContent.CommonPrefixes![i].Prefix.slice(0, -1)
+            const size = await this.getFolderSize(key)
+            const cont: FileBrowserContentType = {
+              key,
+              url: `${this.bucketAssetURL}/${key}`,
+              name: key.split('/').pop()!,
+              type: 'folder',
+              size
+            }
+            resolve(cont)
+          })
+        )
+      }
     }
 
     // Files
@@ -711,6 +735,19 @@ export class S3Provider implements StorageProviderInterface {
               name: query!.groups!.name,
               type: query!.groups!.extension,
               size: folderContent.Contents[i].Size
+            }
+            resolve(cont)
+          })
+        )
+      } else if (recursive && !query && key !== folderName) {
+        promises.push(
+          new Promise(async (resolve) => {
+            const cont: FileBrowserContentType = {
+              key,
+              url: `${this.bucketAssetURL}/${key}`,
+              name: key.split('/').filter(Boolean).pop()!,
+              type: 'folder',
+              size: await this.getFolderSize(key)
             }
             resolve(cont)
           })


### PR DESCRIPTION
## Summary

This change ensures that sub-folders at all levels are included during recursive searches.
It also accounts for prefixes representing folders and x-empty type files that mimic folder structures.

Ticket: https://tsu.atlassian.net/browse/IR-8209

![Screen Recording 2025-05-08 at 12 24 01 p m](https://github.com/user-attachments/assets/2e567c37-63e3-439c-8db6-d4ec66be051d)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

**Note: Testing this requires GCS access, as the local storage provider may behave differently.**

- Open an scene in the studio
- Upload folder with supported files from the File panel
- Search for full or partial name of uploaded folder
