### PR TITLE
IR-9784 fixing ui button transitions

### DIFF
--- a/packages/client-core/src/systems/ui/PoiUI.tsx
+++ b/packages/client-core/src/systems/ui/PoiUI.tsx
@@ -154,6 +154,7 @@ const PoiUiView = (props: PoiUiProps) => {
       poiCamera.targetPoiIndex.set(newTargetIndex)
       poiCamera.currentPoiIndex.set(currentTargetIndex) // Keep current as starting point
       poiCamera.poiLerpValue.set(0) // Reset lerp to start transition
+      poiCamera.isTransitioning.set(true)
     } else {
       // Scrolling mode: directly set current index (legacy behavior)
       poiCamera.currentPoiIndex.set(newTargetIndex)
@@ -180,6 +181,7 @@ const PoiUiView = (props: PoiUiProps) => {
       poiCamera.targetPoiIndex.set(newTargetIndex)
       poiCamera.currentPoiIndex.set(currentTargetIndex) // Keep current as starting point
       poiCamera.poiLerpValue.set(0) // Reset lerp to start transition
+      poiCamera.isTransitioning.set(true)
     } else {
       // Scrolling mode: directly set current index (legacy behavior)
       poiCamera.currentPoiIndex.set(newTargetIndex)


### PR DESCRIPTION
## Summary
ui buttons for POI mode, snapping, show ui buttons were not lerping

## References
[https://tsu.atlassian.net/browse/IR-9784](https://tsu.atlassian.net/browse/IR-9784)

## QA Steps
add 2+ poiComponents to entities in the scene, go to cameraSettingsComponent on the Settings entity and make sure the CameraSettingsComponent values as follows are set:
POI mode
Snapping
transition buttons enabled

click preview and click a button , is should lerp between the POIs when you click