### PR TITLE
IR-10725: Fix error moving nonexistent objects

### DIFF
--- a/packages/server-core/src/media/storageprovider/gcs.storage.ts
+++ b/packages/server-core/src/media/storageprovider/gcs.storage.ts
@@ -478,7 +478,7 @@ export class GCSStorage extends BaseStorageProvider implements StorageProviderIn
     const newFilePath = path.join(newPath, newName)
     const listResponse = await this.listObjects(oldFilePath + (isDirectory ? '/' : ''), false, undefined, isDirectory)
 
-    if (listResponse.Contents.length > 0)
+    if (listResponse.Contents.length > 0) {
       return await Promise.all([
         ...listResponse.Contents.map(async (file) => {
           const relativePath = file.Key.replace(oldFilePath, '')
@@ -488,11 +488,6 @@ export class GCSStorage extends BaseStorageProvider implements StorageProviderIn
           else return await this.provider.bucket(this.bucket).file(file.Key).move(key, {})
         })
       ])
-    else {
-      const oldPath = path.join(oldFilePath, '/')
-      const newPath = path.join(newFilePath, '/')
-      if (isCopy) return await this.provider.bucket(this.bucket).file(oldPath).copy(newPath, {})
-      else return await this.provider.bucket(this.bucket).file(oldPath).move(newPath, {})
     }
   }
 }


### PR DESCRIPTION
## Summary

This fixes an issue that occurs when attempting to move folders in GCP. In GCP, folders don’t actually exist, they are inferred from file prefixes. For example, /scenes/NewScene-1.gltf and /scenes/NewScene-2.gltf imply a scenes/ folder, which is displayed in the studio UI, however, when trying to move such a “folder,” the GCS provider may throw an error since the folder itself doesn't exist, only the files do. 

This change prevents those errors by skipping attempts to move nonexistent objects like folders. 

![Screen Recording 2025-06-17 at 10 17 06 a m](https://github.com/user-attachments/assets/cc16c86a-1e15-4254-9db4-a9de17c5786b)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
