### PR TITLE
[IR-9604] Connect VideoCarousel to video sources

### DIFF
--- a/packages/client-core/src/components/Glass/MultiVideo.tsx
+++ b/packages/client-core/src/components/Glass/MultiVideo.tsx
@@ -29,6 +29,7 @@ import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import { largeIconButtonStyles } from './Buttons'
+import { useVideoStream } from './VideoMenu'
 
 function interpolateRange(value, [fromMax, fromMin], [toMax, toMin]) {
   const normalized = (value - fromMin) / (fromMax - fromMin)
@@ -37,7 +38,7 @@ function interpolateRange(value, [fromMax, fromMin], [toMax, toMin]) {
   return toMin + normalized * toRange
 }
 
-const multiVideoContainerStyles = `
+const containerStyles = `
   absolute
   left-6
   top-6
@@ -64,14 +65,19 @@ const videosStyles = `
 
 const videoStyles = `
   flex items-center justify-center
+
+  overflow-hidden
+
   rounded-xl
   border-2
   border-white/90
   bg-white/10
   backdrop-blur-3xl
+
   text-xl
-  font-bold
   text-white
+  font-bold
+
   transition-transform
   duration-150
 `
@@ -83,15 +89,68 @@ const collapsedVideosStyles = `
   cursor-pointer
 `
 
-const multiVideoButtonsStyles = `
+const bottomButtonsStyles = `
   flex
   justify-between
 `
 
-export const MultiVideos = ({ handleSidebarOpen }) => {
-  const [list, setList] = useState([...Array(40)])
+const windowSize = 4
+const stackSize = 2
+
+const stackVideoGap = 0.4
+const windowVideoGap = 0.5
+
+const stackScaleMin = 0.75
+
+const halfWindowSize = windowSize / 2
+
+const aspectRatio = 9 / 16
+
+const videoWidth = 10
+const videoHeight = videoWidth * aspectRatio
+
+const scrollHeightMultiplier = 10
+const windowVideoHeightAndGap = videoHeight + windowVideoGap
+
+const CollapsedVideo = ({ index, videoMediaStream }) => {
+  const scale = interpolateRange(index, [0, stackSize], [1, stackScaleMin])
+
+  const ref = useRef<HTMLVideoElement>(null)
+
+  useVideoStream(ref.current, videoMediaStream)
+
+  return (
+    <div
+      style={{
+        zIndex: -index
+      }}
+      className={twMerge(
+        `
+          absolute
+          transition-transform
+          duration-200
+        `
+      )}
+    >
+      <div
+        style={{
+          height: `${videoHeight}rem`,
+          width: `${videoWidth}rem`,
+          transform: `translateY(${index * stackVideoGap}rem) scale(${scale})`
+        }}
+        className={twMerge(`origin-bottom`, videoStyles)}
+      >
+        <video ref={ref} />
+      </div>
+    </div>
+  )
+}
+
+export const VideoCarousel = ({ handleSidebarOpen, videoElements, videoMediaStreams }) => {
   const [collapsed, setCollapsed] = useState(true)
   const [muted, setMuted] = useState(false)
+
+  const [mounted, setMounted] = useState(false)
 
   const container = React.useRef<HTMLDivElement>(null)
   const videosRef = React.useRef<HTMLDivElement>(null)
@@ -102,32 +161,33 @@ export const MultiVideos = ({ handleSidebarOpen }) => {
     container: container
   })
 
-  const perVideoPercent = list.length && 1 / list.length
-  const windowSize = 4
-  const stackSize = 2
+  const numVideos = videoElements.length
+  const showVideos = numVideos > 0
 
-  const stackVideoGap = 0.4
-  const windowVideoGap = 0.5
+  const hasEnoughVideosForCarousel = numVideos > 1
 
-  const stackScaleMin = 0.75
+  const showBottomButtons = !collapsed && hasEnoughVideosForCarousel
 
-  const halfWindowSize = windowSize / 2
-
-  const aspectRatio = 9 / 16
-
-  const videoWidth = 10
-  const videoHeight = videoWidth * aspectRatio
-
-  const scrollHeightMultiplier = 10
-
-  const windowVideoHeightAndGap = videoHeight + windowVideoGap
+  const handleCollapsedVideosClick = useCallback(() => {
+    if (!hasEnoughVideosForCarousel) {
+      return
+    }
+    setCollapsed(false)
+  }, [hasEnoughVideosForCarousel])
 
   const createVideos = useCallback(() => {
-    if (!videosRef.current) {
+    if (!videosRef.current || !numVideos) {
       return
     }
 
-    const videos = list.map((__, i) => {
+    if (videosRef.current.children.length === numVideos) {
+      return
+    }
+    console.log('creating')
+
+    setMounted(true)
+
+    const videos = videoElements.map((videoElement, i) => {
       const videoContainer = document.createElement('div')
       const video = document.createElement('div')
 
@@ -144,7 +204,7 @@ export const MultiVideos = ({ handleSidebarOpen }) => {
       video.style.height = `${videoHeight}rem`
       video.style.width = `${videoWidth}rem`
 
-      video.innerHTML = `${i}`
+      video.appendChild(videoElement)
 
       videoContainer.appendChild(video)
 
@@ -152,19 +212,19 @@ export const MultiVideos = ({ handleSidebarOpen }) => {
     })
 
     videosRef.current.replaceChildren(...videos)
-  }, [videosRef.current, list.length])
+  }, [videosRef.current, numVideos])
 
   const positionVideos = useCallback(
     (latest = 0) => {
-      if (!videosRef.current) {
+      if (!videosRef.current || !numVideos) {
         return
       }
 
-      const minScroll = 1 / list.length
-      const maxScroll = (list.length - (windowSize - 1)) / list.length
+      const minScroll = 1 / numVideos
+      const maxScroll = (numVideos - (windowSize - 1)) / numVideos
       _scrollYProgress.current = Math.min(Math.max(latest, minScroll), maxScroll)
 
-      const currentVideoIndex = Math.round(_scrollYProgress.current * list.length)
+      const currentVideoIndex = Math.round(_scrollYProgress.current * numVideos)
 
       const windowTopIndex = Math.max(Math.floor(currentVideoIndex - halfWindowSize) + 1, 0)
       const windowBottomIndex = Math.max(Math.floor(currentVideoIndex + halfWindowSize), 0)
@@ -173,12 +233,17 @@ export const MultiVideos = ({ handleSidebarOpen }) => {
       const topStackBottomIndex = windowTopIndex
       const bottomStackTopIndex = windowBottomIndex
       const bottomStackBottomIndex = windowBottomIndex + stackSize
-      list.map((__, i) => {
+      videoElements.map((__, i) => {
         if (!videosRef.current) {
           return
         }
 
-        const videoContainerEl = videosRef.current.children[i] as HTMLElement
+        const videoContainerEl = videosRef.current.children?.[i] as HTMLElement
+
+        if (!videoContainerEl) {
+          return
+        }
+
         const videoEl = videoContainerEl.children[0] as HTMLElement
 
         const above = i < windowTopIndex
@@ -240,7 +305,7 @@ export const MultiVideos = ({ handleSidebarOpen }) => {
           : `${i}`
       })
     },
-    [videosRef.current, list.length]
+    [videosRef.current, numVideos]
   )
 
   const positionVideosWithCollapsed = useCallback(
@@ -257,93 +322,70 @@ export const MultiVideos = ({ handleSidebarOpen }) => {
   useMotionValueEvent(scrollYProgress, 'renderRequest', positionVideosWithCollapsed)
 
   useLayoutEffect(() => {
-    if (!container.current || !videosRef.current || !list.length) {
+    if (!container.current || !videosRef.current || !numVideos) {
       return
     }
 
     createVideos()
     positionVideos(0)
-  }, [container.current, videosRef.current, list.length])
+  }, [container.current, videosRef.current, numVideos])
 
-  const CollapsedVideo = ({ id }) => {
-    const scale = interpolateRange(id, [0, stackSize], [1, stackScaleMin])
-
-    return (
-      <div
-        style={{
-          zIndex: -id
-        }}
-        className={twMerge(
-          `
-          absolute
-          transition-transform
-          duration-200
-        `
-        )}
-      >
-        <div
-          style={{
-            height: `${videoHeight}rem`,
-            width: `${videoWidth}rem`,
-            transform: `translateY(${id * stackVideoGap}rem) scale(${scale})`
-          }}
-          className={twMerge(`origin-bottom`, videoStyles)}
-        >
-          {id}
-        </div>
-      </div>
-    )
-  }
-
-  const collapsedVideos = list
+  const collapsedVideos = videoElements
     .filter((__, i) => {
       return i <= stackSize
     })
     .reverse()
     .map((__, i) => {
-      return <CollapsedVideo key={i} id={i} />
+      return <CollapsedVideo videoMediaStream={videoMediaStreams[i]} key={i} index={i} />
     })
 
-  const scrollHeight = (list.length - (windowSize - 1)) * scrollHeightMultiplier
-  const videosListHeight = videoHeight + stackSize * stackVideoGap
+  const scrollHeight = (numVideos - (windowSize - 1)) * scrollHeightMultiplier
+  const collapsedVideosListHeight = videoHeight + stackSize * stackVideoGap
+  const openVideosListHeight = numVideos > 4 ? 25.7 : Math.min(numVideos, 4) * windowVideoHeightAndGap
+
+  const videosListHeight = showVideos ? (collapsed ? collapsedVideosListHeight : openVideosListHeight) : 0
 
   return (
-    <div className={multiVideoContainerStyles}>
+    <div className={containerStyles}>
       <div
         ref={container}
         style={{
-          height: collapsed ? `${videosListHeight}rem` : `25.7rem`
+          height: `${videosListHeight}rem`
         }}
         className={twMerge(videosListStyles)}
       >
-        <button
-          style={{
-            height: `${videoHeight}rem`,
-            width: `${videoWidth}rem`
-          }}
-          onClick={() => setCollapsed((prev) => false)}
-          className={twMerge(collapsedVideosStyles, collapsed ? `` : `hidden`)}
-        >
-          {collapsedVideos}
-        </button>
-        <>
-          <div
-            onClick={() => setCollapsed((prev) => true)}
-            ref={videosRef}
-            className={twMerge(videosStyles, collapsed ? `hidden` : ``)}
-          />
-          <div
-            style={{
-              height: `${scrollHeight}rem`,
-              width: `${videoWidth}rem`
-            }}
-          />
-        </>
+        {showVideos ? (
+          <>
+            <button
+              style={{
+                height: `${videoHeight}rem`,
+                width: `${videoWidth}rem`
+              }}
+              onClick={handleCollapsedVideosClick}
+              className={twMerge(collapsedVideosStyles, collapsed ? `` : `hidden`)}
+            >
+              {collapsedVideos}
+            </button>
+            <>
+              <div
+                onClick={() => setCollapsed(true)}
+                ref={videosRef}
+                className={twMerge(videosStyles, collapsed ? `hidden` : ``)}
+              />
+              <div
+                style={{
+                  height: `${scrollHeight}rem`,
+                  width: `${videoWidth}rem`
+                }}
+              />
+            </>
+          </>
+        ) : (
+          <></>
+        )}
       </div>
-      {collapsed ? (
-        <></>
-      ) : (
-        <div className={multiVideoButtonsStyles}>
+      {showBottomButtons ? (
+        <div className={bottomButtonsStyles}>
           <button onClick={() => setMuted((prev) => !prev)} className={twMerge(largeIconButtonStyles, ``)}>
             {muted ? <VolumeXMd /> : <VolumeMinMd />}
           </button>
@@ -351,6 +393,8 @@ export const MultiVideos = ({ handleSidebarOpen }) => {
             <Expand01Md />
           </button>
         </div>
+      ) : (
+        <></>
       )}
     </div>
   )

--- a/packages/client-core/src/components/Glass/VideoMenu.tsx
+++ b/packages/client-core/src/components/Glass/VideoMenu.tsx
@@ -124,6 +124,20 @@ const videoButtonsInner = `
   group-hover:visible
 `
 
+export const useVideoStream = (videoElement, videoMediaStream) => {
+  useEffect(() => {
+    if (!videoElement || videoElement.srcObject || !videoMediaStream) return
+
+    videoElement.autoplay = true
+    videoElement.muted = true
+    videoElement.setAttribute('playsinline', 'true')
+
+    const newVideoTrack = videoMediaStream.getVideoTracks()[0].clone()
+    videoElement.srcObject = new MediaStream([newVideoTrack])
+    videoElement.play()
+  }, [videoElement, videoMediaStream])
+}
+
 const Video = ({ peerID, type }: WindowType) => {
   const {
     isSelf,
@@ -146,17 +160,7 @@ const Video = ({ peerID, type }: WindowType) => {
 
   const ref = useRef<HTMLVideoElement>(null)
 
-  useEffect(() => {
-    if (!ref.current || ref.current.srcObject || !videoMediaStream) return
-
-    ref.current.autoplay = true
-    ref.current.muted = true
-    ref.current.setAttribute('playsinline', 'true')
-
-    const newVideoTrack = videoMediaStream.getVideoTracks()[0].clone()
-    ref.current.srcObject = new MediaStream([newVideoTrack])
-    ref.current.play()
-  }, [ref.current, videoMediaStream])
+  useVideoStream(ref.current, videoMediaStream)
 
   const showVideoIfSelf = isSelf ? isCamVideoEnabled : true
   const showVideo = showVideoIfSelf && !videoStreamPaused
@@ -169,9 +173,9 @@ const Video = ({ peerID, type }: WindowType) => {
       {showVideo ? (
         <video
           className={`
-        h-full
-        max-w-[unset]
-      `}
+            h-full
+            max-w-[unset]
+          `}
           ref={ref}
         />
       ) : (

--- a/packages/client-core/src/components/Glass/index.tsx
+++ b/packages/client-core/src/components/Glass/index.tsx
@@ -38,11 +38,12 @@ import { ToolbarAndSidebar } from './ToolbarAndSidebar'
 
 import PopupMenu from '@ir-engine/ui/src/primitives/tailwind/PopupMenu'
 import { useMediaWindows } from '../../user/VideoWindows'
+import { useUserMediaWindowsHook } from '../../user/VideoWindows/hook'
 import Settings, { screens as settingsScreens } from '../Settings'
 import { ChatMenu } from './ChatMenu'
 import { ChatProvider } from './ChatProvider'
 import { MultimediaStateProvider } from './MultimediaStateProvider'
-import { MultiVideos } from './MultiVideo'
+import { VideoCarousel } from './MultiVideo'
 import { NavigationProvider, useNavigationProvider } from './NavigationProvider'
 import { ToolbarMenu } from './ToolbarMenu'
 import { VideoMenu } from './VideoMenu'
@@ -140,6 +141,8 @@ const Menu = () => {
   const onFullscreenVideosClick = createToggleSidebarKey(`Video`)
   const onSettingsClick = createToggleSidebarKey(`Settings`)
 
+  const { videoElements, videoMediaStreams } = useUserMediaWindowsHook(windows)
+
   const toolbar = (
     <ToolbarMenu
       onMessageClick={onMessageClick}
@@ -156,7 +159,11 @@ const Menu = () => {
 
   return (
     <div id="location-container" ref={locationContainer} className="fixed h-dvh w-full">
-      <MultiVideos handleSidebarOpen={onFullscreenVideosClick} />
+      <VideoCarousel
+        handleSidebarOpen={onFullscreenVideosClick}
+        videoElements={videoElements}
+        videoMediaStreams={videoMediaStreams}
+      />
 
       <ToolbarAndSidebar
         handleSidebarClose={navigateClose}

--- a/packages/client-core/src/user/VideoWindows/hook.tsx
+++ b/packages/client-core/src/user/VideoWindows/hook.tsx
@@ -24,8 +24,8 @@ import { t } from 'i18next'
 import React, { RefObject, useEffect, useRef } from 'react'
 
 import { AuthState } from '@ir-engine/client-core/src/user/services/AuthService'
-import { useGet } from '@ir-engine/common'
-import { UserName, userPath } from '@ir-engine/common/src/schema.type.module'
+import { useFind, useGet } from '@ir-engine/common'
+import { userAvatarPath, UserName, userPath } from '@ir-engine/common/src/schema.type.module'
 import { useExecute } from '@ir-engine/ecs'
 import { Engine } from '@ir-engine/ecs/src/Engine'
 import { AudioState } from '@ir-engine/engine/src/audio/AudioState'
@@ -53,12 +53,337 @@ import { drawPoseToCanvas } from '@ir-engine/ui/src/pages/Capture'
 
 import { useUserAvatarThumbnail } from '../../hooks/useUserAvatarThumbnail'
 
-export interface Props {
+export interface WindowType {
   peerID: PeerID
   type: 'screen' | 'cam'
 }
 
-export const useUserMediaWindowHook = ({ peerID, type }: Props) => {
+import _ from 'lodash'
+
+function addItem<T>(array: readonly T[], i: number, value: T): T[] {
+  const newArray = [...array]
+
+  newArray[i] = value
+
+  return newArray
+}
+
+export const useUserMediaWindowsHook = (windows: WindowType[]) => {
+  const mediaChannelState = useHookstate(getMutableState(MediaChannelState))
+  const mediaStreamState = useMutableState(MediaStreamState)
+  const mediaSettingState = useMutableState(MediaSettingsState)
+
+  const soundIndicators = useHookstate<boolean[]>([])
+  const isPiP = useHookstate(false)
+  const resumeVideoOnUnhide = useRef<boolean>(false)
+  const resumeAudioOnUnhide = useRef<boolean>(false)
+  const audioState = useMutableState(AudioState)
+  const volumes = useHookstate<number[]>([])
+
+  const harkListeners = useHookstate<ReturnType<typeof hark>[]>([])
+
+  const selfUser = useMutableState(AuthState).user.get(NO_PROXY)
+  const mediaNetwork = NetworkState.mediaNetwork
+  const rendered = !mediaSettingState.immersiveMedia.value
+
+  const userIdsByPeerId = {}
+
+  const peers = mediaNetwork?.peers || {}
+
+  _.forEach(peers, ({ userId }, peerID) => {
+    userIdsByPeerId[peerID] = userId
+  })
+
+  const userIds = _.uniq(
+    _.map(userIdsByPeerId, (userId, peerID) => {
+      return userId
+    })
+  )
+
+  const users = useFind(userPath, { query: { id: { $in: userIds } } })?.data
+  const avatarThumbnails = useFind(userAvatarPath, { query: { id: { $in: userIds } } })?.data
+
+  const _windows = windows
+    .map(({ peerID, type }, i) => {
+      const audioChannelType = type === 'screen' ? screenshareAudioMediaChannelType : webcamAudioMediaChannelType
+      const videoChannelType = type === 'screen' ? screenshareVideoMediaChannelType : webcamVideoMediaChannelType
+
+      const peerMediaChannelState = mediaChannelState.value[peerID]
+
+      const audioMediaChannelState = peerMediaChannelState[audioChannelType]
+      const videoMediaChannelState = peerMediaChannelState[videoChannelType]
+
+      const {
+        stream: audioMediaStream,
+        paused: audioStreamPaused,
+        element: audioElement
+      } = audioMediaChannelState as MediaStreamInterface
+
+      const {
+        stream: videoMediaStream,
+        paused: videoStreamPaused,
+        element: videoElement
+      } = videoMediaChannelState as MediaStreamInterface
+
+      const isSelf =
+        !mediaNetwork ||
+        peerID === Engine.instance.store.peerID ||
+        (mediaNetwork?.peers &&
+          Object.values(mediaNetwork.peers).find((peer) => peer.userId === selfUser.id)?.peerID === peerID) ||
+        peerID === 'self'
+
+      const userId = isSelf ? selfUser?.id : userIdsByPeerId[peerID]
+      const user = users.find(({ id }) => id === userId)
+
+      const _volume = volumes.value[i] || 1
+
+      const volume = isSelf ? audioState.microphoneGain.value : _volume
+      const isScreen = type === 'screen'
+
+      if (isScreen) {
+        mediaChannelState[peerID][videoChannelType].quality.set('largest')
+      }
+
+      const getUsername = () => {
+        if (isSelf && !isScreen) return t('user:person.you')
+        if (isSelf && isScreen) return t('user:person.yourScreen')
+        const username = user?.name ?? 'A User'
+        if (!isSelf && isScreen) return username + "'s Screen"
+        return username
+      }
+
+      const username = getUsername() as UserName
+      const avatarThumbnail = avatarThumbnails.find((avatar) => {
+        return (avatar.userId = userId)
+      })
+
+      const toggleVideo = async () => {
+        if (isSelf && !isScreen) {
+          MediaStreamState.toggleWebcamPaused()
+        } else if (isSelf && isScreen) {
+          MediaStreamState.toggleScreenshareVideoPaused()
+        } else {
+          mediaChannelState[peerID][videoChannelType].paused.set((val) => !val)
+        }
+      }
+
+      const toggleAudio = async () => {
+        if (isSelf && !isScreen) {
+          MediaStreamState.toggleMicrophonePaused()
+        } else if (isSelf && isScreen) {
+          MediaStreamState.toggleScreenshareAudioPaused()
+        } else {
+          mediaChannelState[peerID][audioChannelType].paused.set((val) => !val)
+        }
+      }
+
+      const adjustVolume = (e, value) => {
+        if (isSelf) {
+          getMutableState(AudioState).microphoneGain.set(value)
+        } else {
+          audioElement!.volume = value
+        }
+
+        volumes.set(addItem(volumes.value, i, value))
+      }
+
+      const handleVisibilityChange = () => {
+        if (document.hidden) {
+          if (!videoStreamPaused && mediaStreamState.webcamMediaStream.value) {
+            resumeVideoOnUnhide.current = true
+            mediaChannelState[peerID][videoChannelType].paused.set(true)
+            toggleVideo()
+          }
+          if (!audioStreamPaused && mediaStreamState.microphoneMediaStream.value) {
+            resumeAudioOnUnhide.current = true
+            mediaChannelState[peerID][audioChannelType].paused.set(true)
+            toggleAudio()
+          }
+        }
+        if (!document.hidden) {
+          if (resumeVideoOnUnhide.current) {
+            mediaChannelState[peerID][videoChannelType].paused.set(false)
+            toggleVideo()
+          }
+          if (resumeAudioOnUnhide.current) {
+            mediaChannelState[peerID][audioChannelType].paused.set(false)
+            toggleAudio()
+          }
+          resumeVideoOnUnhide.current = false
+          resumeAudioOnUnhide.current = false
+        }
+      }
+
+      const switchQualityByPiP = () => {
+        mediaChannelState[peerID][videoChannelType].quality.set(isPiP.value ? 'largest' : 'smallest')
+      }
+
+      const play = () => {
+        videoElement?.play()
+        audioElement?.play()
+        harkListeners.value[i]?.resume()
+      }
+
+      const handleHark = (mounted) => {
+        if (!audioMediaStream || !audioMediaStream.getAudioTracks().length) return
+
+        audioElement.id = `${peerID}_audio`
+        audioElement.autoplay = true
+        audioElement.setAttribute('playsinline', 'true')
+        audioElement.muted = audioStreamPaused || isSelf
+        audioElement.volume = audioStreamPaused || isSelf ? 0 : volume
+
+        audioElement.srcObject = audioMediaStream
+
+        const newHark = hark(audioElement.srcObject, { play: false })
+        newHark.on('speaking', () => {
+          if (mounted) return
+
+          soundIndicators.set(addItem(soundIndicators.value, i, true))
+        })
+        newHark.on('stopped_speaking', () => {
+          if (mounted) return
+          soundIndicators.set(addItem(soundIndicators.value, i, false))
+        })
+        harkListeners.set(addItem(harkListeners.value, i, newHark))
+
+        return newHark
+      }
+
+      const handleAudioPause = () => {
+        audioElement.muted = audioStreamPaused || isSelf
+        audioElement.volume = _volume
+      }
+
+      const handleScreenshareTexture = () => {
+        if (!videoMediaStream) return
+
+        videoElement.id = `${peerID}_video`
+        videoElement.autoplay = true
+        videoElement.muted = true
+        videoElement.setAttribute('playsinline', 'true')
+        videoElement.srcObject = videoMediaStream
+
+        if (isScreen) {
+          applyScreenshareToTexture(videoElement as HTMLVideoElement)
+        }
+      }
+
+      return {
+        peerID,
+        type,
+        handleVisibilityChange,
+        adjustVolume,
+        toggleVideo,
+        toggleAudio,
+        harkListeners,
+        audioElement,
+        videoElement,
+        audioMediaStream,
+        videoMediaStream,
+        audioStreamPaused,
+        isSelf,
+        isScreen,
+        switchQualityByPiP,
+        play,
+        handleHark,
+        handleAudioPause,
+        handleScreenshareTexture
+      }
+    })
+    .filter(({ audioMediaStream, videoMediaStream }) => {
+      return audioMediaStream || videoMediaStream
+    })
+
+  const videoMediaStreams = _windows.map(({ videoMediaStream }) => {
+    return videoMediaStream
+  })
+
+  const audioMediaStreams = _windows.map(({ audioMediaStream }) => {
+    return audioMediaStream
+  })
+
+  const audioStreamPauseds = _windows.map(({ audioStreamPaused }) => {
+    return audioStreamPaused
+  })
+
+  const videoElements = _windows.map(({ videoElement }) => {
+    return videoElement
+  })
+
+  const audioElements = _windows.map(({ audioElement }) => {
+    return audioElement
+  })
+
+  const togglePiP = () => isPiP.set(!isPiP.value)
+
+  useEffect(() => {
+    mediaStreamState.microphoneGainNode.value?.gain.setTargetAtTime(
+      audioState.microphoneGain.value,
+      audioState.audioContext.currentTime.value,
+      0.01
+    )
+  }, [audioState.microphoneGain.value])
+
+  useEffect(() => {
+    function onUserInteraction() {
+      _windows.forEach(({ play }) => play())
+    }
+    window.addEventListener('pointerup', onUserInteraction)
+    return () => {
+      window.removeEventListener('pointerup', onUserInteraction)
+    }
+  }, [videoElements, audioElements])
+
+  useEffect(() => {
+    if (!audioMediaStreams.length) {
+      return
+    }
+
+    let mounted = _windows.map(() => false)
+
+    const newHarks = _windows.map(({ handleHark }, i) => {
+      return handleHark(mounted[i])
+    })
+
+    return () => {
+      mounted = mounted.map(() => true)
+      newHarks.map((newHark) => {
+        newHark?.stop()
+      })
+    }
+  }, [audioMediaStreams])
+
+  useEffect(() => {
+    _windows.map(({ handleAudioPause }) => handleAudioPause())
+  }, [audioStreamPauseds])
+
+  useEffect(() => {
+    _windows.map(({ handleScreenshareTexture }) => handleScreenshareTexture())
+  }, [videoMediaStreams])
+
+  useEffect(() => {
+    _windows.map(({ switchQualityByPiP }) => switchQualityByPiP())
+  }, [isPiP.value])
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      _windows.forEach(({ handleVisibilityChange }) => handleVisibilityChange())
+    }
+
+    if (isMobile) {
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+
+      return () => {
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+      }
+    }
+  }, [_windows])
+
+  return { videoElements, videoMediaStreams }
+}
+
+export const useUserMediaWindowHook = ({ peerID, type }: WindowType) => {
   const audioChannelType = type === 'screen' ? screenshareAudioMediaChannelType : webcamAudioMediaChannelType
   const videoChannelType = type === 'screen' ? screenshareVideoMediaChannelType : webcamVideoMediaChannelType
   const audioMediaChannelState = useHookstate(getMutableState(MediaChannelState)[peerID][audioChannelType])

--- a/packages/client-core/src/user/VideoWindows/window.tsx
+++ b/packages/client-core/src/user/VideoWindows/window.tsx
@@ -40,9 +40,9 @@ import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { twMerge } from 'tailwind-merge'
 import { ReportUserState } from '../../util/ReportUserState'
-import { Props, useUserMediaWindowHook } from './hook'
+import { useUserMediaWindowHook, WindowType } from './hook'
 
-export const SingleVideoWindow = ({ peerID, type }: Props): JSX.Element => {
+export const SingleVideoWindow = ({ peerID, type }: WindowType): JSX.Element => {
   const { isSelf, isPiP, isScreen, videoMediaStream, avatarThumbnail, videoStreamPaused, togglePiP } =
     useUserMediaWindowHook({
       peerID,
@@ -145,7 +145,7 @@ export const SingleVideoWindow = ({ peerID, type }: Props): JSX.Element => {
   )
 }
 
-export const SingleVideoWindowWidget = ({ peerID, type }: Props): JSX.Element => {
+export const SingleVideoWindowWidget = ({ peerID, type }: WindowType): JSX.Element => {
   const { username, isSelf, videoMediaStream, avatarThumbnail, videoStreamPaused, audioStreamPaused, toggleAudio } =
     useUserMediaWindowHook({ peerID, type })
 


### PR DESCRIPTION
## Summary

This connects the VideoCarousel to real-time video sources.

The `useUserMediaWindowHook` assumed a single source, which work for the past design. To connect to the VideoCarousel and for performance I created a new hook that does the same thing but for an array of sources. That way the logic can be batched and used in vanilla JS (like in the VideoCarousel) 

https://github.com/user-attachments/assets/3dd8b93b-a10d-4d3c-9fcd-cd872956ccf4

## QA Steps

- Open a Viewer scene
- Repeat X times:
  - Open new tab with the same link
  - Click camera icon
- For each tab, there should be a video in the VideoCarousel
- When one of the tabs turns off it's camera, the video should no longer be in the VideoCarousel

