### PR TITLE
[IR-8907] Importing scene gltf downloaded from another project does not allow modifications

### DIFF
--- a/packages/editor/src/systems/EditorControlSystem.ts
+++ b/packages/editor/src/systems/EditorControlSystem.ts
@@ -32,6 +32,7 @@ import {
   EntityTreeComponent,
   getAncestorWithComponents,
   InputSystemGroup,
+  SourceID,
   UndefinedEntity,
   UUIDComponent
 } from '@ir-engine/ecs'
@@ -183,8 +184,13 @@ const onDecreaseGridHeight = () => {
 
 const onDeleteSelection = () => {
   const entities = SelectionState.getSelectedEntities()
+  const sources = new Set<SourceID>(
+    entities
+      .filter((entity) => hasComponent(entity, UUIDComponent))
+      .map((entity) => getComponent(entity, UUIDComponent).entitySourceID)
+  )
   EditorControlFunctions.removeObject(entities)
-  AuthoringState.snapshotEntities(entities)
+  AuthoringState.snapshotSources(sources)
 }
 
 let lastDistanceToCenter = 10

--- a/packages/engine/src/authoring/AuthoringState.tsx
+++ b/packages/engine/src/authoring/AuthoringState.tsx
@@ -234,8 +234,12 @@ export const AuthoringState = defineState({
         .map((entity) => getComponent(entity, UUIDComponent).entitySourceID)
     )
     if (affectedSources.size === 0) return
+    AuthoringState.snapshotSources(affectedSources)
+  },
+
+  snapshotSources: (sources: Set<SourceID>) => {
     const ops = {} as Record<SourceID, Operation[]>
-    for (const sourceID of affectedSources) {
+    for (const sourceID of sources) {
       if (!sourceID) continue
       if (!getState(AuthoringState).sources[sourceID]) continue
       const newData = getSourceSnapshot(sourceID)
@@ -244,7 +248,6 @@ export const AuthoringState = defineState({
     }
     dispatchAction(AuthoringActions.ops({ ops }))
   },
-
   hasEdits: (sourceID: SourceID) => {
     if (!getState(AuthoringState).commands[getState(EngineState).userID]) return false
     return Object.values(getState(AuthoringState).commands[getState(EngineState).userID])


### PR DESCRIPTION
## Summary
Removed entities were not represented in the snapshot patches because by the time the snapshot runs there's no source information for the entity since it was removed, added a function to create the snapshot directly from the sources instead of the entities
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
