### PR TITLE
IR-10900 temporarily disabling hotspot component for release, updating i18n

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -749,6 +749,11 @@
         "donut": "Donut",
         "mesh": "Mesh"
       },
+      "poiComponent": {
+        "name": "POI Component",
+        "description": "Settings for a point of interest camera view",
+        "lbl-poiHotspotEntities": "POI Hotspot Entities"
+      },
       "emission-bursts": "Emission Bursts",
       "add-burst": "Add Burst",
       "remove-burst": "Remove Burst",

--- a/packages/editor/src/services/ComponentEditors.tsx
+++ b/packages/editor/src/services/ComponentEditors.tsx
@@ -118,7 +118,6 @@ import { LookAtComponent } from '@ir-engine/engine/src/scene/components/LookAtCo
 import { MediaComponent } from '@ir-engine/engine/src/scene/components/MediaComponent'
 import { OverlayComponent } from '@ir-engine/engine/src/scene/components/OverlayComponent'
 import { PoiComponent } from '@ir-engine/engine/src/scene/components/PoiComponent'
-import { PoiHotspotComponent } from '@ir-engine/engine/src/scene/components/PoiHotspotComponent'
 import { TriggerCallbackComponent } from '@ir-engine/engine/src/scene/components/TriggerCallbackComponent'
 import { CameraComponent } from '@ir-engine/spatial/src/camera/components/CameraComponent'
 import MediaNodeEditor from '@ir-engine/ui/src/components/editor/properties/media'
@@ -132,7 +131,6 @@ import VisualScriptNodeEditor from '@ir-engine/ui/src/components/editor/properti
 import VolumetricNodeEditor from '@ir-engine/ui/src/components/editor/properties/volumetric'
 import LegacyVolumetricNodeEditor from '@ir-engine/ui/src/components/editor/properties/volumetric/legacy'
 import PoiNodeEditor from '../../../ui/src/components/editor/properties/cameraPoi'
-import PoiHotspotNodeEditor from '../../../ui/src/components/editor/properties/poiHotspot'
 import { EditorComponentType } from '../components/properties/Util'
 
 export const ComponentEditorsState = defineState({
@@ -189,8 +187,8 @@ export const ComponentEditorsState = defineState({
       [TextComponent.name]: TextNodeEditor,
       [LookAtComponent.name]: LookAtNodeEditor,
       [MediaComponent.name]: MediaNodeEditor,
-      [PoiComponent.name]: PoiNodeEditor,
-      [PoiHotspotComponent.name]: PoiHotspotNodeEditor
+      [PoiComponent.name]: PoiNodeEditor
+      //[PoiHotspotComponent.name]: PoiHotspotNodeEditor
     } as Record<string, EditorComponentType>
   }
 })

--- a/packages/editor/src/services/ComponentShelfCategoriesState.ts
+++ b/packages/editor/src/services/ComponentShelfCategoriesState.ts
@@ -45,7 +45,6 @@ import { MountPointComponent } from '@ir-engine/engine/src/scene/components/Moun
 import { OverlayComponent } from '@ir-engine/engine/src/scene/components/OverlayComponent'
 import { ParticleSystemComponent } from '@ir-engine/engine/src/scene/components/ParticleSystemComponent'
 import { PoiComponent } from '@ir-engine/engine/src/scene/components/PoiComponent'
-import { PoiHotspotComponent } from '@ir-engine/engine/src/scene/components/PoiHotspotComponent'
 import { PortalComponent } from '@ir-engine/engine/src/scene/components/PortalComponent'
 import { PrimitiveGeometryComponent } from '@ir-engine/engine/src/scene/components/PrimitiveGeometryComponent'
 import { RenderSettingsComponent } from '@ir-engine/engine/src/scene/components/RenderSettingsComponent'
@@ -115,7 +114,7 @@ export const ComponentShelfCategoriesState = defineState({
         LookAtComponent,
         FogSettingsComponent
       ],
-      Camera: [PoiComponent, PoiHotspotComponent]
+      Camera: [PoiComponent] //PoiHotspotComponent
     } as Record<string, Component[]>
   },
   reactor: () => {

--- a/packages/ui/src/components/editor/properties/cameraPoi/index.tsx
+++ b/packages/ui/src/components/editor/properties/cameraPoi/index.tsx
@@ -28,13 +28,10 @@ import React from 'react'
 
 import { useComponent } from '@ir-engine/ecs/src/ComponentFunctions'
 
-import { EditorComponentType, commitProperty } from '@ir-engine/editor/src/components/properties/Util'
+import { EditorComponentType } from '@ir-engine/editor/src/components/properties/Util'
 import NodeEditor from '@ir-engine/editor/src/panels/properties/common/NodeEditor'
 import { PoiComponent } from '@ir-engine/engine/src/scene/components/PoiComponent'
-import { PoiHotspotComponent } from '@ir-engine/engine/src/scene/components/PoiHotspotComponent'
 import { HiOutlineCamera } from 'react-icons/hi'
-import EntityListInput from '../../input/EntityList'
-import InputGroup from '../../input/Group'
 
 export const PoiNodeEditor: EditorComponentType = (props) => {
   const poiSettings = useComponent(props.entity, PoiComponent)
@@ -42,23 +39,23 @@ export const PoiNodeEditor: EditorComponentType = (props) => {
   return (
     <NodeEditor
       {...props}
-      name={t('editor:properties.cameraPoi.name', 'POI Camera Settings')}
-      description={t('editor:properties.cameraPoi.description', 'Settings for a point of interest camera view')}
+      name={t('editor:properties.poiComponent.name', 'POI Component')}
+      description={t('editor:properties.poiComponent.description', 'Settings for a point of interest camera view')}
       Icon={PoiNodeEditor.iconComponent}
       entity={props.entity}
     >
-      <InputGroup
-        name="hotspotEntities"
-        label={t('editor:properties.cameraPoi.lbl-hotspotEntities', 'Hotspot Entities')}
-      >
-        <EntityListInput
-          value={Array.from(poiSettings.hotspotEntityUUIDs.value)}
-          onChange={commitProperty(PoiComponent, 'hotspotEntityUUIDs')}
-          placeholder="Select entities to use as hotspots"
-          filter={[PoiHotspotComponent]}
-          className="w-full"
-        />
-      </InputGroup>
+      {/*<InputGroup*/}
+      {/*  name="hotspotEntities"*/}
+      {/*  label={t('editor:properties.poiComponent.lbl-poiHotspotEntities', 'POI Hotspot Entities')}*/}
+      {/*>*/}
+      {/*  <EntityListInput*/}
+      {/*    value={Array.from(poiSettings.hotspotEntityUUIDs.value)}*/}
+      {/*    onChange={commitProperty(PoiComponent, 'hotspotEntityUUIDs')}*/}
+      {/*    placeholder="Select entities to use as hotspots"*/}
+      {/*    filter={[PoiHotspotComponent]}*/}
+      {/*    className="w-full"*/}
+      {/*  />*/}
+      {/*</InputGroup>*/}
     </NodeEditor>
   )
 }


### PR DESCRIPTION
## Summary
turned off the "poi hotspot component" (which was a non-functional stub component right now) and updated i18n strings

## References
[https://tsu.atlassian.net/browse/IR-10900](https://tsu.atlassian.net/browse/IR-10900)

## QA Steps
1. ensure you cannot add "poi hotspot component" or see it in the add-component menu
2. ensure you see no references to "poi hotspot component" in the "poi component"