### PR TITLE
fix(IR-9478): auto-close model compression panel on completion with error handling

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -553,6 +553,8 @@
         "lodLevels": "LOD Levels",
         "lodLevelNumber": "LOD Level {{index}}",
         "compress": "Compress",
+        "compressionComplete": "Compress Complete",
+        "compressionError": "Error during compression",
         "compressImage": "Compress Image",
         "applyPresetConfirmation": "Would you like to apply this preset?",
         "savePreset": "Save Preset",

--- a/packages/editor/src/components/assets/ModelCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ModelCompressionPanel.tsx
@@ -52,6 +52,7 @@ import exportGLTF from '../../functions/exportGLTF'
 import { pathJoin } from '@ir-engine/engine/src/assets/functions/miscUtils'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 
+import { NotificationService } from '@ir-engine/client-core/src/common/services/NotificationService'
 import { createSceneEntity } from '@ir-engine/engine/src/scene/functions/createSceneEntity'
 import { Button } from '@ir-engine/ui'
 import ConfirmDialog from '@ir-engine/ui/src/components/tailwind/ConfirmDialog'
@@ -150,11 +151,26 @@ export default function ModelCompressionPanel({
       progress: 0,
       caption: ''
     })
-    for (const file of selectedFiles) {
-      await compressModel(file)
+    try {
+      for (const file of selectedFiles) {
+        await compressModel(file)
+      }
+      await refreshDirectory()
+      NotificationService.dispatchNotify(t('editor:properties.model.transform.compressionComplete'), {
+        variant: 'success',
+        autoHideDuration: 3000
+      })
+    } catch (error) {
+      // Notify user of error
+      NotificationService.dispatchNotify(t('editor:properties.model.transform.compressionError'), {
+        variant: 'error'
+      })
+      console.error('Error during model compression:', error)
+    } finally {
+      compressionLoading.set(false)
+      // Close the modal when compression is complete
+      ModalState.closeModal()
     }
-    await refreshDirectory()
-    compressionLoading.set(false)
   }
 
   const applyPreset = (preset: ModelTransformParameters) => {


### PR DESCRIPTION
fix(IR-9478): auto-close model compression panel on completion with error handling

## Summary


https://github.com/user-attachments/assets/a00d99d4-2d35-4aa5-95dc-6da345ea1218



## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
