### PR TITLE
Add Type naming conventions to Eslint Config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,17 @@ export default [
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-empty-object-type': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'warn',
+      '@typescript-eslint/naming-convention': ['error',
+        {
+          selector: "variableLike",
+          format: ["camelCase", "PascalCase"],
+          leadingUnderscore: "allow"
+        },
+        {
+          selector: "typeLike",
+          format: ["PascalCase"]
+        }
+      ],
       'prefer-const': 'warn',
       'no-loss-of-precision': 'warn',
       'no-async-promise-executor': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,11 +47,6 @@ export default [
       '@typescript-eslint/no-unsafe-function-type': 'warn',
       '@typescript-eslint/naming-convention': ['error',
         {
-          selector: "variableLike",
-          format: ["camelCase", "PascalCase"],
-          leadingUnderscore: "allow"
-        },
-        {
           selector: "typeLike",
           format: ["PascalCase"]
         }

--- a/packages/client-core/src/systems/components/XRCheckboxButton/index.tsx
+++ b/packages/client-core/src/systems/components/XRCheckboxButton/index.tsx
@@ -28,7 +28,7 @@ import React from 'react'
 import { CheckLg } from '@ir-engine/ui/src/icons'
 import styleString from './index.scss?inline'
 
-type labelPositionVariant = 'start' | 'end' | 'none'
+type LabelPositionVariant = 'start' | 'end' | 'none'
 
 const XRCheckboxButton = (props) => {
   const {
@@ -36,7 +36,7 @@ const XRCheckboxButton = (props) => {
     labelContent,
     checked,
     ...inputProps
-  }: { labelPosition: labelPositionVariant; labelContent: any; checked: boolean; inputProps: any } = props
+  }: { labelPosition: LabelPositionVariant; labelContent: any; checked: boolean; inputProps: any } = props
 
   return (
     <>

--- a/packages/client-core/src/systems/components/XRIconButton/index.tsx
+++ b/packages/client-core/src/systems/components/XRIconButton/index.tsx
@@ -27,8 +27,8 @@ import React from 'react'
 
 import styleString from './index.scss?inline'
 
-type iconButtonVariant = 'filled' | 'iconOnly'
-type iconButtonSize = 'small' | 'medium' | 'large'
+type IconButtonVariant = 'filled' | 'iconOnly'
+type IconButtonSize = 'small' | 'medium' | 'large'
 
 const XRIconButton = (props) => {
   const {
@@ -42,8 +42,8 @@ const XRIconButton = (props) => {
     content: any
     className: any
     backgroundColor: string
-    size: iconButtonSize
-    variant: iconButtonVariant
+    size: IconButtonSize
+    variant: IconButtonVariant
     buttonProps: any
   } = props
 

--- a/packages/client-core/src/systems/components/XRSlider/index.tsx
+++ b/packages/client-core/src/systems/components/XRSlider/index.tsx
@@ -27,14 +27,14 @@ import React from 'react'
 
 import styleString from './index.scss?inline'
 
-type labelPositionVariant = 'start' | 'end' | 'none'
+type LabelPositionVariant = 'start' | 'end' | 'none'
 
 const XRSlider = (props) => {
   const {
     labelPosition = 'start',
     labelContent,
     ...inputProps
-  }: { labelPosition: labelPositionVariant; labelContent: any; inputProps: any } = props
+  }: { labelPosition: LabelPositionVariant; labelContent: any; inputProps: any } = props
 
   return (
     <>

--- a/packages/client-core/src/systems/components/XRTextButton/index.tsx
+++ b/packages/client-core/src/systems/components/XRTextButton/index.tsx
@@ -27,7 +27,7 @@ import React from 'react'
 
 import styleString from './index.scss?inline'
 
-type textButtonVariant = 'filled' | 'outlined' | 'gradient'
+type TextButtonVariant = 'filled' | 'outlined' | 'gradient'
 
 const XRTextButton = (props) => {
   const {
@@ -35,7 +35,7 @@ const XRTextButton = (props) => {
     className,
     children,
     ...buttonProps
-  }: { variant: textButtonVariant; className: any; content: any; children: React.ReactNode; buttonProps: any } = props
+  }: { variant: TextButtonVariant; className: any; content: any; children: React.ReactNode; buttonProps: any } = props
 
   return (
     <>

--- a/packages/client-core/src/systems/components/XRToggleButton/index.tsx
+++ b/packages/client-core/src/systems/components/XRToggleButton/index.tsx
@@ -27,14 +27,14 @@ import React from 'react'
 
 import styleString from './index.scss?inline'
 
-type labelPositionVariant = 'start' | 'end' | 'none'
+type LabelPositionVariant = 'start' | 'end' | 'none'
 
 const XRToggleButton = (props) => {
   const {
     labelPosition = 'start',
     labelContent,
     ...inputProps
-  }: { labelPosition: labelPositionVariant; labelContent: any; inputProps: any } = props
+  }: { labelPosition: LabelPositionVariant; labelContent: any; inputProps: any } = props
 
   return (
     <>

--- a/packages/client-core/src/systems/components/XRUploadButton/index.tsx
+++ b/packages/client-core/src/systems/components/XRUploadButton/index.tsx
@@ -27,14 +27,14 @@ import React from 'react'
 
 import styleString from './index.scss?inline'
 
-type uploadButtonVariant = 'filled' | 'outlined' | 'gradient'
+type UploadButtonVariant = 'filled' | 'outlined' | 'gradient'
 
 const XRUploadButton = (props) => {
   const {
     variant = 'filled',
     buttonContent,
     ...inputProps
-  }: { variant: uploadButtonVariant; buttonContent: any; inputProps: any } = props
+  }: { variant: UploadButtonVariant; buttonContent: any; inputProps: any } = props
 
   return (
     <>

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -35,7 +35,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import Toolbar from '../components/toolbar/Toolbar'
 import { cmdOrCtrlString } from '../functions/utils'
 import { EditorErrorState } from '../services/EditorErrorServices'
-import { EditorState, activeLowerPanel } from '../services/EditorServices'
+import { ActiveLowerPanel, EditorState } from '../services/EditorServices'
 import { SelectionState } from '../services/SelectionServices'
 import { DndWrapper } from './dnd/DndWrapper'
 import DragLayer from './dnd/DragLayer'
@@ -110,7 +110,7 @@ const onEditorError = (error) => {
 
 const defaultLayout = (flags: {
   visualScriptPanelEnabled: boolean
-  activeLowerPanel: activeLowerPanel
+  activeLowerPanel: ActiveLowerPanel
 }): LayoutData => {
   const tabs = [AssetsPanelTab]
   flags.visualScriptPanelEnabled && tabs.push(VisualScriptPanelTab)

--- a/packages/editor/src/panels/visualscript/hooks/useTemplateHandler.ts
+++ b/packages/editor/src/panels/visualscript/hooks/useTemplateHandler.ts
@@ -32,15 +32,15 @@ import { GraphTemplate, VisualScriptState } from '@ir-engine/visual-script'
 import { useSelectionHandler } from './useSelectionHandler'
 import { useVisualScriptFlow } from './useVisualScriptFlow'
 
-type selectionHandler = ReturnType<typeof useSelectionHandler>
-type visualScriptFlow = ReturnType<typeof useVisualScriptFlow>
+type SelectionHandler = ReturnType<typeof useSelectionHandler>
+type VisualScriptFlow = ReturnType<typeof useVisualScriptFlow>
 export const useTemplateHandler = ({
   selectedNodes,
   selectedEdges,
   pasteNodes,
   onNodesChange
-}: Pick<selectionHandler, 'pasteNodes'> &
-  Pick<visualScriptFlow, 'onNodesChange'> & {
+}: Pick<SelectionHandler, 'pasteNodes'> &
+  Pick<VisualScriptFlow, 'onNodesChange'> & {
     selectedNodes: Node[]
     selectedEdges: Edge[]
   }) => {

--- a/packages/editor/src/panels/visualscript/hooks/useVariableHandler.ts
+++ b/packages/editor/src/panels/visualscript/hooks/useVariableHandler.ts
@@ -29,12 +29,12 @@ import { VariableJSON } from '@ir-engine/visual-script'
 
 import { useVisualScriptFlow } from './useVisualScriptFlow'
 
-type visualScriptFlow = ReturnType<typeof useVisualScriptFlow>
+type VisualScriptFlow = ReturnType<typeof useVisualScriptFlow>
 
 export const useVariableHandler = ({
   variables,
   setVariables
-}: Pick<visualScriptFlow, 'variables' | 'setVariables'>) => {
+}: Pick<VisualScriptFlow, 'variables' | 'setVariables'>) => {
   const createVariable = (): VariableJSON => ({
     id: uuidv4(),
     name: 'variable ' + Math.random().toString(36).slice(-6),

--- a/packages/editor/src/panels/visualscript/sidepanel.tsx
+++ b/packages/editor/src/panels/visualscript/sidepanel.tsx
@@ -43,9 +43,9 @@ import { useTemplateHandler, useVariableHandler, useVisualScriptFlow } from './h
 import { Examples } from './modals/load'
 import { visualToFlow } from './transformers'
 
-type templateHandler = ReturnType<typeof useTemplateHandler>
-type variableHandler = ReturnType<typeof useVariableHandler>
-type visualScriptFlow = ReturnType<typeof useVisualScriptFlow>
+type TemplateHandler = ReturnType<typeof useTemplateHandler>
+type VariableHandler = ReturnType<typeof useVariableHandler>
+type VisualScriptFlow = ReturnType<typeof useVisualScriptFlow>
 
 export type SidePanelProps = {
   flowref: React.MutableRefObject<HTMLElement | null>
@@ -66,9 +66,9 @@ export const SidePanel = ({
   handleEditVariable,
   handleDeleteVariable
 }: SidePanelProps &
-  Pick<templateHandler, 'handleApplyTemplate' | 'handleDeleteTemplate' | 'handleEditTemplate' | 'handleAddTemplate'> &
-  Pick<visualScriptFlow, 'onNodesChange'> &
-  Pick<variableHandler, 'handleAddVariable' | 'handleDeleteVariable' | 'handleEditVariable'>) => {
+  Pick<TemplateHandler, 'handleApplyTemplate' | 'handleDeleteTemplate' | 'handleEditTemplate' | 'handleAddTemplate'> &
+  Pick<VisualScriptFlow, 'onNodesChange'> &
+  Pick<VariableHandler, 'handleAddVariable' | 'handleDeleteVariable' | 'handleEditVariable'>) => {
   const reactFlow = useReactFlow()
   const visualScriptState = useMutableState(VisualScriptState)
   const { t } = useTranslation()

--- a/packages/editor/src/panels/visualscript/util/colors.ts
+++ b/packages/editor/src/panels/visualscript/util/colors.ts
@@ -25,9 +25,9 @@ Infinite Reality Engine. All Rights Reserved.
 
 import { NodeSpecJSON } from '@ir-engine/visual-script'
 
-export type color = 'red' | 'green' | 'lime' | 'purple' | 'blue' | 'gray' | 'white' | 'orange' | 'cyan' | 'indigo'
+export type Color = 'red' | 'green' | 'lime' | 'purple' | 'blue' | 'gray' | 'white' | 'orange' | 'cyan' | 'indigo'
 
-export const colors: Record<color, [string, string, string]> = {
+export const colors: Record<Color, [string, string, string]> = {
   red: ['bg-rose-900', 'border-[#dd6b20]', 'text-[#fff]'],
   green: ['bg-green-900', 'border-[#38a169]', 'text-[#fff]'],
   lime: ['bg-[#84cc16]', 'border-[#84cc16]', 'text-[#2d3748]'],
@@ -49,7 +49,7 @@ export const valueTypeColorMap: Record<string, string> = {
   string: 'purple'
 }
 
-export const categoryColorMap: Record<NodeSpecJSON['category'], color> = {
+export const categoryColorMap: Record<NodeSpecJSON['category'], Color> = {
   Logic: 'red',
   Math: 'purple',
   Engine: 'blue',

--- a/packages/editor/src/services/EditorServices.ts
+++ b/packages/editor/src/services/EditorServices.ts
@@ -40,7 +40,7 @@ export enum UIMode {
   ADVANCED = 'ADVANCED'
 }
 
-export type activeLowerPanel = 'properties' | 'inspector'
+export type ActiveLowerPanel = 'properties' | 'inspector'
 
 export const EditorState = defineState({
   name: 'EditorState',
@@ -56,9 +56,9 @@ export const EditorState = defineState({
     uiEnabled: true,
     uiMode: UIMode.ADVANCED,
     canvasRef: null as React.RefObject<HTMLElement> | null,
-    activeLowerPanel: 'properties' as activeLowerPanel
+    activeLowerPanel: 'properties' as ActiveLowerPanel
   }),
-  setActiveLowerPanel: (panel: activeLowerPanel) => {
+  setActiveLowerPanel: (panel: ActiveLowerPanel) => {
     getMutableState(EditorState).activeLowerPanel.set(panel)
   },
   useIsModified: () => {

--- a/packages/engine/src/scene/components/UVOL2Component.ts
+++ b/packages/engine/src/scene/components/UVOL2Component.ts
@@ -76,7 +76,7 @@ import { AssetState } from '../../gltf/GLTFState'
 import {
   ASTCTextureTarget,
   AudioFileFormat,
-  DRACO_Manifest,
+  DracoManifest,
   FORMAT_TO_EXTENSION,
   GeometryFormat,
   KTX2TextureTarget,
@@ -84,7 +84,7 @@ import {
   TextureFormat,
   TextureType,
   UniformSolveTarget,
-  UVOL_TYPE
+  UvolType
 } from '../constants/LegacyUVOLTypes'
 import { PlayMode } from '../constants/PlayMode'
 import { handleAutoplay, LegacyVolumetricComponent } from './LegacyVolumetricComponent'
@@ -499,7 +499,7 @@ function UVOL2Reactor() {
   const material = useMemo(() => {
     const manifest = component.data.value
     let _material: ShaderMaterial | MeshBasicMaterial = new MeshBasicMaterial({ color: 0xffffff })
-    if (manifest.type === UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
+    if (manifest.type === UvolType.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
       const firstTarget = Object.keys(manifest.geometry.targets)[0]
       const hasNormals = !manifest.geometry.targets[firstTarget].settings.excludeNormals
       const shaderType = hasNormals ? 'physical' : 'basic'
@@ -597,7 +597,7 @@ transformed.z += mix(keyframeA.z, keyframeB.z, mixRatio);
     }
 
     const [sortedManifest, sortedGeometryTargets, sortedTextureTargets, useVideoTexture] = calculatePriority(
-      component.data.get({ noproxy: true }) as DRACO_Manifest
+      component.data.get({ noproxy: true }) as DracoManifest
     )
     component.data.set(sortedManifest)
     component.geometryInfo.targets.set(sortedGeometryTargets)
@@ -643,7 +643,7 @@ transformed.z += mix(keyframeA.z, keyframeB.z, mixRatio);
     }
 
     const shadow = getMutableComponent(entity, ShadowComponent)
-    if (sortedManifest.type === UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
+    if (sortedManifest.type === UvolType.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
       // TODO: Cast shadows properly with uniform solve
       shadow.cast.set(false)
       shadow.receive.set(false)
@@ -764,7 +764,7 @@ transformed.z += mix(keyframeA.z, keyframeB.z, mixRatio);
 
   useEffect(() => {
     if (!shadow) return
-    if (component.data.value.type === UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
+    if (component.data.value.type === UvolType.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
       // TODO: Cast shadows properly with uniform solve
       shadow.cast.set(false)
       shadow.receive.set(false)
@@ -1095,7 +1095,7 @@ transformed.z += mix(keyframeA.z, keyframeB.z, mixRatio);
       let headerTemplate: RegExp | undefined = /\/\/\sHEADER_REPLACE_START([\s\S]*?)\/\/\sHEADER_REPLACE_END/
       let mainTemplate: RegExp | undefined = /\/\/\sMAIN_REPLACE_START([\s\S]*?)\/\/\sMAIN_REPLACE_END/
 
-      if (component.data.value.type !== UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE || 1 == 1) {
+      if (component.data.value.type !== UvolType.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE || 1 == 1) {
         headerTemplate = undefined
         mainTemplate = undefined
       }
@@ -1498,7 +1498,7 @@ transformed.z += mix(keyframeA.z, keyframeB.z, mixRatio);
   }
 
   const updateGeometry = (currentTime: number) => {
-    if (component.data.value.type === UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
+    if (component.data.value.type === UvolType.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
       updateUniformSolve(currentTime)
     } else {
       updateNonUniformSolve(currentTime)

--- a/packages/engine/src/scene/constants/LegacyUVOLTypes.ts
+++ b/packages/engine/src/scene/constants/LegacyUVOLTypes.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-export enum UVOL_TYPE {
+export enum UvolType {
   DRACO_WITH_COMPRESSED_TEXTURE = 0,
   GLB_WITH_COMPRESSED_TEXTURE = 1,
   UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE = 2
@@ -390,31 +390,31 @@ export interface BasePlayerManifest {
   deletePreviousBuffers: boolean
 }
 
-export interface DRACO_Manifest extends BasePlayerManifest {
-  type: UVOL_TYPE.DRACO_WITH_COMPRESSED_TEXTURE
+export interface DracoManifest extends BasePlayerManifest {
+  type: UvolType.DRACO_WITH_COMPRESSED_TEXTURE
   geometry: {
     targets: Record<string, DRACOTarget>
     path: EncoderManifest['geometryOutputPath']
   }
 }
 
-export interface GLB_Manifest extends BasePlayerManifest {
-  type: UVOL_TYPE.GLB_WITH_COMPRESSED_TEXTURE
+export interface GlbManifest extends BasePlayerManifest {
+  type: UvolType.GLB_WITH_COMPRESSED_TEXTURE
   geometry: {
     targets: Record<string, GLBTarget>
     path: EncoderManifest['geometryOutputPath']
   }
 }
 
-export interface UniformSolve_Manifest extends BasePlayerManifest {
-  type: UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE
+export interface UniformSolveManifest extends BasePlayerManifest {
+  type: UvolType.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE
   geometry: {
     targets: Record<string, UniformSolveTarget>
     path: EncoderManifest['geometryOutputPath']
   }
 }
 
-export type PlayerManifest = DRACO_Manifest | GLB_Manifest | UniformSolve_Manifest
+export type PlayerManifest = DracoManifest | GlbManifest | UniformSolveManifest
 
 export const ABC_TO_OBJ_PADDING = 7
 

--- a/packages/engine/src/scene/constants/UVOLTypes.ts
+++ b/packages/engine/src/scene/constants/UVOLTypes.ts
@@ -84,7 +84,7 @@ export interface KTX2EncodeOptions {
   vflip?: boolean
 }
 
-export enum UVOL_TYPE {
+export enum UvolType {
   DRACO_WITH_COMPRESSED_TEXTURE = 0,
   GLB_WITH_COMPRESSED_TEXTURE = 1,
   UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE = 2
@@ -402,23 +402,23 @@ export interface BasePlayerManifest {
   deletePreviousBuffers: boolean
 }
 
-export interface DRACO_Manifest extends BasePlayerManifest {
-  type: UVOL_TYPE.DRACO_WITH_COMPRESSED_TEXTURE
+export interface DracoManifest extends BasePlayerManifest {
+  type: UvolType.DRACO_WITH_COMPRESSED_TEXTURE
   geometry: {
     targets: Record<string, DRACOTarget>
     path: EncoderManifest['geometryOutputPath']
   }
 }
 
-export interface UniformSolve_Manifest extends BasePlayerManifest {
-  type: UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE
+export interface UniformSolveManifest extends BasePlayerManifest {
+  type: UvolType.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE
   geometry: {
     targets: Record<string, UniformSolveTarget>
     path: EncoderManifest['geometryOutputPath']
   }
 }
 
-export type PlayerManifest = DRACO_Manifest | UniformSolve_Manifest
+export type PlayerManifest = DracoManifest | UniformSolveManifest
 
 export const ABC_TO_OBJ_PADDING = 7
 

--- a/packages/engine/src/scene/util/VolumetricBufferingUtils.ts
+++ b/packages/engine/src/scene/util/VolumetricBufferingUtils.ts
@@ -93,7 +93,7 @@ export const bufferLimits = {
   }
 }
 
-interface fetchProps {
+interface FetchProps {
   manifest: OldManifestSchema | ManifestSchema | Record<string, never>
   manifestPath: string
   currentTimeInMS: number
@@ -102,7 +102,7 @@ interface fetchProps {
   startTimeInMS: number
 }
 
-interface fetchGeometryProps extends fetchProps {
+interface FetchGeometryProps extends FetchProps {
   geometryType: GeometryType
   geometryBuffer: Map<string, (Mesh<BufferGeometry, Material> | BufferGeometry | KeyframeAttribute)[]>
   mesh: Mesh<BufferGeometry, ShaderMaterial>
@@ -124,7 +124,7 @@ export const fetchGeometry = ({
   startTimeInMS,
   repeat,
   offset
-}: fetchGeometryProps) => {
+}: FetchGeometryProps) => {
   if (Object.keys(manifest).length === 0) return
   const currentTime = currentTimeInMS * (TIME_UNIT_MULTIPLIER / 1000)
   const nextMissing = bufferData.getNextMissing(currentTime)
@@ -358,7 +358,7 @@ export const fetchGeometry = ({
   }
 }
 
-interface deleteUsedGeometryBuffersProps {
+interface DeleteUsedGeometryBuffersProps {
   currentTimeInMS: number
   bufferData?: BufferDataContainer
   geometryType: GeometryType
@@ -378,7 +378,7 @@ export const deleteUsedGeometryBuffers = ({
   frameRate,
   mesh,
   clearAll = false
-}: deleteUsedGeometryBuffersProps) => {
+}: DeleteUsedGeometryBuffersProps) => {
   if (geometryType === GeometryType.Corto || geometryType === GeometryType.Draco) {
     let _frameRate = frameRate || 1
 
@@ -470,7 +470,7 @@ export const deleteUsedGeometryBuffers = ({
   }
 }
 
-interface fetchTextureProps extends fetchProps {
+interface FetchTextureProps extends FetchProps {
   textureType: TextureType
   textureBuffer: Map<string, CompressedTexture[]>
   textureFormat: TextureFormat
@@ -489,7 +489,7 @@ export const fetchTextures = ({
   textureFormat,
   initialBufferLoaded,
   startTimeInMS
-}: fetchTextureProps) => {
+}: FetchTextureProps) => {
   const currentTime = currentTimeInMS * (TIME_UNIT_MULTIPLIER / 1000)
 
   const nextMissing = bufferData.getNextMissing(currentTime)
@@ -574,7 +574,7 @@ export const fetchTextures = ({
   }
 }
 
-interface deleteUsedTextureBuffersProps {
+interface DeleteUsedTextureBuffersProps {
   currentTimeInMS: number
   bufferData?: BufferDataContainer
   textureBuffer: Map<string, CompressedTexture[]>
@@ -590,7 +590,7 @@ export const deleteUsedTextureBuffers = ({
   textureType,
   targetData,
   clearAll = false
-}: deleteUsedTextureBuffersProps) => {
+}: DeleteUsedTextureBuffersProps) => {
   for (const [target, collection] of textureBuffer) {
     if (!collection || !targetData || !targetData[target]) {
       continue

--- a/packages/engine/src/scene/util/VolumetricUtils.ts
+++ b/packages/engine/src/scene/util/VolumetricUtils.ts
@@ -644,13 +644,13 @@ export const getTexture = ({
   return false
 }
 
-interface handleAutoplayProps {
+interface HandleAutoplayProps {
   audioContext: AudioContext
   media: HTMLMediaElement
   paused: State<boolean>
 }
 
-export const handleMediaAutoplay = ({ audioContext, media, paused }: handleAutoplayProps) => {
+export const handleMediaAutoplay = ({ audioContext, media, paused }: HandleAutoplayProps) => {
   const attachEventListeners = () => {
     const canvas = getComponent(Engine.instance.viewerEntity, RendererComponent).canvas!
     const playMedia = () => {

--- a/packages/instanceserver/src/MediasoupRecordingSystem.ts
+++ b/packages/instanceserver/src/MediasoupRecordingSystem.ts
@@ -201,7 +201,7 @@ export const startMediaRecordingPair = async (
   }
 }
 
-type onUploadPartArgs = {
+type OnUploadPartArgs = {
   recordingID: RecordingID
   key: string
   body: PassThrough

--- a/packages/server-core/src/matchmaking/match-instance/match-instance.test.ts
+++ b/packages/server-core/src/matchmaking/match-instance/match-instance.test.ts
@@ -46,7 +46,7 @@ interface User {
   id: string
 }
 
-interface ticketsTestData {
+interface TicketsTestData {
   id: string
   ticket: MatchTicketType
   connection: string
@@ -57,7 +57,7 @@ describe.skip('matchmaking match-instance service', () => {
   let scope: nock.Scope
   const ticketsNumber = 3
   const users: User[] = []
-  const tickets: ticketsTestData[] = []
+  const tickets: TicketsTestData[] = []
   const gameMode = 'test-private-test'
   const tier = 'bronze'
 

--- a/packages/spatial/src/xr/8thwall/XR8Types.ts
+++ b/packages/spatial/src/xr/8thwall/XR8Types.ts
@@ -124,7 +124,7 @@ export type CameraPipelineModule = {
   onRender?: () => void
   onResume?: () => void
   onStart?: () => void
-  onUpdate?: (props: onUpdate) => void
+  onUpdate?: (props: OnUpdate) => void
   onVideoSizeChange?: () => void
   requiredPermission?: () => void
   listeners?: Array<CameraPipelineModuleListeners>
@@ -256,7 +256,7 @@ type GPUResult = {
   }
 }
 
-export type onUpdate = {
+export type OnUpdate = {
   framework: {
     dispatchEvent: (event: any) => void
   }

--- a/packages/spatial/src/xr/XRDepthOcclusion.tsx
+++ b/packages/spatial/src/xr/XRDepthOcclusion.tsx
@@ -176,7 +176,7 @@ function removeDepthOBCPlugin(material: Material) {
 }
 
 /** frame.getDepthInformation has no type currently */
-type getDepthInformationType = {
+type GetDepthInformationType = {
   getDepthInformation: (view: XRView) => XRCPUDepthInformation
 }
 
@@ -186,7 +186,7 @@ type getDepthInformationType = {
  * @returns
  */
 function updateDepthMaterials(
-  frame: XRFrame & getDepthInformationType,
+  frame: XRFrame & GetDepthInformationType,
   referenceSpace: XRReferenceSpace,
   depthTexture?: DepthCanvasTexture
 ) {
@@ -270,7 +270,7 @@ function DepthOcclusionReactor({ obj }) {
 
 const execute = () => {
   const xrFrame = getState(XRState).xrFrame
-  const xrFrameD = xrFrame as XRFrame & getDepthInformationType
+  const xrFrameD = xrFrame as XRFrame & GetDepthInformationType
   depthSupported = typeof xrFrameD?.getDepthInformation === 'function'
   if (!depthSupported) return
   XRDepthOcclusion.updateDepthMaterials(xrFrame as any, ReferenceSpace.origin!, depthTexture)

--- a/scripts/install-manifest.ts
+++ b/scripts/install-manifest.ts
@@ -90,7 +90,7 @@ const fetchManifest = async () => {
   }
 }
 
-interface PackageManifest_V_1_0_0 {
+interface PackageManifestV100 {
   version: string // semver
   name: string
   packages: Array<string>
@@ -98,7 +98,7 @@ interface PackageManifest_V_1_0_0 {
 
 const installManifest = async () => {
   const { branch, singleBranch } = options // ?? 'main' -> unnecessary coalescing operator, leveraging default value from cli settings instead
-  const manifest = (await fetchManifest()) as PackageManifest_V_1_0_0
+  const manifest = (await fetchManifest()) as PackageManifestV100
   const replacing = options.replace?.toLowerCase() === 'yes' || options.replace?.toLowerCase() === 'y'
   if (!manifest) throw new Error('No manifest found')
   if (!manifest.version) throw new Error('No version found in manifest')


### PR DESCRIPTION
## Summary
Given that types typically don't have a naming convention recommend in typscript for us to maintain ours we need a custom eslint configuration rule to adhere to our standard. 