### PR TITLE
adds a check for a RigidBodyComponenet on entity Ancestor

### DIFF
--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -162,10 +162,7 @@ const componentDependenciesLoaded = (dependencies?: ComponentDependencies) => {
 }
 
 const checkCollider = (hasCollider: boolean, entity: Entity) => {
-  if (
-    getAncestorWithComponents(entity, [RigidBodyComponent]) === undefined ||
-    !hasComponent(entity, SimulationLayerComponent)
-  )
+  if (!getAncestorWithComponents(entity, [RigidBodyComponent]) || !hasComponent(entity, SimulationLayerComponent))
     return true
   return hasCollider
 }

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -44,6 +44,7 @@ import {
   Layers,
   removeComponent,
   setComponent,
+  SimulationLayerComponent,
   SourceID,
   UndefinedEntity,
   useAncestorWithComponents,
@@ -161,7 +162,11 @@ const componentDependenciesLoaded = (dependencies?: ComponentDependencies) => {
 }
 
 const checkCollider = (hasCollider: boolean, entity: Entity) => {
-  if (getAncestorWithComponents(entity, [RigidBodyComponent]) === undefined) return true
+  if (
+    getAncestorWithComponents(entity, [RigidBodyComponent]) === undefined ||
+    !hasComponent(entity, SimulationLayerComponent)
+  )
+    return true
   return hasCollider
 }
 

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -33,6 +33,7 @@ import {
   Entity,
   EntityID,
   EntityUUID,
+  getAncestorWithComponents,
   getComponent,
   getMutableComponent,
   getOptionalComponent,
@@ -60,6 +61,7 @@ import { getMutableState, getState, NO_PROXY_STEALTH, none, State, useHookstate 
 import { TransformComponent } from '@ir-engine/spatial'
 import { ActiveHelperComponent } from '@ir-engine/spatial/src/common/ActiveHelperComponent'
 import { ColliderComponent } from '@ir-engine/spatial/src/physics/components/ColliderComponent'
+import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 import { ShapeSchema } from '@ir-engine/spatial/src/physics/types/PhysicsTypes'
 import { MeshComponent } from '@ir-engine/spatial/src/renderer/components/MeshComponent'
 import { ObjectLayerMaskComponent } from '@ir-engine/spatial/src/renderer/components/ObjectLayerComponent'
@@ -147,7 +149,7 @@ export const GLTFComponent = defineComponent({
 
 type DependencyEval = {
   key: string
-  eval: (val: unknown) => boolean
+  eval: (val: unknown, entity?: Entity) => boolean
 }
 
 type ComponentDependencies = {
@@ -156,6 +158,11 @@ type ComponentDependencies = {
 
 const componentDependenciesLoaded = (dependencies?: ComponentDependencies) => {
   return !!dependencies && Object.keys(dependencies.componentDependencies).length === 0
+}
+
+const checkCollider = (hasCollider: boolean, entity: Entity) => {
+  if (getAncestorWithComponents(entity, [RigidBodyComponent]) === undefined) return true
+  return hasCollider
 }
 
 const loadDependencies = {
@@ -168,7 +175,7 @@ const loadDependencies = {
   [ColliderComponent.jsonID]: [
     {
       key: 'hasCollider',
-      eval: (hasCollider: boolean) => hasCollider
+      eval: (hasCollider: boolean, entity: Entity) => checkCollider(hasCollider, entity)
     }
   ]
 } as Record<string, DependencyEval[]>
@@ -348,7 +355,7 @@ const ComponentReactor = (props: { gltfComponentEntity: Entity; entity: Entity; 
   useEffect(() => {
     const compValue = comp.value
     for (const dep of dependencies) {
-      if (!dep.eval(compValue[dep.key])) return
+      if (!dep.eval(compValue[dep.key], entity)) return
     }
 
     removeGLTFDependency()

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -279,10 +279,9 @@ export const GLTFComponentReactor = () => {
   const scene = useOptionalComponent(entity, SceneComponent)
 
   useEffect(() => {
-    if (!sceneLoaded || !scene) return
-    setComponent(entity, SceneComponent)
+    if (!sceneLoaded) return
     setComponent(entity, ActiveHelperComponent, { volumeEnabled: true })
-  }, [sceneLoaded, !!scene])
+  }, [sceneLoaded])
 
   const dependencies = gltfComponent.dependencies.get(NO_PROXY_STEALTH) as ComponentDependencies | undefined
 

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -276,8 +276,6 @@ export const GLTFComponentReactor = () => {
     }
   }, [gltfComponent.document])
 
-  const scene = useOptionalComponent(entity, SceneComponent)
-
   useEffect(() => {
     if (!sceneLoaded) return
     setComponent(entity, ActiveHelperComponent, { volumeEnabled: true })

--- a/packages/engine/src/gltf/GLTFLoader.test.tsx
+++ b/packages/engine/src/gltf/GLTFLoader.test.tsx
@@ -43,8 +43,16 @@ import {
   UUIDComponent
 } from '@ir-engine/ecs'
 import { createEngine, destroyEngine } from '@ir-engine/ecs/src/Engine'
-import { DirectionalLightComponent, PointLightComponent, SpotLightComponent } from '@ir-engine/spatial'
+import {
+  DirectionalLightComponent,
+  PointLightComponent,
+  SpotLightComponent,
+  TransformComponent
+} from '@ir-engine/spatial'
 import { CameraComponent } from '@ir-engine/spatial/src/camera/components/CameraComponent'
+import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics'
+import { ColliderComponent } from '@ir-engine/spatial/src/physics/components/ColliderComponent'
+import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 import { BoneComponent } from '@ir-engine/spatial/src/renderer/components/BoneComponent'
 import { MeshComponent } from '@ir-engine/spatial/src/renderer/components/MeshComponent'
 import { SceneComponent } from '@ir-engine/spatial/src/renderer/components/SceneComponents'
@@ -77,6 +85,8 @@ const instanced_gltf = base_url + '/instanced/SimpleInstancing.gltf'
 const default_url = 'packages/projects/default-project/assets'
 const animation_pack = default_url + '/animations/emotes.glb'
 const rings_gltf = default_url + '/rings.glb'
+const collider_and_rigidbody_gltf = base_url + '/physics/ColliderAndRigidbody.gltf'
+const collider_gltf = base_url + '/physics/ColliderOnly.gltf'
 
 const waitForScene = (entity: Entity) => vi.waitUntil(() => GLTFComponent.isSceneLoaded(entity), { timeout: 10000 })
 
@@ -92,12 +102,26 @@ const setupEntity = () => {
   return entity
 }
 
+const setupPhysicsEntity = () => {
+  const parent = createEntity()
+  setComponent(parent, SceneComponent)
+  setComponent(parent, EntityTreeComponent)
+  const uuid = 'source' as SourceID
+  setComponent(parent, UUIDComponent, { entitySourceID: uuid, entityID: 'test' as EntityID })
+  setComponent(parent, TransformComponent)
+  Physics.createWorld(parent)
+  const entity = createEntity()
+  setComponent(entity, EntityTreeComponent, { parentEntity: parent })
+  return entity
+}
+
 describe('GLTF Loader', async () => {
   overrideFileLoaderLoad()
 
   beforeEach(async () => {
     createEngine()
     startEngineReactor()
+    await Physics.load()
 
     await act(() => render(null))
   })
@@ -733,5 +757,50 @@ describe('GLTF Loader', async () => {
     await loadPromise
 
     assert(!hasComponent(entity, GLTFComponent))
+  })
+
+  it('loads a GLTF with a collider and a rigidbody creates a dependency', async () => {
+    const entity = setupPhysicsEntity()
+
+    setComponent(entity, UUIDComponent, { entitySourceID: 'source' as SourceID, entityID: 'test' as EntityID })
+    setComponent(entity, GLTFComponent, { src: collider_and_rigidbody_gltf })
+
+    await waitForScene(entity)
+
+    const colliderEntities = getChildrenWithComponents(entity, [ColliderComponent])
+    expect(colliderEntities.length).toBeGreaterThan(0)
+
+    const colliderWithoutRigidbody = colliderEntities.find((e) => !hasComponent(e, RigidBodyComponent))
+    expect(colliderWithoutRigidbody).toBeDefined()
+
+    const colliderEntity = getChildrenWithComponents(entity, [ColliderComponent])[0]
+    assert(getComponent(colliderEntity, ColliderComponent).hasCollider === true)
+
+    const dependencies = getComponent(entity, GLTFComponent).dependencies
+    expect(dependencies).toBeDefined()
+
+    const uuid = UUIDComponent.get(colliderWithoutRigidbody!)
+    expect(dependencies?.componentDependencies[uuid]).toBeUndefined()
+  })
+
+  it('loads a GLTF with Detached collider', async () => {
+    const entity = setupPhysicsEntity()
+
+    setComponent(entity, UUIDComponent, { entitySourceID: 'source' as SourceID, entityID: 'test' as EntityID })
+    setComponent(entity, GLTFComponent, { src: collider_gltf })
+
+    await waitForScene(entity)
+
+    const colliderEntities = getChildrenWithComponents(entity, [ColliderComponent])
+    expect(colliderEntities.length).toBeGreaterThan(0)
+
+    const colliderEntity = getChildrenWithComponents(entity, [ColliderComponent])[0]
+    assert(getComponent(colliderEntity, ColliderComponent).hasCollider === false)
+
+    const colliderWithoutRigidbody = colliderEntities.find((e) => !hasComponent(e, RigidBodyComponent))
+    expect(colliderWithoutRigidbody).toBeDefined()
+
+    const rigidbodyEntities = getChildrenWithComponents(entity, [RigidBodyComponent])
+    expect(rigidbodyEntities.length).toBe(0)
   })
 })

--- a/packages/engine/tests/assets/physics/ColliderAndRigidbody.gltf
+++ b/packages/engine/tests/assets/physics/ColliderAndRigidbody.gltf
@@ -1,0 +1,521 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "THREE.GLTFExporter"
+  },
+  "scenes": [
+    {
+      "name": "platform",
+      "nodes": [
+        2
+      ],
+      "extras": {
+        "src": "__$project$__/default-project/assets/platform.glb"
+      }
+    }
+  ],
+  "scene": 0,
+  "nodes": [
+    {
+      "matrix": [
+        10,
+        0,
+        0,
+        0,
+        0,
+        0.10000000149011612,
+        0,
+        0,
+        0,
+        0,
+        10,
+        0,
+        0,
+        -0.10000000149011612,
+        0,
+        1
+      ],
+      "name": "Collider",
+      "extras": {
+        "name": "Collider"
+      },
+      "mesh": 0,
+      "extensions": {
+        "EE_uuid": "0b77bd2a-245e-4717-8938-ff5946c6fd6d",
+        "EE_collider": {
+          "shape": "box",
+          "mass": 1,
+          "massCenter": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "friction": 0.5,
+          "restitution": 0.5,
+          "collisionLayer": 1,
+          "collisionMask": 7
+        },
+        "EE_shadow": {
+          "cast": true,
+          "receive": true
+        },
+        "EE_envmap": {
+          "type": "Skybox",
+          "envMapTextureType": "Equirectangular",
+          "envMapSourceColor": 4095,
+          "envMapSourceURL": "",
+          "envMapSourceEntityUUID": "",
+          "envMapIntensity": 1
+        }
+      }
+    },
+    {
+      "name": "Geometry",
+      "extras": {
+        "name": "Geometry"
+      },
+      "mesh": 1,
+      "extensions": {
+        "EE_uuid": "80f1b0f4-8760-43da-9268-8967f12a74c4",
+        "EE_visible": true,
+        "EE_shadow": {
+          "cast": true,
+          "receive": true
+        },
+        "EE_envmap": {
+          "type": "Skybox",
+          "envMapTextureType": "Equirectangular",
+          "envMapSourceColor": 4095,
+          "envMapSourceURL": "",
+          "envMapSourceEntityUUID": "",
+          "envMapIntensity": 1
+        }
+      }
+    },
+    {
+      "name": "Base",
+      "children": [
+        0,
+        1
+      ],
+      "extensions": {
+        "EE_uuid": "340406cb-0abc-4855-bc02-0b80f4f5602f",
+        "EE_rigidbody": {
+          "type": "fixed",
+          "ccd": false,
+          "allowRolling": true,
+          "enabledRotations": [
+            true,
+            true,
+            true
+          ],
+          "canSleep": true,
+          "gravityScale": 1
+        },
+        "EE_visible": true
+      }
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 288,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 576,
+      "byteLength": 192,
+      "target": 34962,
+      "byteStride": 8
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 768,
+      "byteLength": 144,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 912,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 1200,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 1488,
+      "byteLength": 192,
+      "target": 34962,
+      "byteStride": 8
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 1680,
+      "byteLength": 144,
+      "target": 34963
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 1824
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1,
+        1
+      ],
+      "min": [
+        -1,
+        -1,
+        -1
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1,
+        1
+      ],
+      "min": [
+        -1,
+        -1,
+        -1
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.875,
+        1
+      ],
+      "min": [
+        0.125,
+        0
+      ],
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5125,
+      "count": 36,
+      "max": [
+        23
+      ],
+      "min": [
+        0
+      ],
+      "type": "SCALAR"
+    },
+    {
+      "bufferView": 4,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        10,
+        0,
+        10
+      ],
+      "min": [
+        -10,
+        -0.20000000298023224,
+        -10
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 5,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1,
+        1
+      ],
+      "min": [
+        -1,
+        -1,
+        -1
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 6,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.875,
+        1
+      ],
+      "min": [
+        0.125,
+        0
+      ],
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 7,
+      "componentType": 5125,
+      "count": 36,
+      "max": [
+        23
+      ],
+      "min": [
+        0
+      ],
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "name": "Material",
+      "extras": {
+        "plugins": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "CSMPlugin": {
+          "id": "CSM0.9043409238087623",
+          "priority": 1
+        }
+      },
+      "extensions": {
+        "EE_material": {
+          "uuid": "7e03c4c7-69a6-4a75-b7a8-e0aea366418a",
+          "name": "Material",
+          "prototype": "MeshStandardMaterial",
+          "plugins": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "args": {
+            "alphaTest": {
+              "type": "float",
+              "contents": 0
+            },
+            "alphaMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "map": {
+              "type": "texture",
+              "contents": null
+            },
+            "color": {
+              "type": "color",
+              "contents": 16777215
+            },
+            "opacity": {
+              "type": "float",
+              "contents": 1
+            },
+            "blending": {
+              "type": "select",
+              "contents": 1
+            },
+            "depthTest": {
+              "type": "boolean",
+              "contents": true
+            },
+            "depthWrite": {
+              "type": "boolean",
+              "contents": true
+            },
+            "side": {
+              "type": "select",
+              "contents": 0
+            },
+            "toneMapped": {
+              "type": "boolean",
+              "contents": true
+            },
+            "transparent": {
+              "type": "boolean",
+              "contents": false
+            },
+            "vertexColors": {
+              "type": "boolean",
+              "contents": false
+            },
+            "emissive": {
+              "type": "color",
+              "contents": 0
+            },
+            "emissiveMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "emissiveIntensity": {
+              "type": "float",
+              "contents": 1
+            },
+            "combine": {
+              "type": "select"
+            },
+            "envMapIntensity": {
+              "type": "float",
+              "contents": 1
+            },
+            "reflectivity": {
+              "type": "float"
+            },
+            "refractionRatio": {
+              "type": "float"
+            },
+            "normalMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "normalMapType": {
+              "type": "select",
+              "contents": 0
+            },
+            "normalScale": {
+              "type": "vec2",
+              "contents": {
+                "x": 1,
+                "y": 1
+              }
+            },
+            "bumpMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "bumpScale": {
+              "type": "float",
+              "contents": 1
+            },
+            "displacementMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "displacementScale": {
+              "type": "float",
+              "contents": 1
+            },
+            "displacementBias": {
+              "type": "float",
+              "contents": 0
+            },
+            "roughness": {
+              "type": "float",
+              "contents": 1
+            },
+            "roughnessMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "metalness": {
+              "type": "float",
+              "contents": 0
+            },
+            "metalnessMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "aoMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "aoMapIntensity": {
+              "type": "float",
+              "contents": 1
+            },
+            "lightMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "lightMapIntensity": {
+              "type": "float",
+              "contents": 1
+            }
+          }
+        }
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "mode": 4,
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1,
+            "TEXCOORD_0": 2
+          },
+          "indices": 3,
+          "material": 0
+        }
+      ],
+      "extensions": {
+        "EE_resourceId": {
+          "resourceId": "1523377b-707e-43d4-9154-11c6ed710de5"
+        }
+      }
+    },
+    {
+      "primitives": [
+        {
+          "mode": 4,
+          "attributes": {
+            "POSITION": 4,
+            "NORMAL": 5,
+            "TEXCOORD_0": 6
+          },
+          "indices": 7,
+          "material": 0
+        }
+      ],
+      "extensions": {
+        "EE_resourceId": {
+          "resourceId": "12b43d2a-a89d-4c1b-9058-065989af7687"
+        }
+      }
+    }
+  ],
+  "extensionsUsed": [
+    "EE_material",
+    "EE_resourceId",
+    "EE_uuid",
+    "EE_collider",
+    "EE_shadow",
+    "EE_envmap",
+    "EE_ecs",
+    "EE_visible",
+    "EE_rigidbody"
+  ]
+}

--- a/packages/engine/tests/assets/physics/ColliderOnly.gltf
+++ b/packages/engine/tests/assets/physics/ColliderOnly.gltf
@@ -1,0 +1,508 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "THREE.GLTFExporter"
+  },
+  "scenes": [
+    {
+      "name": "platform",
+      "nodes": [
+        2
+      ],
+      "extras": {
+        "src": "__$project$__/default-project/assets/platform.glb"
+      }
+    }
+  ],
+  "scene": 0,
+  "nodes": [
+    {
+      "matrix": [
+        10,
+        0,
+        0,
+        0,
+        0,
+        0.10000000149011612,
+        0,
+        0,
+        0,
+        0,
+        10,
+        0,
+        0,
+        -0.10000000149011612,
+        0,
+        1
+      ],
+      "name": "Collider",
+      "extras": {
+        "name": "Collider"
+      },
+      "mesh": 0,
+      "extensions": {
+        "EE_uuid": "0b77bd2a-245e-4717-8938-ff5946c6fd6d",
+        "EE_collider": {
+          "shape": "box",
+          "mass": 1,
+          "massCenter": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "friction": 0.5,
+          "restitution": 0.5,
+          "collisionLayer": 1,
+          "collisionMask": 7
+        },
+        "EE_shadow": {
+          "cast": true,
+          "receive": true
+        },
+        "EE_envmap": {
+          "type": "Skybox",
+          "envMapTextureType": "Equirectangular",
+          "envMapSourceColor": 4095,
+          "envMapSourceURL": "",
+          "envMapSourceEntityUUID": "",
+          "envMapIntensity": 1
+        }
+      }
+    },
+    {
+      "name": "Geometry",
+      "extras": {
+        "name": "Geometry"
+      },
+      "mesh": 1,
+      "extensions": {
+        "EE_uuid": "80f1b0f4-8760-43da-9268-8967f12a74c4",
+        "EE_visible": true,
+        "EE_shadow": {
+          "cast": true,
+          "receive": true
+        },
+        "EE_envmap": {
+          "type": "Skybox",
+          "envMapTextureType": "Equirectangular",
+          "envMapSourceColor": 4095,
+          "envMapSourceURL": "",
+          "envMapSourceEntityUUID": "",
+          "envMapIntensity": 1
+        }
+      }
+    },
+    {
+      "name": "Base",
+      "children": [
+        0,
+        1
+      ],
+      "extensions": {
+        "EE_uuid": "340406cb-0abc-4855-bc02-0b80f4f5602f",
+        "EE_visible": true
+      }
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 288,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 576,
+      "byteLength": 192,
+      "target": 34962,
+      "byteStride": 8
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 768,
+      "byteLength": 144,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 912,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 1200,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 1488,
+      "byteLength": 192,
+      "target": 34962,
+      "byteStride": 8
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 1680,
+      "byteLength": 144,
+      "target": 34963
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 1824
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1,
+        1
+      ],
+      "min": [
+        -1,
+        -1,
+        -1
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1,
+        1
+      ],
+      "min": [
+        -1,
+        -1,
+        -1
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.875,
+        1
+      ],
+      "min": [
+        0.125,
+        0
+      ],
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5125,
+      "count": 36,
+      "max": [
+        23
+      ],
+      "min": [
+        0
+      ],
+      "type": "SCALAR"
+    },
+    {
+      "bufferView": 4,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        10,
+        0,
+        10
+      ],
+      "min": [
+        -10,
+        -0.20000000298023224,
+        -10
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 5,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1,
+        1
+      ],
+      "min": [
+        -1,
+        -1,
+        -1
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 6,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.875,
+        1
+      ],
+      "min": [
+        0.125,
+        0
+      ],
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 7,
+      "componentType": 5125,
+      "count": 36,
+      "max": [
+        23
+      ],
+      "min": [
+        0
+      ],
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "name": "Material",
+      "extras": {
+        "plugins": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "CSMPlugin": {
+          "id": "CSM0.9043409238087623",
+          "priority": 1
+        }
+      },
+      "extensions": {
+        "EE_material": {
+          "uuid": "7e03c4c7-69a6-4a75-b7a8-e0aea366418a",
+          "name": "Material",
+          "prototype": "MeshStandardMaterial",
+          "plugins": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "args": {
+            "alphaTest": {
+              "type": "float",
+              "contents": 0
+            },
+            "alphaMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "map": {
+              "type": "texture",
+              "contents": null
+            },
+            "color": {
+              "type": "color",
+              "contents": 16777215
+            },
+            "opacity": {
+              "type": "float",
+              "contents": 1
+            },
+            "blending": {
+              "type": "select",
+              "contents": 1
+            },
+            "depthTest": {
+              "type": "boolean",
+              "contents": true
+            },
+            "depthWrite": {
+              "type": "boolean",
+              "contents": true
+            },
+            "side": {
+              "type": "select",
+              "contents": 0
+            },
+            "toneMapped": {
+              "type": "boolean",
+              "contents": true
+            },
+            "transparent": {
+              "type": "boolean",
+              "contents": false
+            },
+            "vertexColors": {
+              "type": "boolean",
+              "contents": false
+            },
+            "emissive": {
+              "type": "color",
+              "contents": 0
+            },
+            "emissiveMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "emissiveIntensity": {
+              "type": "float",
+              "contents": 1
+            },
+            "combine": {
+              "type": "select"
+            },
+            "envMapIntensity": {
+              "type": "float",
+              "contents": 1
+            },
+            "reflectivity": {
+              "type": "float"
+            },
+            "refractionRatio": {
+              "type": "float"
+            },
+            "normalMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "normalMapType": {
+              "type": "select",
+              "contents": 0
+            },
+            "normalScale": {
+              "type": "vec2",
+              "contents": {
+                "x": 1,
+                "y": 1
+              }
+            },
+            "bumpMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "bumpScale": {
+              "type": "float",
+              "contents": 1
+            },
+            "displacementMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "displacementScale": {
+              "type": "float",
+              "contents": 1
+            },
+            "displacementBias": {
+              "type": "float",
+              "contents": 0
+            },
+            "roughness": {
+              "type": "float",
+              "contents": 1
+            },
+            "roughnessMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "metalness": {
+              "type": "float",
+              "contents": 0
+            },
+            "metalnessMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "aoMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "aoMapIntensity": {
+              "type": "float",
+              "contents": 1
+            },
+            "lightMap": {
+              "type": "texture",
+              "contents": null
+            },
+            "lightMapIntensity": {
+              "type": "float",
+              "contents": 1
+            }
+          }
+        }
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "mode": 4,
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1,
+            "TEXCOORD_0": 2
+          },
+          "indices": 3,
+          "material": 0
+        }
+      ],
+      "extensions": {
+        "EE_resourceId": {
+          "resourceId": "1523377b-707e-43d4-9154-11c6ed710de5"
+        }
+      }
+    },
+    {
+      "primitives": [
+        {
+          "mode": 4,
+          "attributes": {
+            "POSITION": 4,
+            "NORMAL": 5,
+            "TEXCOORD_0": 6
+          },
+          "indices": 7,
+          "material": 0
+        }
+      ],
+      "extensions": {
+        "EE_resourceId": {
+          "resourceId": "12b43d2a-a89d-4c1b-9058-065989af7687"
+        }
+      }
+    }
+  ],
+  "extensionsUsed": [
+    "EE_material",
+    "EE_resourceId",
+    "EE_uuid",
+    "EE_collider",
+    "EE_shadow",
+    "EE_envmap",
+    "EE_ecs",
+    "EE_visible"
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a RigidBodyComponent check on entity ancestors before checking for colliders to avoid detached colliders from never loading. If there's no rigidbody ancestor, consider the collider as loaded to prevent scenes with detached colliders from never loading. Also checks if entity is part of the simulation layer before checking on colliders.

## Subtasks Checklist

## Breaking Changes

## References

## QA Steps
