### PR TITLE
[IR-10686] fix flippedTexture logic

### DIFF
--- a/packages/engine/src/assets/loaders/texture/TextureLoader.ts
+++ b/packages/engine/src/assets/loaders/texture/TextureLoader.ts
@@ -94,6 +94,7 @@ class TextureLoader extends Loader<Texture> {
       if (signal?.aborted) return
       const image = this.maxResolution ? getScaledBitmap(i, this.maxResolution) : i
       texture.source.data = image
+      texture.flipY = !this.flipped
       texture.needsUpdate = true
       onLoad(texture)
     }

--- a/packages/engine/src/scene/components/ImageComponent.ts
+++ b/packages/engine/src/scene/components/ImageComponent.ts
@@ -274,12 +274,12 @@ export function ImageReactor() {
     const flippedTexture = uniforms.map.value.flipY
     switch (image.projection.value) {
       case ImageProjection.Equirectangular360:
-        mesh.geometry.set(flippedTexture ? SPHERE_GEO_FLIPPED() : SPHERE_GEO())
+        mesh.geometry.set(flippedTexture ? SPHERE_GEO() : SPHERE_GEO_FLIPPED())
         mesh.scale.value.set(-1, 1, 1)
         break
       case ImageProjection.Flat:
       default:
-        mesh.geometry.set(flippedTexture ? PLANE_GEO_FLIPPED() : PLANE_GEO())
+        mesh.geometry.set(flippedTexture ? PLANE_GEO() : PLANE_GEO_FLIPPED())
     }
   }, [!!mesh?.value, image.projection, !!texture])
 

--- a/packages/engine/src/scene/components/ImageComponent.ts
+++ b/packages/engine/src/scene/components/ImageComponent.ts
@@ -274,12 +274,12 @@ export function ImageReactor() {
     const flippedTexture = uniforms.map.value.flipY
     switch (image.projection.value) {
       case ImageProjection.Equirectangular360:
-        mesh.geometry.set(flippedTexture ? SPHERE_GEO() : SPHERE_GEO_FLIPPED())
+        mesh.geometry.set(flippedTexture ? SPHERE_GEO_FLIPPED() : SPHERE_GEO())
         mesh.scale.value.set(-1, 1, 1)
         break
       case ImageProjection.Flat:
       default:
-        mesh.geometry.set(flippedTexture ? PLANE_GEO() : PLANE_GEO_FLIPPED())
+        mesh.geometry.set(flippedTexture ? PLANE_GEO_FLIPPED() : PLANE_GEO())
     }
   }, [!!mesh?.value, image.projection, !!texture])
 


### PR DESCRIPTION
## Summary
[IR-10686] fixes bug that was resulting in ImageComponents being flipped

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


[IR-10686]: https://tsu.atlassian.net/browse/IR-10686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ