### PR TITLE
IR-10593: Prevent GLTF entity sharing between model instances

### DIFF
--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -1646,7 +1646,6 @@ const loadScene = async (options: GLTFParserOptions, sceneIndex: number) => {
 const unloadScene = (url: string, entity: Entity) => {
   // handle reference counting
   unloadResourcesForEntity(entity)
-
   // if no more references to this url, remove from cache
   const resourceCacheState = getState(ResourceCacheState)
   if (!resourceCacheState[url]) {
@@ -1717,7 +1716,17 @@ export const getDependency = <
   const cache = DependencyCache.get(url)
   if (!cache) throw new Error('GLTFLoader: No cache found for url ' + url)
 
-  const cacheKey = type + ':' + JSON.stringify(args)
+  // Only include sourceID for entity-related dependencies
+  const entityTypes = ['node', 'scene'] as const
+  let cacheKey = type + ':'
+
+  if (entityTypes.includes(type as any)) {
+    // For entity types, include the source ID to make unique instances
+    const sourceID = GLTFComponent.getSourceID(options.entity)
+    cacheKey += sourceID + ':'
+  }
+
+  cacheKey += JSON.stringify(args)
   const dependency = cache.get(cacheKey) as ReturnType<Func> | undefined
 
   if (!dependency) {


### PR DESCRIPTION
## Summary

When loading the same GLTF model multiple times, entities were being shared between instances, causing issues when one instance was removed or modified. This change ensures each GLTF instance gets its own unique entity hierarchy while still sharing resource data like geometries, materials and textures.

![Screen Recording 2025-06-09 at 11 17 01 a m](https://github.com/user-attachments/assets/5b446397-2faf-45d0-be39-6c87eab35308)

**Ticket:** https://tsu.atlassian.net/browse/IR-10593

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Open an scene in the editor 
- Add the same model twice
- Ensure that both assets are rendered
- Duplicate one of the assets 
- Ensure the duplicated asset is rendered

