### PR TITLE
IR-8954: Thumbnail generation causes massive re renders and flashes (2) - removing dimension loading

### DIFF
--- a/packages/editor/src/panels/files/loaders.tsx
+++ b/packages/editor/src/panels/files/loaders.tsx
@@ -187,6 +187,7 @@ function GeneratingThumbnailsProgress() {
         className="mx-2 my-auto h-6 w-6"
         title={t('editor:layout.filebrowser.generatingThumbnails', { count: thumbnailjobCount })}
       />
+      {/* commenting out instead of dealing for future use */}
       {/* <LoadingView
         titleClassname="mt-0"
         containerClassName="flex-row mt-1"

--- a/packages/editor/src/panels/files/loaders.tsx
+++ b/packages/editor/src/panels/files/loaders.tsx
@@ -187,12 +187,12 @@ function GeneratingThumbnailsProgress() {
         className="mx-2 my-auto h-6 w-6"
         title={t('editor:layout.filebrowser.generatingThumbnails', { count: thumbnailjobCount })}
       />
-      <LoadingView
+      {/* <LoadingView
         titleClassname="mt-0"
         containerClassName="flex-row mt-1"
         className="mx-2 my-auto h-6 w-6"
         title={t('editor:layout.filebrowser.generatingDimension', { count: dimensionJobCount })}
-      />
+      /> */}
     </>
   ) : null
 }


### PR DESCRIPTION
## Summary
Work in addition to PR https://github.com/ir-engine/ir-engine/pull/1859
Dimension loading bar causing more glitchy UI, so removing/commenting out for now

## Subtasks Checklist

## Breaking Changes

## References
[IR-8954](https://tsu.atlassian.net/browse/IR-8954)

## QA Steps
Upload files/folders in the Assets/File panel view. 

![image](https://github.com/user-attachments/assets/4e9567c3-b58c-4fa6-9c96-4dc2ac471d35)


[IR-8954]: https://tsu.atlassian.net/browse/IR-8954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ