### PR TITLE
fix: exclude folders in getFileKeysRecursive

### DIFF
--- a/packages/server-core/src/media/storageprovider/gcs.storage.ts
+++ b/packages/server-core/src/media/storageprovider/gcs.storage.ts
@@ -170,7 +170,8 @@ export class GCSStorage implements StorageProviderInterface {
       Contents: files.map((file) => {
         return {
           Key: file.key!,
-          Size: file.size!
+          Size: file.size!,
+          Type: file.type!
         }
       })
     }

--- a/packages/server-core/src/media/storageprovider/storageProviderUtils.ts
+++ b/packages/server-core/src/media/storageprovider/storageProviderUtils.ts
@@ -6,8 +6,8 @@ Version 1.0. (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
 The License is based on the Mozilla Public License Version 1.1, but Sections 14
-and 15 have been added to cover use of software over a computer network and
-provide for limited attribution for the Original Developer. In addition,
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
 Exhibit A has been modified to be consistent with Exhibit B.
 
 Software distributed under the License is distributed on an "AS IS" basis,
@@ -33,13 +33,8 @@ export const getFileKeysRecursive = async (path: string, storageProviderName?: s
     const response = await storageProvider.listObjects(path, true)
     const entries = response.Contents
     if (entries.length) {
-      for (const { Key, Size } of entries) {
-        // Skip directories which can be identified by:
-        // 1. Keys ending with a slash '/'
-        // 2. Empty files (Size === 0) that don't have a file extension (likely directory placeholders)
-        const isDirectory = Key.endsWith('/') || (Size === 0 && !Key.includes('.') && Key !== path)
-
-        if (!isDirectory) {
+      for (const { Key, Size, Type } of entries) {
+        if (Type !== 'folder') {
           files.push(Key)
         } else {
           logger.debug(`[getFileKeysRecursive] Skipping directory: ${Key}`)

--- a/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
+++ b/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
@@ -89,7 +89,7 @@ export interface StorageListObjectInterface {
   /**
    * Metadata about each object returned.
    */
-  Contents: { Key: string; Size: number }[]
+  Contents: { Key: string; Size: number; Type?: string }[]
   /**
    * All of the keys (up to 1,000) rolled up into a common prefix count as a single return when calculating the number of returns. A response can contain CommonPrefixes only if you specify a delimiter.  CommonPrefixes contains all (if there are any) keys between Prefix and the next occurrence of the string specified by a delimiter.  CommonPrefixes lists keys that act like subdirectories in the directory specified by Prefix. For example, if the prefix is notes/ and the delimiter is a slash (/) as in notes/summer/july, the common prefix is notes/summer/. All of the keys that roll up into a common prefix count as a single return when calculating the number of returns.
    */


### PR DESCRIPTION
## Summary

Exclude folders in getFileKeysRecursive used to install projects 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
