### PR TITLE
add check for null parent in engine canvas reactor

### DIFF
--- a/packages/spatial/src/renderer/functions/useEngineCanvas.ts
+++ b/packages/spatial/src/renderer/functions/useEngineCanvas.ts
@@ -34,7 +34,7 @@ export const useEngineCanvas = (ref: React.RefObject<HTMLElement> | null) => {
   useEffect(() => {
     if (!ref) return
     const parent = ref.current as HTMLElement
-
+    if (!parent) return
     const canvas = document.getElementById('engine-renderer-canvas') as HTMLCanvasElement
 
     const originalParent = canvas.parentElement!


### PR DESCRIPTION
Fixes race condition crash where parent.appendChild throws an error when parent is null