### PR TITLE
Release1.0.2 Hotfix

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1,4 +1,4 @@
-{ 
+{
   "loading": "Loading Project",
   "loadingNode": "Loading {{name}} Editor...",
   "loadingError": "Error loading Project",
@@ -86,7 +86,9 @@
     "unsupported-unknown-file": "Please upload a valid 3D, Image, Audio, or Video file."
   },
   "warnings": {
-    "sceneComplexity": "Scene complexity is {{sceneComplexity}}. Consider optimizing your Scene for better performance. Refer to our docs for optimization guidelines."
+    "addChildToGlbError": "Re-parenting was canceled - Adding children to glb model prefabs is currently not supported.",
+    "rigidbodyDropWarning": "Re-parenting was canceled - Entities with a rigidbody are not allowed to have an ancestor with a rigidbody. Please remove one of the rigidbodies and try again.",
+    "sceneComplexity": "Scene complexity is {{sceneComplexity}}. Consider optimizing your scene for better performance."
   },
   "viewport": {
     "title": "Viewport",
@@ -1462,6 +1464,8 @@
     "lbl-edited": "Edited",
     "lbl-duplicate": "Duplicate",
     "lbl-group": "Group",
+    "lbl-move-to-top": "Move To Top",
+    "lbl-move-to-bottom": "Move To Bottom",
     "lbl-copy": "Copy",
     "lbl-paste": "Paste",
     "lbl-delete": "Delete",
@@ -1684,4 +1688,3 @@
     "okay": "Okay"
   }
 }
-

--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -55,6 +55,8 @@ import { pathJoin } from '@ir-engine/engine/src/assets/functions/miscUtils'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { SourceComponent } from '@ir-engine/engine/src/scene/components/SourceComponent'
 import { getState, useHookstate } from '@ir-engine/hyperflux'
+
+import { FeatureFlags } from '@ir-engine/common/src/constants/FeatureFlags'
 import { TransformComponent } from '@ir-engine/spatial'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
 import { ColliderComponent } from '@ir-engine/spatial/src/physics/components/ColliderComponent'
@@ -71,6 +73,7 @@ import Toggle from '@ir-engine/ui/src/primitives/tailwind/Toggle'
 import { HiOutlineInformationCircle } from 'react-icons/hi2'
 import { Quaternion, Vector3 } from 'three'
 import { NotificationService } from '../../../common/services/NotificationService'
+import useFeatureFlags from '../../../hooks/useFeatureFlags'
 import CompressedPublishConfirmation from './CompressedPublishConfirmation'
 
 function formatPublishedDate(isoString) {
@@ -156,6 +159,9 @@ export default function AddEditLocationModal(props: AddEditLocationModalProps) {
     caption: ''
   })
   const lods = useHookstate<LODVariantDescriptor[]>([])
+
+  const [compressOnPublishEnabled] = useFeatureFlags([FeatureFlags.Studio.UI.CompressOnPublish])
+
   useEffect(() => {
     if (location) {
       name.set(location.name)
@@ -619,7 +625,12 @@ export default function AddEditLocationModal(props: AddEditLocationModalProps) {
               </Button>
             )}
             <Tooltip content={t('editor:toolbar.publishLocation.createCompressedScenePublishInfo')}>
-              <Button className="bg-[#2F3A4D]" onClick={handlePublishFolder}>
+              <Button
+                className="bg-[#2F3A4D]"
+                data-testid="publish-panel-compress-and-publish-button"
+                disabled={isLoading || !compressOnPublishEnabled}
+                onClick={handlePublishFolder}
+              >
                 <HiOutlineInformationCircle />
                 {t('editor:toolbar.publishLocation.createCompressedScenePublish')}
               </Button>

--- a/packages/common/src/constants/FeatureFlags.ts
+++ b/packages/common/src/constants/FeatureFlags.ts
@@ -58,7 +58,8 @@ export const FeatureFlags = {
       Hierarchy: {
         ShowGlbChildren: 'ir.editor.ui.hierarchy.showGlbChildren'
       },
-      PointClick: 'ir.editor.ui.pointClick'
+      PointClick: 'ir.editor.ui.pointClick',
+      CompressOnPublish: 'ir.editor.ui.compressOnPublish'
     }
   }
 }

--- a/packages/editor/src/panels/assets/resources.tsx
+++ b/packages/editor/src/panels/assets/resources.tsx
@@ -171,11 +171,13 @@ export function FileCard({
         data-testid={dataTestIdJson?.fileItemId}
       >
         <div
-          className={twMerge(
-            `box-border h-20 w-16 rounded font-figtree text-sm`,
-            isSelected ? 'rounded border border-[#375DAF] bg-[#2C2E30]' : 'group-hover:bg-[#202225]'
-          )}
+          className={isSelected ? 'rounded border border-ui-primary bg-ui-select-background p-1' : ''}
           data-testid={dataTestIdJson?.fileIconId}
+          style={{
+            height: 100,
+            width: 100,
+            fontSize: 100
+          }}
         >
           <FileIcon
             thumbnailURL={thumbnailURL}

--- a/packages/editor/src/panels/hierarchy/contextmenu.tsx
+++ b/packages/editor/src/panels/hierarchy/contextmenu.tsx
@@ -24,7 +24,7 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { PopoverState } from '@ir-engine/client-core/src/common/services/PopoverState'
-import { hasComponent } from '@ir-engine/ecs'
+import { EntityTreeComponent, getComponent, hasComponent, UndefinedEntity } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { DropdownItem } from '@ir-engine/ui'
 import { ContextMenu } from '@ir-engine/ui/src/components/tailwind/ContextMenu'
@@ -32,6 +32,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import CreatePrefabPanel from '../../components/dialogs/CreatePrefabPanelDialog'
 import SavePrefabPanel from '../../components/dialogs/SavePrefabDialog'
+import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 import { cmdOrCtrlString } from '../../functions/utils'
 import { copyNodes, deleteNode, duplicateNode, groupNodes, pasteNodes } from './helpers'
 import { useHierarchyNodes, useHierarchyTreeContextMenu, useNodeCollapseExpand, useRenamingNode } from './hooks'
@@ -69,6 +70,24 @@ export default function HierarchyTreeContextMenu() {
     deleteNode(entity)
   }
 
+  const onMoveToTop = () => {
+    const parent = getComponent(entity, EntityTreeComponent).parentEntity
+    const children = getComponent(parent, EntityTreeComponent).children
+    const firstChild = children.at(0)
+
+    EditorControlFunctions.reparentObject([entity], firstChild, UndefinedEntity, parent)
+    setMenu()
+  }
+
+  const onMoveToBottom = () => {
+    const parent = getComponent(entity, EntityTreeComponent).parentEntity
+    const children = getComponent(parent, EntityTreeComponent).children
+    const lastChild = children.at(-1)
+
+    EditorControlFunctions.reparentObject([entity], UndefinedEntity, lastChild, parent)
+    setMenu()
+  }
+
   return (
     <ContextMenu anchorEvent={anchorEvent} open={!!entity} onClose={() => setMenu()}>
       <div className="w-[220px]" data-testid="hierarchy-panel-scene-item-context-menu">
@@ -92,6 +111,16 @@ export default function HierarchyTreeContextMenu() {
           onClick={onGroupNodes}
           secondaryText={cmdOrCtrlString + ' + g'}
           label={t('editor:hierarchy.lbl-group')}
+        />
+        <DropdownItem
+          data-testid="hierarchy-panel-scene-item-context-menu-move-to-top-button"
+          onClick={onMoveToTop}
+          label={t('editor:hierarchy.lbl-move-to-top')}
+        />
+        <DropdownItem
+          data-testid="hierarchy-panel-scene-item-context-menu-move-to-bottom-button"
+          onClick={onMoveToBottom}
+          label={t('editor:hierarchy.lbl-move-to-bottom')}
         />
         <DropdownItem
           data-testid="hierarchy-panel-scene-item-context-menu-copy-button"

--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -67,7 +67,7 @@ export const uploadOptions = {
 
 /* NODE FUNCTIONALITIES */
 
-const getSelectedEntities = (entity?: Entity) => {
+export const getSelectedEntities = (entity?: Entity) => {
   const selected = entity
     ? getState(SelectionState).selectedEntities.includes(getComponent(entity, UUIDComponent))
     : true

--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -75,6 +75,10 @@ const getSelectedEntities = (entity?: Entity) => {
   return selectedEntities
 }
 
+export function getNodeElId(node: HierarchyTreeNodeType) {
+  return 'hierarchy-node-' + node.entity
+}
+
 export const deleteNode = (entity: Entity) => {
   EditorHistoryFunctions.removeEntity(getSelectedEntities(entity))
 }

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -336,7 +336,6 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         ref={drag}
         id={getNodeElId(node)}
         tabIndex={0}
-        onKeyDown={onKeyDown}
         onClick={onClickNode}
         onContextMenu={(event) => {
           event.preventDefault()

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -70,7 +70,7 @@ import { EditorHelperState, PlacementMode } from '../../services/EditorHelperSta
 import { EditorHistoryFunctions } from '../../services/EditorHistoryState'
 import { EditorState } from '../../services/EditorServices'
 import { HierarchyTreeState } from '../../services/HierarchyNodeState'
-import { deleteNode, HierarchyTreeNodeType } from './helpers'
+import { HierarchyTreeNodeType } from './helpers'
 import {
   useHierarchyNodes,
   useHierarchyTreeContextMenu,
@@ -186,76 +186,6 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
   useEffect(() => {
     preview(getEmptyImage(), { captureDraggingState: true })
   }, [preview])
-
-  const onKeyDown = (event: KeyboardEvent) => {
-    const nodeIndex = nodes.findIndex((node) => node.entity === entity)
-    const entityTree = getComponent(entity, EntityTreeComponent)
-    switch (event.key) {
-      case 'ArrowDown': {
-        event.preventDefault()
-        if (entity === rootEntity) return
-
-        const nextNode = nodeIndex !== -1 && nodes[nodeIndex + 1]
-        if (!nextNode) return
-
-        if (event.shiftKey) {
-          EditorControlFunctions.addToSelection([getComponent(nextNode.entity, UUIDComponent)])
-        }
-
-        const nextNodeEl = document.getElementById(getNodeElId(nextNode))
-        if (nextNodeEl) {
-          nextNodeEl.focus()
-        }
-        break
-      }
-      // case 'ArrowUp': {
-      //   event.preventDefault()
-      //   if (entity === rootEntity) return
-
-      //   const prevNode = nodeIndex !== -1 && nodes[nodeIndex - 1]
-      //   if (!prevNode) return
-
-      //   if (event.shiftKey) {
-      //     EditorControlFunctions.addToSelection([getComponent(prevNode.entity, UUIDComponent)])
-      //   }
-
-      //   const prevNodeEl = document.getElementById(getNodeElId(prevNode))
-      //   if (prevNodeEl) {
-      //     prevNodeEl.focus()
-      //   }
-      //   break
-      // }
-      case 'ArrowLeft': {
-        if (entityTree && (!entityTree.children || entityTree.children.length === 0)) return
-
-        if (event.shiftKey) collapseChildren(entity)
-        else collapseNode(entity)
-        break
-      }
-      case 'ArrowRight': {
-        if (entityTree && (!entityTree.children || entityTree.children.length === 0)) return
-
-        if (event.shiftKey) expandChildren(entity)
-        else expandNode(entity)
-        break
-      }
-      case 'Enter': {
-        if (entity === rootEntity) return
-        if (event.shiftKey) {
-          EditorControlFunctions.toggleSelection([getComponent(entity, UUIDComponent)])
-        } else {
-          EditorControlFunctions.replaceSelection([getComponent(entity, UUIDComponent)])
-        }
-        break
-      }
-      case 'Delete':
-      case 'Backspace': {
-        if (entity === rootEntity) return
-        if (selected && renamingNode.entity !== entity) deleteNode(entity)
-        break
-      }
-    }
-  }
 
   const onClickNode = (event: React.MouseEvent) => {
     if (renamingNode.entity !== entity) {

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -208,23 +208,23 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         }
         break
       }
-      case 'ArrowUp': {
-        event.preventDefault()
-        if (entity === rootEntity) return
+      // case 'ArrowUp': {
+      //   event.preventDefault()
+      //   if (entity === rootEntity) return
 
-        const prevNode = nodeIndex !== -1 && nodes[nodeIndex - 1]
-        if (!prevNode) return
+      //   const prevNode = nodeIndex !== -1 && nodes[nodeIndex - 1]
+      //   if (!prevNode) return
 
-        if (event.shiftKey) {
-          EditorControlFunctions.addToSelection([getComponent(prevNode.entity, UUIDComponent)])
-        }
+      //   if (event.shiftKey) {
+      //     EditorControlFunctions.addToSelection([getComponent(prevNode.entity, UUIDComponent)])
+      //   }
 
-        const prevNodeEl = document.getElementById(getNodeElId(prevNode))
-        if (prevNodeEl) {
-          prevNodeEl.focus()
-        }
-        break
-      }
+      //   const prevNodeEl = document.getElementById(getNodeElId(prevNode))
+      //   if (prevNodeEl) {
+      //     prevNodeEl.focus()
+      //   }
+      //   break
+      // }
       case 'ArrowLeft': {
         if (entityTree && (!entityTree.children || entityTree.children.length === 0)) return
 
@@ -280,6 +280,12 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         if (!selected) {
           EditorControlFunctions.replaceSelection([getComponent(entity, UUIDComponent)])
         }
+        const node = nodes.find((node) => node.entity === entity)
+        if (node) {
+          const nodeEl = document.getElementById(getNodeElId(node))
+          nodeEl?.focus()
+        }
+
         firstSelectedEntity.set(entity)
       }
     } else if (event.detail === 2) {

--- a/packages/editor/src/panels/hierarchy/hierarchytree.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchytree.tsx
@@ -23,21 +23,17 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { getComponent, UUIDComponent } from '@ir-engine/ecs'
 import { getMutableState, useHookstate } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import { Popup } from '@ir-engine/ui/src/components/tailwind/Popup'
 import SearchBar from '@ir-engine/ui/src/components/tailwind/SearchBar'
 import { PlusCircleSm } from '@ir-engine/ui/src/icons'
 import React, { useCallback, useEffect, useRef } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 import { useTranslation } from 'react-i18next'
 import { FixedSizeList, ListChildComponentProps } from 'react-window'
 import { twMerge } from 'tailwind-merge'
-import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 import { HierarchyTreeState } from '../../services/HierarchyNodeState'
 import ElementList from '../properties/elementlist'
-import { getNodeElId } from './helpers'
 import HierarchyTreeNode from './hierarchynode'
 import { useHierarchyNodes, useHierarchyTreeDrop, useHierarchyTreeHotkeys } from './hooks'
 
@@ -102,30 +98,6 @@ export function Contents() {
   }, [])
 
   useHierarchyTreeHotkeys()
-  useHotkeys('ArrowUp', () => {
-    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
-    const index = nodes.findIndex((node) => node.entity === selectedEntity)
-    if (index === -1) return
-    const upperNode = nodes.at(index - 1)
-    if (!upperNode) return
-    const upperNodeEl = document.getElementById(getNodeElId(upperNode))
-    upperNodeEl?.focus()
-    EditorControlFunctions.replaceSelection([getComponent(upperNode.entity, UUIDComponent)])
-    getMutableState(HierarchyTreeState).firstSelectedEntity.set(upperNode.entity)
-  })
-  useHotkeys('ArrowDown', () => {
-    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
-    const index = nodes.findIndex((node) => node.entity === selectedEntity)
-    if (index === -1) return
-    let lowerNode = nodes.at(index + 1)
-    if (!lowerNode) {
-      lowerNode = nodes.at(0)
-    }
-    const lowerNodeEl = document.getElementById(getNodeElId(lowerNode!))
-    lowerNodeEl?.focus()
-    EditorControlFunctions.replaceSelection([getComponent(lowerNode!.entity, UUIDComponent)])
-    getMutableState(HierarchyTreeState).firstSelectedEntity.set(lowerNode!.entity)
-  })
 
   return (
     <div

--- a/packages/editor/src/panels/hierarchy/hierarchytree.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchytree.tsx
@@ -23,17 +23,21 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+import { getComponent, UUIDComponent } from '@ir-engine/ecs'
 import { getMutableState, useHookstate } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import { Popup } from '@ir-engine/ui/src/components/tailwind/Popup'
 import SearchBar from '@ir-engine/ui/src/components/tailwind/SearchBar'
 import { PlusCircleSm } from '@ir-engine/ui/src/icons'
 import React, { useCallback, useEffect, useRef } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { useTranslation } from 'react-i18next'
 import { FixedSizeList, ListChildComponentProps } from 'react-window'
 import { twMerge } from 'tailwind-merge'
+import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 import { HierarchyTreeState } from '../../services/HierarchyNodeState'
 import ElementList from '../properties/elementlist'
+import { getNodeElId } from './helpers'
 import HierarchyTreeNode from './hierarchynode'
 import { useHierarchyNodes, useHierarchyTreeDrop, useHierarchyTreeHotkeys } from './hooks'
 
@@ -98,10 +102,35 @@ export function Contents() {
   }, [])
 
   useHierarchyTreeHotkeys()
+  useHotkeys('ArrowUp', () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const upperNode = nodes.at(index - 1)
+    if (!upperNode) return
+    const upperNodeEl = document.getElementById(getNodeElId(upperNode))
+    upperNodeEl?.focus()
+    EditorControlFunctions.replaceSelection([getComponent(upperNode.entity, UUIDComponent)])
+    getMutableState(HierarchyTreeState).firstSelectedEntity.set(upperNode.entity)
+  })
+  useHotkeys('ArrowDown', () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    let lowerNode = nodes.at(index + 1)
+    if (!lowerNode) {
+      lowerNode = nodes.at(0)
+    }
+    const lowerNodeEl = document.getElementById(getNodeElId(lowerNode!))
+    lowerNodeEl?.focus()
+    EditorControlFunctions.replaceSelection([getComponent(lowerNode!.entity, UUIDComponent)])
+    getMutableState(HierarchyTreeState).firstSelectedEntity.set(lowerNode!.entity)
+  })
 
   return (
     <div
       ref={ref}
+      tabIndex={0}
       className={twMerge('h-5/6 overflow-hidden', isOver && canDrop && 'border border-dotted')}
       data-testid="hierarchy-panel-scene-item-list"
     >

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -34,7 +34,8 @@ import {
   traverseEntityNode,
   UndefinedEntity,
   useComponent,
-  useQuery
+  useQuery,
+  UUIDComponent
 } from '@ir-engine/ecs'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { SourceComponent } from '@ir-engine/engine/src/scene/components/SourceComponent'
@@ -57,6 +58,8 @@ import {
   copyNodes,
   duplicateNode,
   ecsHierarchyTreeWalker,
+  getNodeElId,
+  getSelectedEntities,
   groupNodes,
   HierarchyTreeNodeType,
   pasteNodes,
@@ -359,6 +362,8 @@ const useSimplifiedHotkey = (key: string, onAction: () => void) => {
 
 export const useHierarchyTreeHotkeys = () => {
   const renamingNode = useRenamingNode()
+  const nodes = useHierarchyNodes()
+  const { expandNode, collapseNode } = useNodeCollapseExpand()
   useSimplifiedHotkey('d', duplicateNode)
   useSimplifiedHotkey('g', groupNodes)
   useSimplifiedHotkey('c', copyNodes)
@@ -368,5 +373,67 @@ export const useHierarchyTreeHotkeys = () => {
     for (const entity of selectedEntities) {
       renamingNode.set(entity)
     }
+  })
+  useHotkeys('ArrowLeft', () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const node = nodes[index]
+    const entityTree = getComponent(node.entity, EntityTreeComponent)
+    if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
+    collapseNode(node.entity)
+  })
+  useHotkeys('ArrowRight', () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const node = nodes[index]
+    const entityTree = getComponent(node.entity, EntityTreeComponent)
+    if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
+    expandNode(node.entity)
+  })
+
+  useHotkeys(['ArrowUp', 'Shift + ArrowUp'], (event) => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const upperNode = nodes.at(index - 1)
+    if (!upperNode) return
+    const upperNodeEl = document.getElementById(getNodeElId(upperNode))
+    upperNodeEl?.focus()
+    if (event.shiftKey) {
+      const uuids = [
+        ...getSelectedEntities().map((e) => getComponent(e, UUIDComponent)),
+        getComponent(upperNode.entity, UUIDComponent)
+      ].filter((value, index, array) => array.indexOf(value) === index)
+
+      EditorControlFunctions.addToSelection([...uuids, getComponent(upperNode.entity, UUIDComponent)])
+    } else {
+      EditorControlFunctions.replaceSelection([getComponent(upperNode.entity, UUIDComponent)])
+    }
+    getMutableState(HierarchyTreeState).firstSelectedEntity.set(upperNode.entity)
+  })
+  useHotkeys(['ArrowDown', 'Shift + ArrowDown'], (event) => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    let lowerNode = nodes.at(index + 1)
+    if (!lowerNode) {
+      lowerNode = nodes.at(0)
+    }
+    lowerNode = lowerNode!
+    const lowerNodeEl = document.getElementById(getNodeElId(lowerNode))
+    lowerNodeEl?.focus()
+    if (event.shiftKey) {
+      const uuids = [
+        ...getSelectedEntities().map((e) => getComponent(e, UUIDComponent)),
+        getComponent(lowerNode!.entity, UUIDComponent)
+      ].filter((value, index, array) => array.indexOf(value) === index)
+
+      EditorControlFunctions.addToSelection([...uuids, getComponent(lowerNode.entity, UUIDComponent)])
+    } else {
+      EditorControlFunctions.replaceSelection([getComponent(lowerNode.entity, UUIDComponent)])
+    }
+    getMutableState(HierarchyTreeState).firstSelectedEntity.set(lowerNode.entity)
   })
 }

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -56,6 +56,7 @@ import { HierarchyTreeState } from '../../services/HierarchyNodeState'
 import { SelectionState } from '../../services/SelectionServices'
 import {
   copyNodes,
+  deleteNode,
   duplicateNode,
   ecsHierarchyTreeWalker,
   getNodeElId,
@@ -363,7 +364,9 @@ const useSimplifiedHotkey = (key: string, onAction: () => void) => {
 export const useHierarchyTreeHotkeys = () => {
   const renamingNode = useRenamingNode()
   const nodes = useHierarchyNodes()
-  const { expandNode, collapseNode } = useNodeCollapseExpand()
+  const { rootEntity } = useMutableState(EditorState)
+
+  const { expandNode, collapseNode, collapseChildren, expandChildren } = useNodeCollapseExpand()
   useSimplifiedHotkey('d', duplicateNode)
   useSimplifiedHotkey('g', groupNodes)
   useSimplifiedHotkey('c', copyNodes)
@@ -374,23 +377,48 @@ export const useHierarchyTreeHotkeys = () => {
       renamingNode.set(entity)
     }
   })
-  useHotkeys('ArrowLeft', () => {
+  useHotkeys(['Enter', 'Shift + Enter'], ({ shiftKey }) => {
     const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
-    const index = nodes.findIndex((node) => node.entity === selectedEntity)
-    if (index === -1) return
-    const node = nodes[index]
-    const entityTree = getComponent(node.entity, EntityTreeComponent)
-    if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
-    collapseNode(node.entity)
+    if (selectedEntity === rootEntity.value || !selectedEntity) return
+    if (shiftKey) {
+      EditorControlFunctions.toggleSelection([getComponent(selectedEntity, UUIDComponent)])
+    } else {
+      EditorControlFunctions.replaceSelection([getComponent(selectedEntity, UUIDComponent)])
+    }
   })
-  useHotkeys('ArrowRight', () => {
+
+  useHotkeys(['Delete', 'Backspace'], () => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    if (selectedEntity === rootEntity.value || !selectedEntity) return
+    if (renamingNode.entity !== selectedEntity) deleteNode(selectedEntity)
+  })
+
+  useHotkeys(['ArrowLeft', 'Shift + ArrowLeft'], ({ shiftKey }) => {
     const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
     const index = nodes.findIndex((node) => node.entity === selectedEntity)
     if (index === -1) return
     const node = nodes[index]
     const entityTree = getComponent(node.entity, EntityTreeComponent)
     if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
-    expandNode(node.entity)
+    if (shiftKey) {
+      collapseChildren(node.entity)
+    } else {
+      collapseNode(node.entity)
+    }
+  })
+  useHotkeys(['ArrowRight', 'Shift + ArrowRight'], ({ shiftKey }) => {
+    const selectedEntity = getMutableState(HierarchyTreeState).firstSelectedEntity.value
+    const index = nodes.findIndex((node) => node.entity === selectedEntity)
+    if (index === -1) return
+    const node = nodes[index]
+    const entityTree = getComponent(node.entity, EntityTreeComponent)
+    if (!entityTree || !entityTree.children || entityTree.children.length === 0) return
+
+    if (shiftKey) {
+      expandChildren(node.entity)
+    } else {
+      expandNode(node.entity)
+    }
   })
 
   useHotkeys(['ArrowUp', 'Shift + ArrowUp'], (event) => {

--- a/packages/engine/src/assets/loaders/image/ImageBitmapLoader.ts
+++ b/packages/engine/src/assets/loaders/image/ImageBitmapLoader.ts
@@ -18,8 +18,9 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { Cache, Loader } from 'three'
+import { Cache } from 'three'
 import { FileLoader } from '../base/FileLoader'
+import { Loader } from '../base/Loader'
 
 class ImageBitmapLoader extends Loader<ImageBitmap> {
   isImageBitmapLoader = true

--- a/packages/engine/src/assets/loaders/texture/TextureLoader.ts
+++ b/packages/engine/src/assets/loaders/texture/TextureLoader.ts
@@ -24,11 +24,14 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { isClient } from '@ir-engine/hyperflux'
+import { PromiseQueue } from '@ir-engine/spatial/src/common/classes/PromiseQueue'
 import { iOS } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { ImageBitmapLoader, LoadingManager, Texture } from 'three'
 import { Loader } from '../base/Loader'
 
 const noop = () => {}
+
+const loadQueue = new PromiseQueue(4)
 
 // Do we still need this check if we're now reliant on a browser that's new enough to have ArrayBuffer.resize?
 const iOSMaxResolution = 1024
@@ -62,15 +65,49 @@ const getScaledBitmap = (img: ImageBitmap, maxResolution: number) => {
 class TextureLoader extends Loader<Texture> {
   maxResolution: number | undefined
   flipped: boolean
+  numRetries: number
 
-  constructor(manager?: LoadingManager, maxResolution?: number, flipped: boolean = true) {
+  constructor(manager?: LoadingManager, maxResolution?: number, flipped: boolean = true, numRetries = 3) {
     super(manager)
     if (maxResolution) this.maxResolution = maxResolution
     else if (iOS) this.maxResolution = iOSMaxResolution
     this.flipped = flipped
+    this.numRetries = numRetries
   }
 
-  override async load(
+  loadRetry(
+    url: string,
+    onLoad: (loadedTexture: ImageBitmap) => void,
+    onProgress: ((event: ProgressEvent) => void) | undefined,
+    onError: ((err: unknown) => void) | undefined,
+    signal: AbortSignal | undefined,
+    retryCount = 0
+  ) {
+    loadQueue.enqueuePromise(() => {
+      return new Promise((resolve, reject) => {
+        const retryOnError = (err: Error) => {
+          if (retryCount < this.numRetries) {
+            console.warn('TextureLoader: Retrying texture load', url, 'due to error', err)
+            this.loadRetry(url, onLoad, onProgress, onError, signal, retryCount + 1)
+          } else {
+            onError?.(err)
+          }
+          reject(err)
+        }
+
+        const loadCallback = (img: ImageBitmap) => {
+          resolve(img)
+          onLoad(img)
+        }
+
+        const loader = new ImageBitmapLoader(this.manager).setCrossOrigin(this.crossOrigin).setPath(this.path)
+        if (this.flipped) loader.setOptions({ imageOrientation: 'flipY' })
+        loader.load(url, loadCallback, onProgress, retryOnError)
+      })
+    })
+  }
+
+  override load(
     url: string,
     onLoad: (loadedTexture: Texture) => void,
     onProgress?: (event: ProgressEvent) => void,
@@ -92,9 +129,7 @@ class TextureLoader extends Loader<Texture> {
       return
     }
 
-    const loader = new ImageBitmapLoader(this.manager).setCrossOrigin(this.crossOrigin).setPath(this.path)
-    if (this.flipped) loader.setOptions({ imageOrientation: 'flipY' })
-    loader.load(url, onImage, onProgress, onError)
+    this.loadRetry(url, onImage, onProgress, onError, signal)
   }
 }
 

--- a/packages/engine/src/assets/loaders/texture/TextureLoader.ts
+++ b/packages/engine/src/assets/loaders/texture/TextureLoader.ts
@@ -124,8 +124,10 @@ class TextureLoader extends Loader<Texture> {
     const onImage = (i: ImageBitmap | HTMLImageElement) => {
       if (signal?.aborted) return
 
-      const image = this.maxResolution && i instanceof ImageBitmap ? getScaledBitmap(i, this.maxResolution) : i
+      const isBitmap = i instanceof ImageBitmap
+      const image = this.maxResolution && isBitmap ? getScaledBitmap(i, this.maxResolution) : i
       const texture = new Texture(image)
+      if (!isBitmap) texture.flipY = this.flipped
       texture.userData.url = url
       texture.needsUpdate = true
       onLoad(texture)

--- a/packages/engine/src/assets/loaders/texture/TextureLoader.ts
+++ b/packages/engine/src/assets/loaders/texture/TextureLoader.ts
@@ -26,8 +26,9 @@ Infinite Reality Engine. All Rights Reserved.
 import { isClient } from '@ir-engine/hyperflux'
 import { PromiseQueue } from '@ir-engine/spatial/src/common/classes/PromiseQueue'
 import { iOS } from '@ir-engine/spatial/src/common/functions/isMobile'
-import { ImageBitmapLoader, LoadingManager, Texture } from 'three'
+import { ImageLoader, LoadingManager, Texture } from 'three'
 import { Loader } from '../base/Loader'
+import { ImageBitmapLoader } from '../image/ImageBitmapLoader'
 
 const noop = () => {}
 
@@ -77,31 +78,37 @@ class TextureLoader extends Loader<Texture> {
 
   loadRetry(
     url: string,
-    onLoad: (loadedTexture: ImageBitmap) => void,
+    onLoad: (loadedTexture: ImageBitmap | HTMLImageElement) => void,
     onProgress: ((event: ProgressEvent) => void) | undefined,
     onError: ((err: unknown) => void) | undefined,
     signal: AbortSignal | undefined,
-    retryCount = 0
+    retryCount = 0,
+    fallback = false
   ) {
     loadQueue.enqueuePromise(() => {
       return new Promise((resolve, reject) => {
         const retryOnError = (err: Error) => {
           if (retryCount < this.numRetries) {
             console.warn('TextureLoader: Retrying texture load', url, 'due to error', err)
-            this.loadRetry(url, onLoad, onProgress, onError, signal, retryCount + 1)
+            this.loadRetry(url, onLoad, onProgress, onError, signal, retryCount + 1, retryCount > 1)
           } else {
             onError?.(err)
           }
           reject(err)
         }
 
-        const loadCallback = (img: ImageBitmap) => {
+        const loadCallback = (img: ImageBitmap | HTMLImageElement) => {
           resolve(img)
           onLoad(img)
         }
 
-        const loader = new ImageBitmapLoader(this.manager).setCrossOrigin(this.crossOrigin).setPath(this.path)
-        if (this.flipped) loader.setOptions({ imageOrientation: 'flipY' })
+        let loader
+        if (fallback) {
+          loader = new ImageLoader(this.manager).setCrossOrigin(this.crossOrigin).setPath(this.path)
+        } else {
+          loader = new ImageBitmapLoader(this.manager).setCrossOrigin(this.crossOrigin).setPath(this.path)
+          if (this.flipped) loader.setOptions({ imageOrientation: 'flipY' })
+        }
         loader.load(url, loadCallback, onProgress, retryOnError)
       })
     })
@@ -114,10 +121,10 @@ class TextureLoader extends Loader<Texture> {
     onError?: (err: unknown) => void,
     signal?: AbortSignal
   ) {
-    const onImage = (i: ImageBitmap) => {
+    const onImage = (i: ImageBitmap | HTMLImageElement) => {
       if (signal?.aborted) return
 
-      const image = this.maxResolution ? getScaledBitmap(i, this.maxResolution) : i
+      const image = this.maxResolution && i instanceof ImageBitmap ? getScaledBitmap(i, this.maxResolution) : i
       const texture = new Texture(image)
       texture.userData.url = url
       texture.needsUpdate = true

--- a/packages/engine/src/gltf/useApplyCollidersToChildMeshesEffect.ts
+++ b/packages/engine/src/gltf/useApplyCollidersToChildMeshesEffect.ts
@@ -64,15 +64,9 @@ export function useApplyCollidersToChildMeshesEffect(entity: Entity) {
   const rigidbodyEntity = useAncestorWithComponents(entity, [RigidBodyComponent])
   const rigidbodyComponent = useOptionalComponent(rigidbodyEntity, RigidBodyComponent)
   const component = useComponent(entity, GLTFComponent)
-  const loaded = GLTFComponent.useSceneLoaded(entity)
 
   useLayoutEffect(() => {
-    if (
-      !loaded ||
-      !rigidbodyComponent?.initialized?.value ||
-      !physicsWorld ||
-      !physicsWorld.Rigidbodies.has(rigidbodyEntity)
-    )
+    if (!rigidbodyComponent?.initialized?.value || !physicsWorld || !physicsWorld.Rigidbodies.has(rigidbodyEntity))
       return
     forceUpdateMatrices(entity)
 
@@ -103,7 +97,6 @@ export function useApplyCollidersToChildMeshesEffect(entity: Entity) {
     !!rigidbodyComponent?.initialized?.value,
     component.applyColliders.value,
     // Work around, remove JSON.stringify after useChildrenWithComponents has been updated to return a reactive array again
-    JSON.stringify(childMeshEntities),
-    loaded
+    JSON.stringify(childMeshEntities)
   ])
 }

--- a/packages/engine/src/gltf/useApplyCollidersToChildMeshesEffect.ts
+++ b/packages/engine/src/gltf/useApplyCollidersToChildMeshesEffect.ts
@@ -64,9 +64,15 @@ export function useApplyCollidersToChildMeshesEffect(entity: Entity) {
   const rigidbodyEntity = useAncestorWithComponents(entity, [RigidBodyComponent])
   const rigidbodyComponent = useOptionalComponent(rigidbodyEntity, RigidBodyComponent)
   const component = useComponent(entity, GLTFComponent)
+  const loaded = GLTFComponent.useSceneLoaded(entity)
 
   useLayoutEffect(() => {
-    if (!rigidbodyComponent?.initialized?.value || !physicsWorld || !physicsWorld.Rigidbodies.has(rigidbodyEntity))
+    if (
+      !loaded ||
+      !rigidbodyComponent?.initialized?.value ||
+      !physicsWorld ||
+      !physicsWorld.Rigidbodies.has(rigidbodyEntity)
+    )
       return
     forceUpdateMatrices(entity)
 
@@ -96,6 +102,8 @@ export function useApplyCollidersToChildMeshesEffect(entity: Entity) {
     component.shape,
     !!rigidbodyComponent?.initialized?.value,
     component.applyColliders.value,
-    childMeshEntities
+    // Work around, remove JSON.stringify after useChildrenWithComponents has been updated to return a reactive array again
+    JSON.stringify(childMeshEntities),
+    loaded
   ])
 }

--- a/packages/engine/src/gltf/useApplyCollidersToChildMeshesEffect.ts
+++ b/packages/engine/src/gltf/useApplyCollidersToChildMeshesEffect.ts
@@ -25,6 +25,7 @@ Infinite Reality Engine. All Rights Reserved.
 
 import {
   Entity,
+  entityExists,
   getTreeFromChildToAncestor,
   hasComponent,
   removeComponent,
@@ -35,13 +36,13 @@ import {
   useComponent,
   useOptionalComponent
 } from '@ir-engine/ecs'
-import { useHookstate } from '@ir-engine/hyperflux'
 import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics'
 import { ColliderComponent } from '@ir-engine/spatial/src/physics/components/ColliderComponent'
 import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 import { MeshComponent } from '@ir-engine/spatial/src/renderer/components/MeshComponent'
 import { computeTransformMatrix } from '@ir-engine/spatial/src/transform/systems/TransformSystem'
-import { useEffect, useLayoutEffect } from 'react'
+import { useLayoutEffect } from 'react'
+import { SourceComponent } from '../scene/components/SourceComponent'
 import { GLTFComponent } from './GLTFComponent'
 
 function forceUpdateMatrices(childEntity: Entity, ancestorEntity: Entity = UndefinedEntity) {
@@ -63,45 +64,38 @@ export function useApplyCollidersToChildMeshesEffect(entity: Entity) {
   const rigidbodyEntity = useAncestorWithComponents(entity, [RigidBodyComponent])
   const rigidbodyComponent = useOptionalComponent(rigidbodyEntity, RigidBodyComponent)
   const component = useComponent(entity, GLTFComponent)
-  const meshesToApplyColliders = useHookstate([] as Entity[])
 
-  useEffect(() => {
-    if (meshesToApplyColliders.length === 0) {
-      const entitiesArray =
-        !childMeshEntities.includes(entity) && hasComponent(entity, MeshComponent)
-          ? ([...childMeshEntities, entity] as Entity[])
-          : childMeshEntities
-      meshesToApplyColliders.set(entitiesArray.filter((entity) => !hasComponent(entity, ColliderComponent)))
-    }
-  }, [childMeshEntities.length])
-
-  //populate/update collider state
   useLayoutEffect(() => {
-    if (meshesToApplyColliders.length === 0 || !rigidbodyComponent?.initialized?.value || !physicsWorld) return
-
+    if (!rigidbodyComponent?.initialized?.value || !physicsWorld || !physicsWorld.Rigidbodies.has(rigidbodyEntity))
+      return
     forceUpdateMatrices(entity)
-    for (const childMeshEntity of meshesToApplyColliders.value) {
-      if (component.applyColliders.value) {
-        setComponent(childMeshEntity, ColliderComponent, { shape: component.shape.value, matchMesh: true })
-        forceUpdateMatrices(childMeshEntity)
-      } else {
-        removeComponent(childMeshEntity, ColliderComponent)
+
+    if (!component.applyColliders.value) return
+
+    const children = [...childMeshEntities]
+    if (hasComponent(entity, MeshComponent)) children.push(entity)
+
+    const added = [] as Entity[]
+    for (const child of children) {
+      // Don't add colliders to meshes with colliders baked in or helper meshes
+      if (entityExists(child) && !hasComponent(child, ColliderComponent) && hasComponent(child, SourceComponent)) {
+        setComponent(child, ColliderComponent, { shape: component.shape.value, matchMesh: true })
+        forceUpdateMatrices(child)
+        added.push(child)
+      }
+    }
+
+    return () => {
+      for (const entity of added) {
+        if (entityExists(entity)) removeComponent(entity, ColliderComponent)
       }
     }
   }, [
+    entity,
     physicsWorld,
     component.shape,
-    meshesToApplyColliders.value.length,
     !!rigidbodyComponent?.initialized?.value,
-    component.applyColliders
+    component.applyColliders.value,
+    childMeshEntities
   ])
-
-  useEffect(() => {
-    return () => {
-      const entities = [...childMeshEntities, entity] as Entity[]
-      for (const childMeshEntity of entities) {
-        removeComponent(childMeshEntity, ColliderComponent)
-      }
-    }
-  }, [])
 }

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -44,7 +44,7 @@ import { useEntityContext } from '@ir-engine/ecs'
 import { defineComponent, removeComponent, setComponent, useComponent } from '@ir-engine/ecs/src/ComponentFunctions'
 import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
 import { isClient } from '@ir-engine/hyperflux'
-import { MeshComponent } from '@ir-engine/spatial/src/renderer/components/MeshComponent'
+import { ObjectComponent } from '@ir-engine/spatial/src/renderer/components/ObjectComponent'
 import { T } from '@ir-engine/spatial/src/schema/schemaFunctions'
 
 /**
@@ -253,11 +253,11 @@ export const TextComponent = defineComponent({
       }
 
       troikaMesh = new TroikaText()
-      setComponent(entity, MeshComponent, troikaMesh)
+      setComponent(entity, ObjectComponent, troikaMesh)
       troikaMeshRef.current = troikaMesh
 
       return () => {
-        removeComponent(entity, MeshComponent)
+        removeComponent(entity, ObjectComponent)
         troikaMesh.dispose()
       }
     }, [text.text])

--- a/packages/engine/src/scene/components/VideoComponent.tsx
+++ b/packages/engine/src/scene/components/VideoComponent.tsx
@@ -465,8 +465,30 @@ function VideoReactor() {
     const sourceTexture = sourceVideoComponent?.texture
 
     if (video.texture.value) {
+      const videoEl = mediaElement.element as HTMLVideoElement
+
+      const resetMuted = () => {
+        videoEl.muted = false
+        document.removeEventListener('pointerdown', resetMuted)
+      }
+
+      if (videoEl.paused) {
+        videoEl.pause()
+      } else {
+        videoEl.play().catch((error) => {
+          if (error.name === 'NotAllowedError') {
+            videoEl.muted = true
+            videoEl.play()
+
+            document.addEventListener('pointerdown', resetMuted)
+          } else {
+            console.error(error)
+          }
+        })
+      }
+
       //needed to set up the self-referencing source video texture
-      ;(video.texture.value.image as HTMLVideoElement) = mediaElement.element as HTMLVideoElement
+      ;(video.texture.value.image as HTMLVideoElement) = videoEl
       clearErrors(entity, VideoComponent)
     } else {
       if (sourceTexture && sourceMeshComponent) {

--- a/packages/spatial/src/physics/classes/Physics.ts
+++ b/packages/spatial/src/physics/classes/Physics.ts
@@ -51,7 +51,13 @@ import {
   Vector3
 } from 'three'
 
-import { getComponent, getOptionalComponent, hasComponent, setComponent } from '@ir-engine/ecs/src/ComponentFunctions'
+import {
+  entityExists,
+  getComponent,
+  getOptionalComponent,
+  hasComponent,
+  setComponent
+} from '@ir-engine/ecs/src/ComponentFunctions'
 import { Entity, UndefinedEntity } from '@ir-engine/ecs/src/Entity'
 
 import { getAncestorWithComponents, useAncestorWithComponents } from '@ir-engine/ecs'
@@ -676,7 +682,7 @@ function attachCollider(
   rigidBodyEntity: Entity,
   colliderEntity: Entity
 ) {
-  if (world.Colliders.has(colliderEntity)) return
+  if (world.Colliders.has(colliderEntity) || !entityExists(colliderEntity)) return
   const rigidBody = world.Rigidbodies.get(rigidBodyEntity) // guaranteed will exist
   if (!rigidBody) return console.error('Rigidbody not found for entity ' + rigidBodyEntity)
   const collider = world.createCollider(colliderDesc, rigidBody)

--- a/packages/spatial/src/resources/ResourceState.tsx
+++ b/packages/spatial/src/resources/ResourceState.tsx
@@ -248,6 +248,7 @@ const resourceCallbacks = {
       if (!asset.image) return
       resource.metadata.merge({ onGPU: false, discarded: false })
       asset.onUpdate = () => {
+        if (!resource.metadata || resource.metadata.value.onGPU) return
         resource.metadata.merge({ onGPU: true, discarded: discardUponUpload })
         //@ts-ignore
         // asset.onUpdate = null


### PR DESCRIPTION
## Summary

v1.0.2 - Hotfix: Performance and stability (May 2025)


Release date:  2025/05/07

Summary


This hotfix introduces a free trial for new users and restores performance and stability after the 1.0.2 update. It fixes asset‑loading delays, unexpected video pauses, GLB compression failures, and several UI issues in the Studio Editor and Dashboard. 


The release also adds GIF support to the Image component, blocks invalid drag‑and‑drop actions in the hierarchy, improves modal handling during project creation, and gives clearer feedback while large assets load.


New features


Free trial for new users
New accounts can now start with a full‑feature trial period, so creators can explore the iR Studio.
GIF support in Image component
You can now upload animated or static GIF files to the [Image component](https://github.com/image-component)
. Animated GIFs are automatically converted to MP4 for smooth playback.



Improvements


Block re‑parenting under GLB files
If you try to nest an object under a GLB model, the Editor now highlights the action in red and shows a brief message before canceling it, so you don’t accidentally create an invalid hierarchy.
Explicit modal close controls
Project‑creation and Wizard‑selection modals stay open unless you click Close or Back, preventing accidental dismissals when you click outside the window.
Instant loading feedback for dropped assets
Dropping large assets into the viewport now shows a loading spinner immediately, so you know the asset is processing.



Bug fixes


Studio Editor and Spaces
Fixed an issue where GIFs brought in via ecommerce component gallery caused scenes to not load or crash
Fixed an issue where dragging the camera or objects unintentionally paused or played videos with media controls enabled.
Fixed an issue where newly compressed GLB files failed to load in the scene after conversion.
Addressed a problem causing intermittent delays when rendering assets dropped into the viewport.
Fixed a missing iR logo in the top‑left corner of the Editor, restoring the link to the Dashboard.
Addressed an issue that prevented scrolling through all material properties in the Materials → Properties tab.
Fixed a loading failure that caused previously published Spaces to stall after the 1.0.2 release.
Fixed a styling issue in the Files list view that distorted the table layout.






End of release notes v1.0.2 - Hotfix.