### PR TITLE
[MT-DEV] Video - media controls are not present in locations

### DIFF
--- a/packages/client-core/src/systems/MediaControlSystem.tsx
+++ b/packages/client-core/src/systems/MediaControlSystem.tsx
@@ -139,21 +139,6 @@ const onUpdate = (entity: Entity) => {
 const execute = () => {
   if (getState(EngineState).isEditing || !isClient) return
 
-  for (const entity of mediaQuery.enter()) {
-    const mediaComponent = getComponent(entity, MediaComponent)
-    if (!mediaComponent.controls) continue
-
-    const transition = createTransitionState(0.25, 'IN')
-    MediaFadeTransitions.set(entity, transition)
-
-    mediaComponent.xruiEntity = createMediaControlsUI(entity).entity
-    setComponent(mediaComponent.xruiEntity, EntityTreeComponent, { parentEntity: Engine.instance.originEntity })
-  }
-
-  for (const entity of mediaQuery.exit()) {
-    if (MediaFadeTransitions.has(entity)) MediaFadeTransitions.delete(entity)
-  }
-
   for (const entity of mediaQuery()) {
     onUpdate(entity)
   }


### PR DESCRIPTION
removed the un needed for loops that setup / tear down the media components xrui controls, since they are already being handled via the MediaXRUIReactor

This was causing two sets of xrui controls to be created, but only one was being shown / hidden on interactions

## Summary
https://tsu.atlassian.net/browse/IR-9077
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
