### PR TITLE
Enables spline componenet through feature flags

### DIFF
--- a/packages/common/src/constants/FeatureFlags.ts
+++ b/packages/common/src/constants/FeatureFlags.ts
@@ -45,7 +45,8 @@ export const FeatureFlags = {
       LegacyVolumetric: 'ir.studio.components.legacyVolumetric',
       Volumetric: 'ir.studio.components.volumetric',
       AudioAnalysis: 'ir.studio.components.audioAnalysis',
-      ScreenshareTarget: 'ir.studio.components.screenshareTarget'
+      ScreenshareTarget: 'ir.studio.components.screenshareTarget',
+      Spline: 'ir.studio.components.spline'
     },
     Panel: {
       VisualScript: 'ir.editor.panel.visualScript',

--- a/packages/editor/src/services/ComponentShelfCategoriesState.ts
+++ b/packages/editor/src/services/ComponentShelfCategoriesState.ts
@@ -54,6 +54,7 @@ import { ScreenshareTargetComponent } from '@ir-engine/engine/src/scene/componen
 import { ShadowComponent } from '@ir-engine/engine/src/scene/components/ShadowComponent'
 import { SkyboxComponent } from '@ir-engine/engine/src/scene/components/SkyboxComponent'
 import { SpawnPointComponent } from '@ir-engine/engine/src/scene/components/SpawnPointComponent'
+import { SplineComponent } from '@ir-engine/engine/src/scene/components/SplineComponent'
 import { TextComponent } from '@ir-engine/engine/src/scene/components/TextComponent'
 import { TriggerCallbackComponent } from '@ir-engine/engine/src/scene/components/TriggerCallbackComponent'
 import { VariantComponent } from '@ir-engine/engine/src/scene/components/VariantComponent'
@@ -119,7 +120,7 @@ export const ComponentShelfCategoriesState = defineState({
   reactor: () => {
     const [portalEnabled] = useFeatureFlags([FeatureFlags.Studio.Panel.Portal])
     const [grabbleEnabled] = useFeatureFlags([FeatureFlags.Studio.Panel.Grabble])
-
+    const [splineEnabled] = useFeatureFlags([FeatureFlags.Studio.Components.Spline])
     const [visualScriptEnabled] = useFeatureFlags([FeatureFlags.Studio.Panel.VisualScript])
 
     const [legacyVolumetricEnabled] = useFeatureFlags([FeatureFlags.Studio.Components.LegacyVolumetric])
@@ -128,6 +129,17 @@ export const ComponentShelfCategoriesState = defineState({
     const [screenshareTargetEnabled] = useFeatureFlags([FeatureFlags.Studio.Components.ScreenshareTarget])
 
     const cShelfState = getMutableState(ComponentShelfCategoriesState)
+
+    useEffect(() => {
+      if (splineEnabled) {
+        cShelfState.Interaction.merge([SplineComponent])
+        return () => {
+          cShelfState.Interaction.set((curr) => {
+            return curr.splice(curr.findIndex((item) => item.name == SplineComponent.name))
+          })
+        }
+      }
+    }, [splineEnabled])
 
     useEffect(() => {
       if (portalEnabled) {


### PR DESCRIPTION
## Summary

## Subtasks Checklist

## Breaking Changes

## References
Enables the spline component behind a feature flag discussed here: https://tsu.atlassian.net/browse/IR-6988

## QA Steps
Create an empty object. Attach spline component. Enable node visibility helper in the debug menu.

<img width="701" alt="Screenshot 2025-05-19 at 12 07 53 PM" src="https://github.com/user-attachments/assets/f08bddcf-e13e-4876-b891-65f7d1ac412f" />
