### PR TITLE
IR-9980: Fix lock and visibility icons shifting off-screen 

### DIFF
--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -433,7 +433,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
             'flex items-center justify-between gap-x-2 bg-inherit pr-2',
             rootEntity === entity ? 'p-2' : 'py-1 pr-2'
           )}
-          style={{ width: `calc(100% - ${node.depth * 0.75}rem)`, marginLeft: `${node.depth * 0.75}rem` }}
+          style={{ marginLeft: `${node.depth * 0.75}rem` }}
           ref={onDropTarget}
         >
           {node.isLeaf ? (

--- a/packages/editor/src/panels/hierarchy/hierarchynode.tsx
+++ b/packages/editor/src/panels/hierarchy/hierarchynode.tsx
@@ -430,10 +430,10 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
         />
         <div
           className={twMerge(
-            'flex w-full items-center justify-between gap-x-2 bg-inherit pr-2',
-            rootEntity === entity ? 'p-2' : 'py-1 pl-10 pr-2'
+            'flex items-center justify-between gap-x-2 bg-inherit pr-2',
+            rootEntity === entity ? 'p-2' : 'py-1 pr-2'
           )}
-          style={{ marginLeft: `${node.depth * 0.75}rem` }}
+          style={{ width: `calc(100% - ${node.depth * 0.75}rem)`, marginLeft: `${node.depth * 0.75}rem` }}
           ref={onDropTarget}
         >
           {node.isLeaf ? (
@@ -476,7 +476,7 @@ export default React.memo(function HierarchyTreeNode(props: ListChildComponentPr
             ) : (
               <div className="grid min-w-0 text-nowrap rounded bg-transparent px-0.5 py-0 ">
                 <span
-                  className="overflow-x-auto text-nowrap text-sm"
+                  className="overflow-x-auto truncate text-nowrap text-sm"
                   style={{ scrollbarWidth: `none` }}
                   data-testid="hierarchy-panel-scene-item-name"
                 >


### PR DESCRIPTION
## Summary

With this change lock and visibility icons are always kept are the right edge of the list. 

![image](https://github.com/user-attachments/assets/4791482c-b083-442c-aa5b-79f4ab4774d9)

**Ticket:**  https://tsu.atlassian.net/browse/IR-9980 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
