### PR TITLE
fix: Correct suffix values for new envs and add missing ones

### DIFF
--- a/scripts/build_and_publish_package.sh
+++ b/scripts/build_and_publish_package.sh
@@ -33,12 +33,12 @@ if [ "$SOURCE_REPO_PROVIDER" == "gcp" ]; then
     SUFFIX="mt"
   elif [[ "$APP_HOST" =~ "qat" ]]; then
     SUFFIX="qat"
-  elif [[ "$app_host" =~ "mt-nightly" ]]; then
-    suffix="mt-nightly"
-  elif [[ "$app_host" =~ "mt-weekly" ]]; then
-    suffix="mt-weekly"
-  elif [[ "$app_host" =~ "mt-prdmirr" ]]; then
-    suffix="mt-prdmirr"
+  elif [[ "$APP_HOST" =~ "mt-nightly" ]]; then
+    SUFFIX="mt-nightly"
+  elif [[ "$APP_HOST" =~ "mt-weekly" ]]; then
+    SUFFIX="mt-weekly"
+  elif [[ "$APP_HOST" =~ "mt-prdmirr" ]]; then
+    SUFFIX="mt-prdmirr"
   else
     SUFFIX=""
   fi
@@ -74,6 +74,12 @@ elif [ "$DESTINATION_REPO_PROVIDER" == "gcp" ]; then
       SUFFIX="mt"
   elif [[ "$APP_HOST" =~ "qat" ]]; then
       SUFFIX="qat"
+   elif [[ "$APP_HOST" =~ "mt-nightly" ]]; then
+      SUFFIX="mt-nightly"
+   elif [[ "$APP_HOST" =~ "mt-weekly" ]]; then
+      SUFFIX="mt-weekly"
+   elif [[ "$APP_HOST" =~ "mt-prdmirr" ]]; then
+      SUFFIX="mt-prdmirr"
   else
       SUFFIX=""
   fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,12 +37,12 @@ if [ "$DESTINATION_REPO_PROVIDER" = "gcp" ]; then
     SUFFIX="-mt"
   elif [[ "$APP_HOST" =~ "qat" ]]; then
     SUFFIX="-qat"
-  elif [[ "$app_host" =~ "mt-nightly" ]]; then
-    suffix="-mt-nightly"
-  elif [[ "$app_host" =~ "mt-weekly" ]]; then
-    suffix="-mt-weekly"
-    elif [[ "$app_host" =~ "mt-prdmirr" ]]; then
-    suffix="-mt-prdmirr"
+  elif [[ "$APP_HOST" =~ "mt-nightly" ]]; then
+    SUFFIX="-mt-nightly"
+  elif [[ "$APP_HOST" =~ "mt-weekly" ]]; then
+    SUFFIX="-mt-weekly"
+    elif [[ "$APP_HOST" =~ "mt-prdmirr" ]]; then
+    SUFFIX="-mt-prdmirr"
   else
     SUFFIX=""
   fi

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -285,6 +285,12 @@ setup_package_environment() {
     SUFFIX="-mt"
   elif [[ "$APP_HOST" =~ "qat" ]]; then
     SUFFIX="-qat"
+  elif [[ "$APP_HOST" =~ "mt-nightly" ]]; then
+    SUFFIX="-mt-nightly"
+  elif [[ "$APP_HOST" =~ "mt-weekly" ]]; then
+    SUFFIX="-mt-weekly"
+  elif [[ "$APP_HOST" =~ "mt-prdmirr" ]]; then
+    SUFFIX="-mt-prdmirr"
   else
     SUFFIX=""
   fi


### PR DESCRIPTION
This PR fixes addresses mixmatched casing in variable names in `scripts/build_and_publish_package.sh` and adds missing cases for setting suffix variables in the rest of the build, deploy, and publish process for the new environment
