### PR TITLE
IR-9966: fix GLTF load progress

### DIFF
--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -424,10 +424,6 @@ const DependencyReactor = (props: { gltfComponentEntity: Entity; dependencies: C
   )
 }
 
-const onProgress: (event: ProgressEvent) => void = (event) => {
-  // console.log(event)
-}
-
 /* BINARY EXTENSION */
 export const BINARY_EXTENSION_HEADER_MAGIC = 'glTF'
 export const BINARY_EXTENSION_HEADER_LENGTH = 12
@@ -513,7 +509,12 @@ const useGLTFDocument = (entity: Entity) => {
         const dependencies = buildComponentDependencies(entity, gltf)
         state.dependencies.set(dependencies)
       },
-      onProgress,
+      (progress: ProgressEvent) => {
+        if (progress.lengthComputable && progress.total > 0) {
+          const percentage = Math.floor((progress.loaded / progress.total) * 100)
+          state.progress.set(percentage)
+        }
+      },
       onError,
       signal
     )


### PR DESCRIPTION
## Summary

`AssetState.loadAsync` relies on load progress to add GLTF components into the scene. 
This change fixes an issue where 3D model prefabs were not being added properly.

![Screen Recording 2025-05-16 at 10 38 24 a m](https://github.com/user-attachments/assets/f9a10378-08d8-4985-bcad-fc9d668d3c5c)

ticket: https://tsu.atlassian.net/browse/IR-9966


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

1. Open Studio
2. Open a scene
3. Click 'Add Entity' option in the Hierarchy panel
4. Search for Model
5. Select Model prefab
6. Check if it is displayed in the Hierarchy panel
