### PR TITLE
Prevent SceneObjectSystem reactor errors

### DIFF
--- a/packages/engine/src/scene/systems/SceneObjectSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.tsx
@@ -35,7 +35,7 @@ import {
   useOptionalComponent
 } from '@ir-engine/ecs/src/ComponentFunctions'
 import { ECSState } from '@ir-engine/ecs/src/ECSState'
-import { Entity } from '@ir-engine/ecs/src/Entity'
+import { Entity, SourceID } from '@ir-engine/ecs/src/Entity'
 import { defineQuery, EntityArrayBoundary, QueryReactor } from '@ir-engine/ecs/src/QueryFunctions'
 import { defineSystem } from '@ir-engine/ecs/src/SystemFunctions'
 import { AnimationSystemGroup } from '@ir-engine/ecs/src/SystemGroups'
@@ -119,7 +119,7 @@ const execute = () => {
 
 const ModelEntityReactor = (props: { entity: Entity }) => {
   const entity = props.entity
-  const sourceID = UUIDComponent.getAsSourceID(entity)
+  const sourceID = hasComponent(entity, UUIDComponent) ? UUIDComponent.getAsSourceID(entity) : ('' as SourceID)
   const childEntities = UUIDComponent.useEntitiesBySource(sourceID)
 
   return (


### PR DESCRIPTION
## Summary
Adds in a single check due to the query reactor running when the queried component no longer exists. 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
