### PR TITLE
Unable to change url field of the model via file/asset panel

### DIFF
--- a/packages/engine/src/assets/functions/resourceLoaderFunctions.ts
+++ b/packages/engine/src/assets/functions/resourceLoaderFunctions.ts
@@ -156,7 +156,6 @@ export const loadResource = <T extends ResourceAssetType>(
 }
 
 export const unloadResource = (url: string, entity: Entity) => {
-  console.trace('unloadResource', url)
   const resourceCacheState = getMutableState(ResourceCacheState)
   const resource = resourceCacheState[url]
   if (!resource.value) {

--- a/packages/engine/src/assets/functions/resourceLoaderFunctions.ts
+++ b/packages/engine/src/assets/functions/resourceLoaderFunctions.ts
@@ -102,7 +102,7 @@ export const loadResource = <T extends ResourceAssetType>(
     ResourceProgressComponent.setResource(entity, url, 0, 0)
     if (signal) {
       signal.addEventListener('abort', () => {
-        ResourceProgressComponent.setResource(entity, url, 0, 0)
+        ResourceProgressComponent.removeResource(entity, url)
       })
     }
   }
@@ -114,6 +114,7 @@ export const loadResource = <T extends ResourceAssetType>(
     (response: T) => {
       if (!resource || !resource.value) {
         console.warn(`ResourceState:load Resource removed before load finished: ${url} for entity: ${entity}`)
+        onError(new Error('Resource removed before load finished'))
         return
       }
       resource.asset.set(response)
@@ -155,6 +156,7 @@ export const loadResource = <T extends ResourceAssetType>(
 }
 
 export const unloadResource = (url: string, entity: Entity) => {
+  console.trace('unloadResource', url)
   const resourceCacheState = getMutableState(ResourceCacheState)
   const resource = resourceCacheState[url]
   if (!resource.value) {

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -104,7 +104,7 @@ import {
   Vector3,
   VectorKeyframeTrack
 } from 'three'
-import { loadResource, unloadResourcesForEntity } from '../assets/functions/resourceLoaderFunctions'
+import { loadResource, unloadResource } from '../assets/functions/resourceLoaderFunctions'
 import { FileLoader } from '../assets/loaders/base/FileLoader'
 import { Loader } from '../assets/loaders/base/Loader'
 import { ResourceCache } from '../assets/loaders/base/ResourceCache'
@@ -1644,7 +1644,7 @@ const loadScene = async (options: GLTFParserOptions, sceneIndex: number) => {
 
 const unloadScene = (url: string, entity: Entity) => {
   // handle reference counting
-  unloadResourcesForEntity(entity)
+  unloadResource(url, entity)
   // if no more references to this url, remove from cache
   const resourceCacheState = getState(ResourceCacheState)
   if (!resourceCacheState[url]) {


### PR DESCRIPTION
https://tsu.atlassian.net/browse/IR-10986

corrected issues with:

- updating the GLTFComponent src, not loading the new model because unloadResourcesForEntity(entity) was being called, causing the url in process of being loaded to be "unloaded"


- unloading the existing src url asset, causes its abort to be called, there by calling  ResourceProgressComponent.setResource(entity, url, 0, 0), which prevents the loading indicator (ResourceProgressComponent.setResource) from ever return a progress of 100, since the progress is the average of all the resources set. Updated to     ResourceProgressComponent.removeResource(entity, url) to prevent issue

- added     onError(new Error('Resource removed before load finished')) for error return when the url was removed before it was finished loading

## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
