### PR TITLE
[IR-10677] Add History to sidebar and connect SettingsMenu

### DIFF
--- a/packages/client-core/src/components/Glass/Buttons.tsx
+++ b/packages/client-core/src/components/Glass/Buttons.tsx
@@ -36,7 +36,7 @@ export const smallIconButtonStyles = `
   border-2
   border-b-white/0
   border-white/10
-  shadow-xl
+  shadow-lg
   
   bg-white/10
   

--- a/packages/client-core/src/components/Glass/ChatMenu.tsx
+++ b/packages/client-core/src/components/Glass/ChatMenu.tsx
@@ -26,8 +26,6 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 import { HiChatBubbleLeftRight } from 'react-icons/hi2'
 import { twMerge } from 'tailwind-merge'
-import { ModalState } from '../../common/services/ModalState'
-import SettingsMenu from '../Settings'
 
 import { useMutableState } from '@ir-engine/hyperflux'
 import { Send01Md } from '@ir-engine/ui/src/icons'
@@ -136,12 +134,11 @@ const inputOuterStyles = `
   pb-4 px-4 pt-4
 `
 
-export const ChatMenu = () => {
+export const ChatMenu = ({ navigateTo }: { navigateTo: (screenKey: string, historyKey: string) => void }) => {
   const user = useMutableState(AuthState).user
+
   const isGuest = user.isGuest.value
-  const onCTAClicked = () => {
-    ModalState.openModal(<SettingsMenu initScreen="signup" onClose={ModalState.closeModal} />)
-  }
+  const onCTAClicked = () => navigateTo('Settings', 'signup')
 
   const { messageGroupedBySender, inputRef, handleInputChange, sendMessage, composedMessage } = useChatProvider()
 

--- a/packages/client-core/src/components/Glass/MenuButton.tsx
+++ b/packages/client-core/src/components/Glass/MenuButton.tsx
@@ -49,6 +49,7 @@ const buttonStyles = `
 
   transition-[background]
   transition-transform
+  text-inherit
 
   hover:scale-[1.05]
   hover:bg-white/10

--- a/packages/client-core/src/components/Glass/NavigationProvider.tsx
+++ b/packages/client-core/src/components/Glass/NavigationProvider.tsx
@@ -1,0 +1,108 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/ir-engine/ir-engine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Infinite Reality Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Infinite Reality Engine team.
+
+All portions of the code written by the Infinite Reality Engine team are Copyright © 2021-2025
+Infinite Reality Engine. All Rights Reserved.
+*/
+
+import React, { useState } from 'react'
+
+type DirectionType = 1 | -1
+
+type NavigationProviderType = {
+  navigateTo: (screenKey: string, historyKey: string) => void
+  activeHistoryKey: string
+  sidebarKey: string
+  setSidebarKey: (sidebarKey: string) => void
+  createToggleSidebarKey: (sidebarKey: string) => () => void
+  isSidebarOpen: boolean
+  navigateClose: () => void
+  navigateBack: () => void
+  hasHistory: boolean
+  direction: DirectionType
+}
+
+const useSidebarNavigation = () => {
+  const [history, setHistory] = useState<string[]>([])
+  const [direction, setDirection] = useState<DirectionType>(1) // 1 for forward, -1 for backward
+  const [sidebarKey, setSidebarKey] = useState(``)
+
+  const navigateTo = (screenKey: string, historyKey: string): void => {
+    setSidebarKey(screenKey)
+    setDirection(1)
+    setHistory([...history, historyKey])
+  }
+
+  const navigateBack = (): void => {
+    if (history.length > 1) {
+      setDirection(-1)
+      setHistory(history.slice(0, -1))
+    } else {
+      closeSidebar()
+    }
+  }
+
+  const closeSidebar = () => setSidebarKey(``)
+
+  const navigateClose = () => {
+    setDirection(-1)
+    setHistory([``])
+    closeSidebar()
+  }
+
+  const createToggleSidebarKey = (sidebarKey) => () => {
+    setSidebarKey((prev) => {
+      return prev === sidebarKey ? `` : sidebarKey
+    })
+    setHistory([``])
+  }
+
+  const activeHistoryKey = history[history.length - 1]
+  const isSidebarOpen = !!sidebarKey
+  const hasHistory = !!activeHistoryKey
+
+  return {
+    activeHistoryKey,
+    navigateBack,
+    navigateTo,
+    navigateClose,
+    direction,
+    history,
+
+    setSidebarKey,
+    sidebarKey,
+    hasHistory,
+    createToggleSidebarKey,
+    isSidebarOpen
+  }
+}
+
+const MultimediaStateContext = React.createContext({} as NavigationProviderType)
+
+export const useNavigationProvider = () => React.useContext(MultimediaStateContext)
+
+const Provider = MultimediaStateContext.Provider
+
+export const NavigationProvider = ({ children }) => {
+  const state = useSidebarNavigation()
+
+  return <Provider value={state}>{children}</Provider>
+}

--- a/packages/client-core/src/components/Glass/ToolbarAndSidebar.tsx
+++ b/packages/client-core/src/components/Glass/ToolbarAndSidebar.tsx
@@ -25,8 +25,9 @@ Infinite Reality Engine. All Rights Reserved.
 
 import React from 'react'
 
-import { XCloseLg } from '@ir-engine/ui/src/icons'
+import { ChevronLeftMd, XCloseLg } from '@ir-engine/ui/src/icons'
 import { twMerge } from 'tailwind-merge'
+import { smallIconButtonStyles } from './Buttons'
 import { MenuButton } from './MenuButton'
 import { HorizontalMenu, VerticalMenu } from './ToolbarMenu'
 
@@ -40,6 +41,8 @@ type HeaderProps = {
   heading: string
   tabs?: TabProps[]
   handleSidebarClose: () => void
+  handleSidebarBack: () => void
+  hasHistory: boolean
 }
 
 type ToolbarAndSidebarProps = HeaderProps & {
@@ -90,7 +93,7 @@ const headerInnerStyles = `
   w-full
 `
 
-const closeButtonStyles = `
+const buttonContainer_base = `
   absolute z-10
   right-0
   top-1/2
@@ -101,6 +104,16 @@ const closeButtonStyles = `
   lg:bottom-auto
   lg:top-0
   lg:translate-y-0
+`
+
+const closeButtonStyles = `
+  right-0
+`
+
+const backButtonStyles = `
+  left-0
+  
+  lg:hidden
 `
 
 const Tab = ({ onClick, heading, active }: TabProps) => {
@@ -127,21 +140,36 @@ const headingsStyles = `
   text-2xl
   
   lg:justify-start
-  lg:p-4
+  lg:py-4
+  lg:pl-2
   lg:text-5xl
+  lg:gap-x-4
 `
 
-const Header = ({ tabs = [], heading, handleSidebarClose }: HeaderProps) => {
+const headerBackButtonStyles = `
+  hidden
+  lg:block
+`
+
+const Header = ({ tabs = [], heading, handleSidebarClose, handleSidebarBack, hasHistory }: HeaderProps) => {
+  const backButton = (
+    <button className={twMerge(smallIconButtonStyles, `shadow`)} onClick={handleSidebarBack}>
+      <ChevronLeftMd />
+    </button>
+  )
+
   return (
     <div className={headerContainerStyles}>
       <div className={headerInnerStyles}>
-        <div className={closeButtonStyles}>
-          <MenuButton onClick={handleSidebarClose}>
-            <XCloseLg className={'h-8 w-8'} />
+        {hasHistory ? <div className={twMerge(buttonContainer_base, backButtonStyles)}>{backButton}</div> : <></>}
+        <div className={twMerge(buttonContainer_base, closeButtonStyles)}>
+          <MenuButton className={`text-3xl`} onClick={handleSidebarClose}>
+            <XCloseLg />
           </MenuButton>
         </div>
         <div style={{ textShadow: `0 0.025em 0.08em hsla(0, 0%, 0%, 0.2)` }} className={headingsStyles}>
-          <h2 className={`hidden lg:block`}>{heading}</h2>
+          {hasHistory ? <div className={headerBackButtonStyles}>{backButton}</div> : <></>}
+          <h2 className={twMerge(`lg:block`, tabs.length ? `hidden` : ``)}>{heading}</h2>
           {tabs.map((tabProps) => {
             return <Tab {...tabProps} />
           })}
@@ -201,6 +229,8 @@ export const ToolbarAndSidebar = ({
   heading,
   tabs = [],
   handleSidebarClose,
+  handleSidebarBack,
+  hasHistory,
   isSidebarOpen
 }: ToolbarAndSidebarProps) => {
   tabs = (tabs as TabProps[]) || [{ heading } as TabProps]
@@ -210,7 +240,13 @@ export const ToolbarAndSidebar = ({
       <div className={twMerge(containerStyles, isSidebarOpen ? `translate-x-0` : `translate-x-full`)}>
         <VerticalMenu>{toolbar}</VerticalMenu>
         <div className={sidebarContainerStyles}>
-          <Header tabs={tabs} heading={heading} handleSidebarClose={handleSidebarClose} />
+          <Header
+            tabs={tabs}
+            heading={heading}
+            hasHistory={hasHistory}
+            handleSidebarClose={handleSidebarClose}
+            handleSidebarBack={handleSidebarBack}
+          />
           <div className={`h-[2px] lg:bg-white/10`} />
           <div className={contentContainerStyles}>
             <div className={contentFakeSpacer} />

--- a/packages/client-core/src/components/Glass/ToolbarMenu.tsx
+++ b/packages/client-core/src/components/Glass/ToolbarMenu.tsx
@@ -28,8 +28,6 @@ import React, { useState } from 'react'
 import { ChevronDownMd, ChevronLeftMd, CogMd, EmoteM, MessageTextSquare01Sm } from '@ir-engine/ui/src/icons'
 import { useTranslation } from 'react-i18next'
 import { twMerge } from 'tailwind-merge'
-import { ModalState } from '../../common/services/ModalState'
-import Settings from '../Settings'
 import { Badge } from './Badge'
 import { useChatProvider } from './ChatProvider'
 import { MenuButton } from './MenuButton'
@@ -251,7 +249,7 @@ const collapsableSectionCloseStyles = `
   sm:max-lg:scale-x-0  
 `
 
-export const ToolbarMenu = ({ onMessageClick, onShareClick, activeKey }) => {
+export const ToolbarMenu = ({ onMessageClick, onShareClick, onSettingsClick, activeKey }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const { unreadMessages } = useChatProvider()
   const showMessagesBadge = unreadMessages.value
@@ -275,7 +273,7 @@ export const ToolbarMenu = ({ onMessageClick, onShareClick, activeKey }) => {
             isMenuOpen ? collapsableSectionOpenStyles : collapsableSectionCloseStyles
           )}
         >
-          <MenuButton onClick={() => ModalState.openModal(<Settings onClose={ModalState.closeModal} />)}>
+          <MenuButton onClick={onSettingsClick}>
             <CogMd />
           </MenuButton>
           <MenuButton

--- a/packages/client-core/src/components/Glass/index.tsx
+++ b/packages/client-core/src/components/Glass/index.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import React, { useLayoutEffect, useRef, useState } from 'react'
+import React, { useLayoutEffect, useRef } from 'react'
 
 import { TouchGamepad } from '@ir-engine/client-core/src/common/components/TouchGamepad'
 import { EngineState } from '@ir-engine/ecs'
@@ -37,9 +37,11 @@ import { XRLoading } from '../XRLoading'
 import { ToolbarAndSidebar } from './ToolbarAndSidebar'
 
 import PopupMenu from '@ir-engine/ui/src/primitives/tailwind/PopupMenu'
+import Settings, { screens as settingsScreens } from '../Settings'
 import { ChatMenu } from './ChatMenu'
 import { ChatProvider } from './ChatProvider'
 import { MultiVideos } from './MultiVideo'
+import { NavigationProvider, useNavigationProvider } from './NavigationProvider'
 import { ToolbarMenu } from './ToolbarMenu'
 import { VideoMenu } from './VideoMenu'
 
@@ -71,6 +73,18 @@ const Menu = () => {
   const externalInjectedMenus = useMutableState(ViewerMenuState).externalInjectedMenus.get(NO_PROXY)
   const locationContainer = useRef<HTMLDivElement>(null)
 
+  const {
+    activeHistoryKey,
+    sidebarKey,
+    setSidebarKey,
+    createToggleSidebarKey,
+    isSidebarOpen,
+    navigateClose,
+    navigateBack,
+    hasHistory,
+    navigateTo
+  } = useNavigationProvider()
+
   useLayoutEffect(() => {
     if (locationContainer.current) locationContainer.current.style.opacity = '0'
   }, [locationContainer])
@@ -79,20 +93,12 @@ const Menu = () => {
 
   if (!isLoggedIn) return null
 
-  const [sidebarKey, setSidebarKey] = useState(``)
-
-  const isSidebarOpen = !!sidebarKey
-
-  const createToggleSidebarKey = (sidebarKey) => () =>
-    setSidebarKey((prev) => {
-      return prev === sidebarKey ? `` : sidebarKey
-    })
-
   const headings = {
     Chat: `Chat`,
     Video: `Video`,
     Cart: `Cart`,
-    Share: `Share`
+    Share: `Share`,
+    Settings: `Settings`
   }
 
   const tabs = {
@@ -121,33 +127,43 @@ const Menu = () => {
   }
 
   const contents = {
-    Chat: <ChatMenu />,
-    Video: <VideoMenu />
+    Chat: <ChatMenu navigateTo={navigateTo} />,
+    Video: <VideoMenu />,
+    Settings: <Settings />
   }
 
   const onMessageClick = createToggleSidebarKey(`Chat`)
   const onShareClick = createToggleSidebarKey(`Share`)
   const onFullscreenVideosClick = createToggleSidebarKey(`Video`)
+  const onSettingsClick = createToggleSidebarKey(`Settings`)
 
-  const toolbar = <ToolbarMenu onMessageClick={onMessageClick} onShareClick={onShareClick} activeKey={sidebarKey} />
+  const toolbar = (
+    <ToolbarMenu
+      onMessageClick={onMessageClick}
+      onShareClick={onShareClick}
+      activeKey={sidebarKey}
+      onSettingsClick={onSettingsClick}
+    />
+  )
+  const sidebarHeadingFromHistory = settingsScreens[activeHistoryKey]?.title
 
   const sidebarTabs = tabs[sidebarKey] || []
-  const sidebarHeading = headings[sidebarKey]
+  const sidebarHeading = sidebarHeadingFromHistory || headings[sidebarKey]
   const sidebarContent = isSidebarOpen && contents[sidebarKey]
-
-  const closeSidebar = () => setSidebarKey(``)
 
   return (
     <div id="location-container" ref={locationContainer} className="fixed h-dvh w-full">
       <MultiVideos handleSidebarOpen={onFullscreenVideosClick} />
 
       <ToolbarAndSidebar
-        handleSidebarClose={closeSidebar}
+        handleSidebarClose={navigateClose}
+        handleSidebarBack={navigateBack}
         isSidebarOpen={isSidebarOpen}
         content={sidebarContent}
         heading={sidebarHeading}
         tabs={sidebarTabs}
         toolbar={toolbar}
+        hasHistory={hasHistory}
       />
 
       <ARPlacement />
@@ -161,8 +177,10 @@ const Menu = () => {
 
 export const ViewerInteractions = () => {
   return (
-    <ChatProvider>
-      <Menu />
-    </ChatProvider>
+    <NavigationProvider>
+      <ChatProvider>
+        <Menu />
+      </ChatProvider>
+    </NavigationProvider>
   )
 }

--- a/packages/client-core/src/components/Settings/AccountSettings.tsx
+++ b/packages/client-core/src/components/Settings/AccountSettings.tsx
@@ -31,24 +31,24 @@ import { Section } from './Section'
 
 // Define types for screen components
 interface ScreenProps {
-  navigateTo: (screen: string) => void
-  onClose?: () => void
+  navigateTo: (screenKey: string, historyKey: string) => void
+  navigateClose?: () => void
 }
 
 const AccountSettings: React.FC<ScreenProps> = ({ navigateTo }) => (
   <div className="h-full space-y-4">
     <Section>
-      <MenuItem label="Username & Password" onClick={() => navigateTo('usernamePassword')} hasChevron />
+      <MenuItem label="Username & Password" onClick={() => navigateTo('Settings', 'usernamePassword')} hasChevron />
       <Divider />
-      <MenuItem label="User ID" onClick={() => navigateTo('userId')} hasChevron />
+      <MenuItem label="User ID" onClick={() => navigateTo('Settings', 'userId')} hasChevron />
       <Divider />
-      <MenuItem label="Permissions" onClick={() => navigateTo('permissions')} hasChevron />
+      <MenuItem label="Permissions" onClick={() => navigateTo('Settings', 'permissions')} hasChevron />
     </Section>
 
     <Section>
-      <MenuItem label="Single Sign On" onClick={() => navigateTo('sso')} hasChevron />
+      <MenuItem label="Single Sign On" onClick={() => navigateTo('Settings', 'sso')} hasChevron />
       <Divider />
-      <MenuItem label="Delete My Account" onClick={() => navigateTo('deleteAccount')} hasChevron />
+      <MenuItem label="Delete My Account" onClick={() => navigateTo('Settings', 'deleteAccount')} hasChevron />
     </Section>
   </div>
 )

--- a/packages/client-core/src/components/Settings/DeleteAccountScreen.tsx
+++ b/packages/client-core/src/components/Settings/DeleteAccountScreen.tsx
@@ -28,11 +28,11 @@ import { motion } from 'motion/react'
 import React, { useState } from 'react'
 
 interface DeleteAccountScreenProps {
-  navigateTo: (screen: string) => void
-  onClose?: () => void
+  navigateTo: (screenKey: string, historyKey: string) => void
+  navigateClose: () => void
 }
 
-const DeleteAccountScreen: React.FC<DeleteAccountScreenProps> = ({ navigateTo, onClose }) => {
+const DeleteAccountScreen: React.FC<DeleteAccountScreenProps> = ({ navigateTo, navigateClose }) => {
   const [showConfirmation, setShowConfirmation] = useState(true)
   const [showSuccess, setShowSuccess] = useState(false)
 
@@ -42,11 +42,11 @@ const DeleteAccountScreen: React.FC<DeleteAccountScreenProps> = ({ navigateTo, o
   }
 
   const handleStayHere = () => {
-    navigateTo('account')
+    navigateTo('Settings', 'account')
   }
 
   const handleClose = () => {
-    onClose?.()
+    navigateClose()
   }
 
   if (showSuccess) {

--- a/packages/client-core/src/components/Settings/DisplayNameScreen.tsx
+++ b/packages/client-core/src/components/Settings/DisplayNameScreen.tsx
@@ -27,7 +27,7 @@ import { motion } from 'motion/react'
 import React, { useEffect, useRef, useState } from 'react'
 
 interface DisplayNameScreenProps {
-  navigateTo: (screen: string) => void
+  navigateTo: (screenKey: string, historyKey) => void
 }
 
 const DisplayNameScreen: React.FC<DisplayNameScreenProps> = ({ navigateTo }) => {
@@ -56,7 +56,7 @@ const DisplayNameScreen: React.FC<DisplayNameScreenProps> = ({ navigateTo }) => 
     // Hide success message after 2 seconds and navigate back
     setTimeout(() => {
       setShowSuccessMessage(false)
-      navigateTo('usernamePassword')
+      navigateTo('Settings', 'usernamePassword')
     }, 2000)
   }
 

--- a/packages/client-core/src/components/Settings/GraphicsSettings.tsx
+++ b/packages/client-core/src/components/Settings/GraphicsSettings.tsx
@@ -35,8 +35,8 @@ import ToggleItem from './ToggleItem'
 
 // Define types for screen components
 interface ScreenProps {
-  navigateTo: (screen: string) => void
-  onClose?: () => void
+  navigateTo: (screenKey: string, historyKey: string) => void
+  navigateClose?: () => void
 }
 
 const GraphicsSettings: React.FC<ScreenProps> = ({ navigateTo }) => {
@@ -64,7 +64,11 @@ const GraphicsSettings: React.FC<ScreenProps> = ({ navigateTo }) => {
         <Divider />
         <ToggleItem label="Shadows" checked={useShadows.value} onClick={onShadowToggle} />
         <Divider />
-        <MenuItem label="Shadow Map Resolution" onClick={() => navigateTo('shadowMapResolution')} hasChevron />
+        <MenuItem
+          label="Shadow Map Resolution"
+          onClick={() => navigateTo('Settings', 'shadowMapResolution')}
+          hasChevron
+        />
       </Section>
     </div>
   )

--- a/packages/client-core/src/components/Settings/MainMenu.tsx
+++ b/packages/client-core/src/components/Settings/MainMenu.tsx
@@ -35,8 +35,8 @@ import ToggleItem from './ToggleItem'
 
 // Define types for screen components
 interface ScreenProps {
-  navigateTo: (screen: string) => void
-  onClose?: () => void
+  navigateTo: (screenKey: string, historyKey: string) => void
+  navigateClose?: () => void
 }
 
 const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
@@ -50,7 +50,7 @@ const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
     <div className="space-y-4">
       {/* Communication Section */}
       <Section>
-        <MenuItem label="Share Space" onClick={() => navigateTo('shareSpace')} hasChevron />
+        <MenuItem label="Share Space" onClick={() => navigateTo('Settings', 'shareSpace')} hasChevron />
         <Divider />
         <ToggleItem
           label="Video Communication"
@@ -72,20 +72,20 @@ const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
 
       {/* World & Account Section */}
       <Section>
-        <MenuItem label="World" onClick={() => navigateTo('world')} hasChevron />
+        <MenuItem label="World" onClick={() => navigateTo('Settings', 'world')} hasChevron />
         <Divider />
         <ToggleItem label="Multiplayer" checked={multiplayer} onClick={() => setMultiplayer(!multiplayer)} />
         <Divider />
-        <MenuItem label="Account" onClick={() => navigateTo('account')} hasChevron />
+        <MenuItem label="Account" onClick={() => navigateTo('Settings', 'account')} hasChevron />
         <Divider />
-        <MenuItem label="Avatar" onClick={() => navigateTo('avatar')} hasChevron />
+        <MenuItem label="Avatar" onClick={() => navigateTo('Settings', 'avatar')} hasChevron />
       </Section>
 
       {/* System Section */}
       <Section>
-        <MenuItem label="Controls" onClick={() => navigateTo('controls')} hasChevron />
+        <MenuItem label="Controls" onClick={() => navigateTo('Settings', 'controls')} hasChevron />
         <Divider />
-        <MenuItem label="Graphics" onClick={() => navigateTo('graphics')} hasChevron />
+        <MenuItem label="Graphics" onClick={() => navigateTo('Settings', 'graphics')} hasChevron />
         <MenuItem label="Log Out" onClick={AuthService.logoutUser} />
       </Section>
     </div>

--- a/packages/client-core/src/components/Settings/UsernamePasswordScreen.tsx
+++ b/packages/client-core/src/components/Settings/UsernamePasswordScreen.tsx
@@ -29,7 +29,7 @@ import React, { useState } from 'react'
 import { Section } from './Section'
 
 interface UsernamePasswordScreenProps {
-  navigateTo: (screen: string) => void
+  navigateTo: (screenKey: string, historyKey: string) => void
 }
 
 const UsernamePasswordScreen: React.FC<UsernamePasswordScreenProps> = ({ navigateTo }) => {
@@ -58,11 +58,16 @@ const UsernamePasswordScreen: React.FC<UsernamePasswordScreenProps> = ({ navigat
   return (
     <div className="flex h-full flex-col gap-4">
       <Section>
-        <FieldItem label="Display Name" value={displayName} onClick={() => navigateTo('displayName')} />
+        <FieldItem label="Display Name" value={displayName} onClick={() => navigateTo('Settings', 'displayName')} />
         <Divider />
-        <FieldItem label="User ID" value={userId} onClick={() => navigateTo('userId')} />
+        <FieldItem label="User ID" value={userId} onClick={() => navigateTo('Settings', 'userId')} />
         <Divider />
-        <FieldItem label="Password" value={password} onClick={() => navigateTo('password')} isPassword={true} />
+        <FieldItem
+          label="Password"
+          value={password}
+          onClick={() => navigateTo('Settings', 'password')}
+          isPassword={true}
+        />
       </Section>
     </div>
   )

--- a/packages/client-core/src/components/Settings/WorldSettings.tsx
+++ b/packages/client-core/src/components/Settings/WorldSettings.tsx
@@ -32,8 +32,8 @@ import ToggleItem from './ToggleItem'
 
 // Define types for screen components
 interface ScreenProps {
-  navigateTo: (screen: string) => void
-  onClose?: () => void
+  navigateTo: (screenKey: string, historyKey: string) => void
+  navigateClose?: () => void
 }
 
 const WorldSettings: React.FC<ScreenProps> = () => (

--- a/packages/client-core/src/components/Settings/index.tsx
+++ b/packages/client-core/src/components/Settings/index.tsx
@@ -24,14 +24,13 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { AnimatePresence, motion, Variant } from 'motion/react'
-import React, { useState } from 'react'
+import React from 'react'
 
 // Import icons from the icons module
-import { ArrowLeftSm, XCloseSm } from '@ir-engine/ui/src/icons'
 // Define types for screen components
 interface ScreenProps {
-  navigateTo: (screen: string) => void
-  onClose?: () => void
+  navigateTo: (screenKey: string, historyKey: string) => void
+  navigateClose?: () => void
 }
 
 // Import main screen components
@@ -41,6 +40,7 @@ import MainMenu from './MainMenu'
 import WorldSettings from './WorldSettings'
 
 // Import other screen components
+import { useNavigationProvider } from '../Glass/NavigationProvider'
 import AvatarScreen from './AvatarScreen'
 import DeleteAccountScreen from './DeleteAccountScreen'
 import DisplayNameScreen from './DisplayNameScreen'
@@ -118,27 +118,10 @@ interface SettingsMenuProps {
   initScreen?: string
 }
 
-const SettingsMenu: React.FC<SettingsMenuProps> = ({ onClose, initScreen = 'main' }) => {
-  const [history, setHistory] = useState<string[]>([initScreen]) // Stack to keep track of navigation
-  const [direction, setDirection] = useState<number>(1) // 1 for forward, -1 for backward
+const SettingsMenu: React.FC<SettingsMenuProps> = ({ initScreen = 'main' }) => {
+  const { activeHistoryKey, direction, navigateBack, navigateTo, navigateClose } = useNavigationProvider()
 
-  const activeScreenKey = history[history.length - 1]
-  const ActiveComponent = screens[activeScreenKey].component
-  const currentTitle = screens[activeScreenKey].title
-
-  const navigateTo = (screenKey: string): void => {
-    setDirection(1)
-    setHistory([...history, screenKey])
-  }
-
-  const navigateBack = (): void => {
-    if (history.length > 1) {
-      setDirection(-1)
-      setHistory(history.slice(0, -1))
-    } else {
-      onClose?.() // Optional chaining in case onClose is not provided
-    }
-  }
+  const ActiveComponent = screens[activeHistoryKey || initScreen].component
 
   // Animation variants for slide transitions
   const variants: Record<string, Variant> = {
@@ -160,51 +143,28 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onClose, initScreen = 'main
     <div
       data-testid="settings-menu-backdrop"
       id="settings-menu-backdrop"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) {
-          onClose?.()
-        }
-      }}
-      className="fixed inset-0 z-50 mx-auto flex items-start justify-center overflow-y-auto "
+      className={`
+        flex w-full items-start
+        justify-center
+      `}
     >
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.95 }}
         transition={{ duration: 0.2 }}
-        className="pointer-events-auto flex h-full w-full max-w-sm flex-1 flex-col rounded-3xl p-5 font-dm-sans text-white md:mt-5 md:max-w-screen-md md:pt-0"
-        style={{
-          maxHeight: '90vh'
-        }}
+        className={`
+          pointer-events-auto
+          flex w-full
+          flex-col
+          font-dm-sans
+          text-white
+        `}
       >
-        {/* Header */}
-        <div className="text-shadow-md mb-4 flex h-10 items-center justify-between justify-self-start">
-          {history.length > 1 ? (
-            <button
-              onClick={navigateBack}
-              className="-ml-1 rounded-full p-2 transition-colors hover:bg-white/10"
-              aria-label="Back"
-            >
-              <ArrowLeftSm className="text-white/90" />
-            </button>
-          ) : (
-            <div className="w-8"></div> // Placeholder for spacing
-          )}
-          <h2 className=" text-xl font-semibold text-white/90">{currentTitle}</h2>
-          <button
-            onClick={onClose}
-            className="-mr-1 rounded-full p-2 transition-colors hover:bg-white/10"
-            aria-label="Close settings"
-          >
-            <XCloseSm className="h-5 w-5 text-white/90" />
-          </button>
-        </div>
-
-        {/* Screen Content with AnimatePresence for transitions */}
         <div className="relative my-auto h-full overflow-hidden rounded-md">
           <AnimatePresence initial={false} mode="popLayout" custom={direction}>
             <motion.div
-              key={activeScreenKey}
+              key={activeHistoryKey}
               custom={direction}
               variants={variants}
               initial="enter"
@@ -214,9 +174,13 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onClose, initScreen = 'main
                 x: { type: 'tween', duration: 0.2 },
                 opacity: { duration: 0.2 }
               }}
-              className="scrollbar-hide ju flex h-full max-h-full flex-col justify-center space-y-4  overflow-y-auto"
+              className={`
+                scrollbar-hide
+                flex flex-col justify-center
+                gap-y-4
+              `}
             >
-              <ActiveComponent navigateTo={navigateTo} onClose={onClose} />
+              <ActiveComponent navigateTo={navigateTo} navigateClose={navigateClose} />
             </motion.div>
           </AnimatePresence>
         </div>


### PR DESCRIPTION
## Summary

Migrated the SettingsMenu to use the Sidebar instead of being an isolated modal. Switched to using a history state and a NavigationProvider that sets the state of the sidebar so that any element can change state and history of the sidebar

![image](https://github.com/user-attachments/assets/29ef43e4-1163-414d-8c8a-78064cebaeca)

## QA Steps

- Open toolbar to show Settings cog icon
- Click Settings icon
- SettingsMenu should open in the Sidebar
- Navigating the Settings should work
- The close and back buttons should work to close the sidebar or go back a page in the Settings menu flow