### PR TITLE
IR-9465: Get Engine commit from image published to GCP Artifact registry

### DIFF
--- a/packages/server-core/src/projects/builder-info/builder-info.class.ts
+++ b/packages/server-core/src/projects/builder-info/builder-info.class.ts
@@ -25,8 +25,15 @@ import { getState } from '@ir-engine/hyperflux'
 
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
+import logger from '../../ServerLogger'
 import { ServerState } from '../../ServerState'
-import { dockerHubRegex, engineVersion, privateECRTagRegex, publicECRTagRegex } from '../project/project-helper'
+import {
+  dockerHubRegex,
+  engineVersion,
+  gcpArtifactRegistryTagRegex,
+  privateECRTagRegex,
+  publicECRTagRegex
+} from '../project/project-helper'
 
 export class BuilderInfoService implements ServiceInterface<BuilderInfoType> {
   app: Application
@@ -69,9 +76,11 @@ export class BuilderInfoService implements ServiceInterface<BuilderInfoType> {
       if (builderContainer) {
         const image = builderContainer.image
         if (image && typeof image === 'string') {
+          logger.debug(`builderContainer.image: ${image} `)
           const dockerHubRegexExec = dockerHubRegex.exec(image)
           const publicECRRegexExec = publicECRTagRegex.exec(image)
           const privateECRRegexExec = privateECRTagRegex.exec(image)
+          const gcpArtifactRegistryRegexExec = gcpArtifactRegistryTagRegex.exec(image)
           returned.engineCommit =
             dockerHubRegexExec && !publicECRRegexExec
               ? dockerHubRegexExec[1]
@@ -79,6 +88,8 @@ export class BuilderInfoService implements ServiceInterface<BuilderInfoType> {
               ? publicECRRegexExec[1]
               : privateECRRegexExec
               ? privateECRRegexExec[2]
+              : gcpArtifactRegistryRegexExec
+              ? gcpArtifactRegistryRegexExec[5]
               : ''
         }
       }

--- a/packages/server-core/src/projects/builder-info/builder-info.class.ts
+++ b/packages/server-core/src/projects/builder-info/builder-info.class.ts
@@ -25,7 +25,6 @@ import { getState } from '@ir-engine/hyperflux'
 
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
-import logger from '../../ServerLogger'
 import { ServerState } from '../../ServerState'
 import {
   dockerHubRegex,
@@ -76,7 +75,6 @@ export class BuilderInfoService implements ServiceInterface<BuilderInfoType> {
       if (builderContainer) {
         const image = builderContainer.image
         if (image && typeof image === 'string') {
-          logger.debug(`builderContainer.image: ${image} `)
           const dockerHubRegexExec = dockerHubRegex.exec(image)
           const publicECRRegexExec = publicECRTagRegex.exec(image)
           const privateECRRegexExec = privateECRTagRegex.exec(image)
@@ -89,7 +87,7 @@ export class BuilderInfoService implements ServiceInterface<BuilderInfoType> {
               : privateECRRegexExec
               ? privateECRRegexExec[2]
               : gcpArtifactRegistryRegexExec
-              ? gcpArtifactRegistryRegexExec[5]
+              ? gcpArtifactRegistryRegexExec[6]
               : ''
         }
       }

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -99,6 +99,8 @@ export const publicECRRepoRegex = /^public.ecr.aws\/[a-zA-Z0-9]+\/([a-z0-9\-_\\]
 export const publicECRTagRegex = /^public.ecr.aws\/[a-zA-Z0-9]+\/[a-z0-9\-_\\]+:([\w\d\s\-_.]+?)$/
 export const privateECRRepoRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaws.com\/([a-z0-9\-_\\]+)$/
 export const privateECRTagRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaws.com\/[a-z0-9\-_\\]+:([\w\d\s\-_.]+)$/
+export const gcpArtifactRegistryTagRegex =
+  /^([a-z0-9-]+)-docker\.pkg\.dev\/([a-zA-Z0-9-]+)\/([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_]+):([\w\d\s\-_.]+)$/
 
 const BRANCH_PER_PAGE = 100
 const COMMIT_PER_PAGE = 10

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -100,7 +100,7 @@ export const publicECRTagRegex = /^public.ecr.aws\/[a-zA-Z0-9]+\/[a-z0-9\-_\\]+:
 export const privateECRRepoRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaws.com\/([a-z0-9\-_\\]+)$/
 export const privateECRTagRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaws.com\/[a-z0-9\-_\\]+:([\w\d\s\-_.]+)$/
 export const gcpArtifactRegistryTagRegex =
-  /^([a-z0-9-]+)-docker\.pkg\.dev\/([a-zA-Z0-9-]+)\/([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_]+):([\w\d\s\-_.]+)$/
+  /^([a-z0-9-]+)-docker\.pkg\.dev\/([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_\/]+)(?::([\w\d\s\-_.]+)|@sha256:([a-f0-9]{64}))$/
 
 const BRANCH_PER_PAGE = 100
 const COMMIT_PER_PAGE = 10


### PR DESCRIPTION
## Summary

Added regex to get engine commit from image published to GCP Artifact Registry 

![image](https://github.com/user-attachments/assets/8fe6df69-f1f6-46ef-970e-66e8e044b4c1)

![image](https://github.com/user-attachments/assets/0cf81948-dafa-4623-a60a-b0b465aaa893)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
