### PR TITLE
fix(lookdev): remove the DirectionalLightComponent [IR-9728]

### DIFF
--- a/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
@@ -49,7 +49,7 @@ import { pathJoin } from '@ir-engine/engine/src/assets/functions/miscUtils'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { SkyboxComponent } from '@ir-engine/engine/src/scene/components/SkyboxComponent'
 import { getMutableState, getState, NO_PROXY, none, startReactor, useHookstate } from '@ir-engine/hyperflux'
-import { DirectionalLightComponent, HemisphereLightComponent, TransformComponent } from '@ir-engine/spatial'
+import { HemisphereLightComponent, TransformComponent } from '@ir-engine/spatial'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
 import { ObjectComponent } from '@ir-engine/spatial/src/renderer/components/ObjectComponent'
 import { PostProcessingComponent } from '@ir-engine/spatial/src/renderer/components/PostProcessingComponent'
@@ -93,12 +93,7 @@ export default function CreatePrefabPanel({ entity, isExportLookDev }: { entity?
   }
 
   const exportLookDevPrefab = async (srcProject: string, fileName: string) => {
-    const lookDevComponent: Component[] = [
-      SkyboxComponent,
-      HemisphereLightComponent,
-      DirectionalLightComponent,
-      PostProcessingComponent
-    ]
+    const lookDevComponent: Component[] = [SkyboxComponent, HemisphereLightComponent, PostProcessingComponent]
 
     const prefabEntity = createEntity()
     const sceneObject = new Scene()


### PR DESCRIPTION
## Summary
- Remove the `DirectionalLightComponent`, this is causing the scene to break when doing drag and drop

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
1. Open studio project
2. Create new scene
3. Select Files menu (IR logo) dropdown > Export Lookdev Prefab
4. Name custom prefab and confirm
5. Find the customized prefab in Files tab
6. Drag prefab into viewport

## Evidence
https://github.com/user-attachments/assets/636e0aa5-be8a-4163-9263-c13bc60ecaa7

## Jira
[IR-9728](https://tsu.atlassian.net/browse/IR-9728)


[IR-9728]: https://tsu.atlassian.net/browse/IR-9728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ