### PR TITLE
[IR-10080] World Builder Frontend UI Hotfix #1887, org repo

### DIFF
--- a/packages/editor/src/panels/viewport/index.tsx
+++ b/packages/editor/src/panels/viewport/index.tsx
@@ -156,7 +156,7 @@ const SceneLoadingProgress = ({ rootEntity }) => {
   )
 }
 
-function ViewportContainer() {
+export function ViewportContainer() {
   const { sceneName, rootEntity, canvasRef } = useMutableState(EditorState)
 
   const { t } = useTranslation()


### PR DESCRIPTION
## Summary
World Builder Frontend UI currently crashes on loading.

## Subtasks Checklist

## Breaking Changes
This fix exports ViewportContainer in IR Engine. In World Builder Frontend UI,:

import { ViewportContainer } from '@ir-engine/editor/src/panels/viewport'


## References
[closes #_insert number here_
](https://tsu.atlassian.net/browse/IR-10080)

## QA Steps
Browse:

In Chrome browser, go to MT-DEV iR Studio Dashboard:
https://ir-engine.mt-dev.theinfinitereality.io/dashboard

Click Add Scene

Click World Builder

Click Continue in World Builder
