### PR TITLE
Rel1.0.3 Add a large fallback to kill field height

### DIFF
--- a/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
@@ -65,8 +65,8 @@ const execute = () => {
 
   for (const entity of killableEntities) {
     const sceneEntity = getAncestorWithComponents(entity, [SceneComponent])
-    const sceneHeight = sceneKillHeights.find(([scene]) => scene === sceneEntity)?.[1]
-    if (typeof sceneHeight !== 'number') continue
+    let sceneHeight = sceneKillHeights.find(([scene]) => scene === sceneEntity)?.[1]
+    if (typeof sceneHeight !== 'number') sceneHeight = -100
 
     const rigidBodyPosition = getComponent(entity, RigidBodyComponent).position
     if (rigidBodyPosition.y < sceneHeight) {


### PR DESCRIPTION
## Summary
If the scene settings component somehow gets deleted this functionality didn't have a fallback. So I added a large  one. This does limit the build depth of the scene though. I also considered a large velocity check but I'd really like to avoid users falling for a long time in any instance.

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-10172
](https://tsu.atlassian.net/browse/IR-10172)
## QA Steps
