### PR TITLE
fix(particles-system): render mode and instancing geometry values [IR-9706]

### DIFF
--- a/packages/ui/src/components/editor/properties/particle/index.tsx
+++ b/packages/ui/src/components/editor/properties/particle/index.tsx
@@ -305,7 +305,7 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
       </InputGroup>
       <InputGroup name="Render Mode" label={t('editor:properties.particle-system.render-mode')}>
         <SelectInput
-          value={particleSystem.systemParameters.renderMode}
+          value={RenderMode[particleSystem.systemParameters.renderMode]}
           onChange={onSetSystemParm('renderMode')}
           options={[
             { label: t('editor:properties.particle-system.render-mode-type.billboard'), value: RenderMode.BillBoard },
@@ -386,7 +386,7 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
       <InputGroup name="Mesh" label={t('editor:properties.particle-system.mesh')}>
         <ModelInput
           value={particleSystem.systemParameters.instancingGeometry}
-          onRelease={onSetState('instancingGeometry')}
+          onRelease={onSetSystemParm('instancingGeometry')}
         />
       </InputGroup>
       <InputGroup name="Blending" label={t('editor:properties.particle-system.blending')}>


### PR DESCRIPTION
## Summary
- Fixed render mode values
- Fixed instancing geometry values

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
1. Open studio scene
2. Add particle system
3. Navigate to Particle Mesh field in properties
4. Click and drag a 3D mesh into the field

## Evidence
https://github.com/user-attachments/assets/02c39f00-7af7-4aad-a55a-fb3b54b9a00c

## Jira
[IR-9706](https://tsu.atlassian.net/browse/IR-9706)

[IR-9706]: https://tsu.atlassian.net/browse/IR-9706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ