### PR TITLE
use the useMutableState hook to prevent error on mt-dev

### DIFF
--- a/packages/client-core/src/user/VideoWindows/hook.tsx
+++ b/packages/client-core/src/user/VideoWindows/hook.tsx
@@ -69,7 +69,7 @@ function addItem<T>(array: readonly T[], i: number, value: T): T[] {
 }
 
 export const useUserMediaWindowsHook = (windows: WindowType[]) => {
-  const mediaChannelState = useHookstate(getMutableState(MediaChannelState))
+  const mediaChannelState = useMutableState(MediaChannelState)
   const mediaStreamState = useMutableState(MediaStreamState)
   const mediaSettingState = useMutableState(MediaSettingsState)
 


### PR DESCRIPTION
## Summary
useHookstate here was inconsistently throwing an error on mt-dev. I believe using useMutableState has some internal logic that prevents this error. It isn't super clear.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
