### PR TITLE
IR-9737: load mesh name from node instead of mesh data

### DIFF
--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -1298,7 +1298,7 @@ const loadMesh = async (options: GLTFParserOptions, entity: Entity, nodeIndex: n
   // }
 
   setComponent(entity, MeshComponent, mesh)
-  setComponent(entity, NameComponent, meshDef.name ?? 'Mesh-' + meshIndex)
+  setComponent(entity, NameComponent, node.name ?? meshDef.name ?? `Mesh-${meshIndex}`)
 
   setComponent(entity, MaterialInstanceComponent, {
     entities: materialEntities


### PR DESCRIPTION
## Summary

load mesh name from node instead of mesh data

**GLTF Example**
![image](https://github.com/user-attachments/assets/cf7443bc-f52f-4c6f-869c-4c57305bd977)

**Hierarchy panel**
![image](https://github.com/user-attachments/assets/31ddeb7d-41f3-45e1-bd63-5e6d09854245)

ticket: https://tsu.atlassian.net/browse/IR-9737

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
