### PR TITLE
IR-7193 link component interaction

### DIFF
--- a/packages/spatial/src/input/components/InputComponent.test.tsx
+++ b/packages/spatial/src/input/components/InputComponent.test.tsx
@@ -490,6 +490,76 @@ describe('InputComponent', () => {
     })
   })
 
+  describe('button state caching', () => {
+    it('should find button states when InputSourceComponent has buttons assigned', () => {
+      // Create test entity and components
+      const testEntity = createEntity()
+      setComponent(testEntity, InputSourceComponent)
+      setComponent(testEntity, InputComponent, { inputSources: [testEntity] })
+      const inputSource = getMutableComponent(testEntity, InputSourceComponent)
+
+      // Test case 1: Initial state - no buttons
+      let result = InputComponent.getButtons(testEntity)
+      assert.ok(!result.PrimaryClick, 'Initially no PrimaryClick button should be present')
+
+      // Test case 2: Add button state to InputSourceComponent
+      inputSource.buttons.set({
+        [MouseButton.PrimaryClick]: createInitialButtonState(testEntity, {
+          down: true,
+          pressed: true
+        })
+      })
+
+      // Get buttons again - should see the new button state
+      result = InputComponent.getButtons(testEntity)
+      assert.ok(result.PrimaryClick, 'PrimaryClick button should now be present')
+      assert.ok(result.PrimaryClick?.down, 'PrimaryClick should be down')
+      assert.ok(result.PrimaryClick?.pressed, 'PrimaryClick should be pressed')
+
+      // Test case 3: Remove button state from InputSourceComponent
+      inputSource.buttons.set({})
+
+      // Get buttons again - should not see the button anymore
+      result = InputComponent.getButtons(testEntity)
+      assert.ok(!result.PrimaryClick, 'PrimaryClick button should no longer be present')
+    })
+
+    it('should handle multiple entities accessing the same button', () => {
+      // Create input source entity
+      const inputSourceEntity = createEntity()
+      setComponent(inputSourceEntity, InputSourceComponent)
+      const inputSource = getMutableComponent(inputSourceEntity, InputSourceComponent)
+
+      // Create two different entities that will access the same input source
+      const entity1 = createEntity()
+      const entity2 = createEntity()
+      setComponent(entity1, InputComponent, { inputSources: [inputSourceEntity] })
+      setComponent(entity2, InputComponent, { inputSources: [inputSourceEntity] })
+
+      // Add button state to InputSourceComponent
+      inputSource.buttons.set({
+        [MouseButton.PrimaryClick]: createInitialButtonState(inputSourceEntity, {
+          down: true,
+          pressed: true
+        })
+      })
+
+      // First entity accesses the button - should consume it
+      let result1 = InputComponent.getButtons(entity1)
+      assert.ok(result1.PrimaryClick, 'Entity1 should see the PrimaryClick button')
+      assert.ok(result1.PrimaryClick?.down, 'Entity1: PrimaryClick should be down')
+      assert.ok(result1.PrimaryClick?.pressed, 'Entity1: PrimaryClick should be pressed')
+
+      // Second entity tries to access the same button - should not see it (consumed by entity1)
+      let result2 = InputComponent.getButtons(entity2)
+      assert.ok(!result2.PrimaryClick, 'Entity2 should not see the PrimaryClick button (consumed by entity1)')
+
+      // First entity accesses again - should still see the consumed button
+      result1 = InputComponent.getButtons(entity1)
+      assert.ok(result1.PrimaryClick, 'Entity1 should still see the consumed PrimaryClick button')
+    })
+  })
+
   describe('useHasFocus', () => {
     it('should update its state to true whenever the ammount of entities returned by InputComponent.getInputSourceEntities is bigger than 0', async () => {
       const effectSpy = sinon.spy()

--- a/packages/spatial/src/input/components/InputComponent.test.tsx
+++ b/packages/spatial/src/input/components/InputComponent.test.tsx
@@ -61,7 +61,13 @@ import { HighlightComponent } from '../../renderer/components/HighlightComponent
 import ClientInputFunctions from '../functions/ClientInputFunctions'
 import { AnyAxis, KeyboardButton, MouseButton, MouseScroll, createInitialButtonState } from '../state/ButtonState'
 import { InputState } from '../state/InputState'
-import { InputButtonBindings, InputComponent, InputExecutionOrder, InputExecutionSystemGroup } from './InputComponent'
+import {
+  DefaultButtonBindings,
+  InputButtonBindings,
+  InputComponent,
+  InputExecutionOrder,
+  InputExecutionSystemGroup
+} from './InputComponent'
 import { InputSinkComponent } from './InputSinkComponent'
 import { InputSourceComponent } from './InputSourceComponent'
 
@@ -499,10 +505,11 @@ describe('InputComponent', () => {
       const inputSource = getMutableComponent(testEntity, InputSourceComponent)
 
       // Test case 1: Initial state - no buttons
-      let result = InputComponent.getButtons(testEntity)
-      assert.ok(!result.PrimaryClick, 'Initially no PrimaryClick button should be present')
+      let result = InputComponent.getButtons(testEntity, DefaultButtonBindings)
+      assert.ok(!result.Interact, 'Initially no Interact button should be present')
 
       // Test case 2: Add button state to InputSourceComponent
+      ClientInputFunctions.refreshInputs(true)
       inputSource.buttons.set({
         [MouseButton.PrimaryClick]: createInitialButtonState(testEntity, {
           down: true,
@@ -511,17 +518,18 @@ describe('InputComponent', () => {
       })
 
       // Get buttons again - should see the new button state
-      result = InputComponent.getButtons(testEntity)
-      assert.ok(result.PrimaryClick, 'PrimaryClick button should now be present')
-      assert.ok(result.PrimaryClick?.down, 'PrimaryClick should be down')
-      assert.ok(result.PrimaryClick?.pressed, 'PrimaryClick should be pressed')
+      result = InputComponent.getButtons(testEntity, DefaultButtonBindings)
+      assert.ok(result.Interact, 'Interact button should now be present')
+      assert.ok(result.Interact?.down, 'Interact should be down')
+      assert.ok(result.Interact?.pressed, 'Interact should be pressed')
 
       // Test case 3: Remove button state from InputSourceComponent
+      ClientInputFunctions.refreshInputs(true)
       inputSource.buttons.set({})
 
       // Get buttons again - should not see the button anymore
-      result = InputComponent.getButtons(testEntity)
-      assert.ok(!result.PrimaryClick, 'PrimaryClick button should no longer be present')
+      result = InputComponent.getButtons(testEntity, DefaultButtonBindings)
+      assert.ok(!result.Interact, 'Interact button should no longer be present')
     })
 
     it('should handle multiple entities accessing the same button', () => {
@@ -537,6 +545,7 @@ describe('InputComponent', () => {
       setComponent(entity2, InputComponent, { inputSources: [inputSourceEntity] })
 
       // Add button state to InputSourceComponent
+      ClientInputFunctions.refreshInputs(true)
       inputSource.buttons.set({
         [MouseButton.PrimaryClick]: createInitialButtonState(inputSourceEntity, {
           down: true,
@@ -545,18 +554,18 @@ describe('InputComponent', () => {
       })
 
       // First entity accesses the button - should consume it
-      let result1 = InputComponent.getButtons(entity1)
-      assert.ok(result1.PrimaryClick, 'Entity1 should see the PrimaryClick button')
-      assert.ok(result1.PrimaryClick?.down, 'Entity1: PrimaryClick should be down')
-      assert.ok(result1.PrimaryClick?.pressed, 'Entity1: PrimaryClick should be pressed')
+      let result1 = InputComponent.getButtons(entity1, DefaultButtonBindings)
+      assert.ok(result1.Interact, 'Entity1 should see the Interact button')
+      assert.ok(result1.Interact?.down, 'Entity1: Interact should be down')
+      assert.ok(result1.Interact?.pressed, 'Entity1: Interact should be pressed')
 
       // Second entity tries to access the same button - should not see it (consumed by entity1)
-      let result2 = InputComponent.getButtons(entity2)
-      assert.ok(!result2.PrimaryClick, 'Entity2 should not see the PrimaryClick button (consumed by entity1)')
+      let result2 = InputComponent.getButtons(entity2, DefaultButtonBindings)
+      assert.ok(!result2.Interact, 'Entity2 should not see the Interact button (consumed by entity1)')
 
       // First entity accesses again - should still see the consumed button
-      result1 = InputComponent.getButtons(entity1)
-      assert.ok(result1.PrimaryClick, 'Entity1 should still see the consumed PrimaryClick button')
+      result1 = InputComponent.getButtons(entity1, DefaultButtonBindings)
+      assert.ok(result1.Interact, 'Entity1 should still see the consumed Interact button')
     })
   })
 

--- a/packages/spatial/src/input/components/InputComponent.ts
+++ b/packages/spatial/src/input/components/InputComponent.ts
@@ -175,7 +175,7 @@ export const InputComponent = defineComponent({
 
     buttons: S.SerializedClass(
       (entity) => {
-        // Helper function to find button state (including consumed ones if consumed by this entity)
+        // Helper function to find first unconsumed button state
         const findButtonState = (button: AnyButton): ButtonState | undefined => {
           const inputComponent = getComponent(entity, InputComponent)
           for (const sourceEntity of inputComponent.inputSources) {
@@ -188,8 +188,7 @@ export const InputComponent = defineComponent({
             //       state.consumed
             //     } - ${getComponent(state.consumed, NameComponent)}`
             //   )
-            // Return the state if it's not consumed, or if it was consumed by this entity
-            if (state && (!state.consumed || state.consumed === entity)) {
+            if (state && !state.consumed) {
               return state
             }
           }
@@ -204,11 +203,20 @@ export const InputComponent = defineComponent({
                 return target[prop]
               }
 
-              // Don't use cache for consumed buttons - always re-evaluate to ensure fresh state
+              // Check cache first
               const inputComponent = getComponent(entity, InputComponent)
               const cachedButtons = inputComponent.cachedButtons
+              if (Object.hasOwn(cachedButtons, prop)) {
+                if (!cachedButtons[prop]) return undefined
+                if (cachedButtons[prop] && cachedButtons[prop].consumed) {
+                  if (inputComponent.autoCapture && cachedButtons[prop].pressed) {
+                    InputState.setCapturingEntity(entity)
+                  }
+                  return cachedButtons[prop]
+                }
+              }
 
-              let result: ButtonState | undefined = undefined
+              let result = cachedButtons[prop]
 
               // First check mapped button states since they define the mapping from alias to actual buttons
               const buttonBindings = inputComponent.buttonBindings
@@ -224,8 +232,7 @@ export const InputComponent = defineComponent({
                     if (!result && isActive) {
                       // All buttons in combo are active and not consumed, consume them and set the result
                       states.forEach((s) => (s.consumed = entity))
-                      result = createInitialButtonState(states[0].inputSourceEntity)
-                      // Don't cache consumed buttons
+                      result = cachedButtons[prop] = createInitialButtonState(states[0].inputSourceEntity)
                     }
 
                     if (result && isActive) {
@@ -247,28 +254,21 @@ export const InputComponent = defineComponent({
                     }
                   } else {
                     // For single button bindings, just return that button
-                    result = findButtonState(b)
-                    if (result) {
-                      result.consumed = entity
-                      // Don't cache consumed buttons
-                    }
+                    result = cachedButtons[prop] = findButtonState(b)
+                    if (result) result.consumed = entity
                     if (inputComponent.autoCapture && result?.pressed) {
                       InputState.setCapturingEntity(entity)
                     }
-                    return result
+                    if (result !== undefined) return result
                   }
-
-                  // If we get here, the button in the binding is not available
-                  return undefined
                 }
+                // If we get here, the button in the binding is not available, so set the state to undefined
+                return (cachedButtons[prop] = undefined)
               }
 
               // Otherwise check if this exact button exists and is not consumed
-              const rawState = findButtonState(prop as AnyButton)
-              if (rawState) {
-                rawState.consumed = entity
-                // Don't cache consumed buttons
-              }
+              const rawState = (cachedButtons[prop] = findButtonState(prop as AnyButton))
+              if (rawState) rawState.consumed = entity
               if (rawState && inputComponent.autoCapture && rawState.pressed) {
                 InputState.setCapturingEntity(entity)
               }

--- a/packages/spatial/src/input/components/InputComponent.ts
+++ b/packages/spatial/src/input/components/InputComponent.ts
@@ -175,7 +175,7 @@ export const InputComponent = defineComponent({
 
     buttons: S.SerializedClass(
       (entity) => {
-        // Helper function to find first unconsumed button state
+        // Helper function to find button state (including consumed ones if consumed by this entity)
         const findButtonState = (button: AnyButton): ButtonState | undefined => {
           const inputComponent = getComponent(entity, InputComponent)
           for (const sourceEntity of inputComponent.inputSources) {
@@ -188,7 +188,8 @@ export const InputComponent = defineComponent({
             //       state.consumed
             //     } - ${getComponent(state.consumed, NameComponent)}`
             //   )
-            if (state && !state.consumed) {
+            // Return the state if it's not consumed, or if it was consumed by this entity
+            if (state && (!state.consumed || state.consumed === entity)) {
               return state
             }
           }
@@ -203,20 +204,11 @@ export const InputComponent = defineComponent({
                 return target[prop]
               }
 
-              // Check cache first
+              // Don't use cache for consumed buttons - always re-evaluate to ensure fresh state
               const inputComponent = getComponent(entity, InputComponent)
               const cachedButtons = inputComponent.cachedButtons
-              if (Object.hasOwn(cachedButtons, prop)) {
-                if (!cachedButtons[prop]) return undefined
-                if (cachedButtons[prop] && cachedButtons[prop].consumed) {
-                  if (inputComponent.autoCapture && cachedButtons[prop].pressed) {
-                    InputState.setCapturingEntity(entity)
-                  }
-                  return cachedButtons[prop]
-                }
-              }
 
-              let result = cachedButtons[prop]
+              let result: ButtonState | undefined = undefined
 
               // First check mapped button states since they define the mapping from alias to actual buttons
               const buttonBindings = inputComponent.buttonBindings
@@ -232,7 +224,8 @@ export const InputComponent = defineComponent({
                     if (!result && isActive) {
                       // All buttons in combo are active and not consumed, consume them and set the result
                       states.forEach((s) => (s.consumed = entity))
-                      result = cachedButtons[prop] = createInitialButtonState(states[0].inputSourceEntity)
+                      result = createInitialButtonState(states[0].inputSourceEntity)
+                      // Don't cache consumed buttons
                     }
 
                     if (result && isActive) {
@@ -254,22 +247,28 @@ export const InputComponent = defineComponent({
                     }
                   } else {
                     // For single button bindings, just return that button
-                    result = cachedButtons[prop] = findButtonState(b)
-                    if (result) result.consumed = entity
+                    result = findButtonState(b)
+                    if (result) {
+                      result.consumed = entity
+                      // Don't cache consumed buttons
+                    }
                     if (inputComponent.autoCapture && result?.pressed) {
                       InputState.setCapturingEntity(entity)
                     }
                     return result
                   }
 
-                  // If we get here, the button in the binding is not available, so set the state to undefined
-                  return (cachedButtons[prop] = undefined)
+                  // If we get here, the button in the binding is not available
+                  return undefined
                 }
               }
 
               // Otherwise check if this exact button exists and is not consumed
-              const rawState = (cachedButtons[prop] = findButtonState(prop as AnyButton))
-              if (rawState) rawState.consumed = entity
+              const rawState = findButtonState(prop as AnyButton)
+              if (rawState) {
+                rawState.consumed = entity
+                // Don't cache consumed buttons
+              }
               if (rawState && inputComponent.autoCapture && rawState.pressed) {
                 InputState.setCapturingEntity(entity)
               }

--- a/packages/spatial/src/input/components/InputComponent.ts
+++ b/packages/spatial/src/input/components/InputComponent.ts
@@ -173,8 +173,9 @@ export const InputComponent = defineComponent({
     /** if true, the input component will automatically capture input when a button is consumed */
     autoCapture: S.Bool({ default: false }),
 
-    buttons: S.SerializedClass(
-      (entity) => {
+    buttons: S.Type<ButtonStateMap<any>>({
+      serialized: false,
+      default: (entity) => {
         // Helper function to find first unconsumed button state
         const findButtonState = (button: AnyButton): ButtonState | undefined => {
           const inputComponent = getComponent(entity, InputComponent)
@@ -276,10 +277,8 @@ export const InputComponent = defineComponent({
             }
           }
         )
-      },
-      {},
-      { serialized: false }
-    )
+      }
+    })
   }),
 
   getInputEntity(entityContext: Entity): Entity {


### PR DESCRIPTION
## Summary
fixed issue with input processing that prevented anything other than the first key of a button alias from having its state evaluated (alias for interact for example is **left click** OR **controller trigger** OR **E key**)

## References
[https://tsu.atlassian.net/browse/IR-7193](https://tsu.atlassian.net/browse/IR-7193)

## QA Steps
set up a link component by adding one to a primitive geometry or mesh
walk up to it in preview/location and press E (clicking always worked because it was the first...and only... key checked in 'Interact' button alias of click/trigger/E)