### PR TITLE
[IR-11027] Attach routing to sidebar and add dynamic routing

### DIFF
--- a/packages/client-core/src/components/Glass/ChatMenu.tsx
+++ b/packages/client-core/src/components/Glass/ChatMenu.tsx
@@ -32,6 +32,7 @@ import { twMerge } from 'tailwind-merge'
 import { Send01Md } from '@ir-engine/ui/src/icons'
 import { AuthState } from '../../user/services/AuthService'
 import { useChatProvider } from './ChatProvider'
+import { useNavigationProvider } from './NavigationProvider'
 
 const messageBaseStyles = `
   inline-grid
@@ -135,13 +136,15 @@ const inputOuterStyles = `
   pb-4 px-4 pt-4
 `
 
-export const ChatMenu = ({ navigateTo }: { navigateTo: (screenKey: string, historyKey: string) => void }) => {
+export const ChatMenu = () => {
   const user = useMutableState(AuthState).user
 
   const isGuest = user.isGuest.value
-  const onCTAClicked = () => navigateTo('Settings', 'signup')
 
   const { messageGroupedBySender, inputRef, handleInputChange, sendMessage, composedMessage } = useChatProvider()
+  const { navigateTo } = useNavigationProvider()
+
+  const onCTAClicked = () => navigateTo('/settings/sign-up')
 
   if (isGuest) {
     return (

--- a/packages/client-core/src/components/Glass/NavigationProvider.tsx
+++ b/packages/client-core/src/components/Glass/NavigationProvider.tsx
@@ -23,86 +23,175 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import React, { useState } from 'react'
+import { defineState, getMutableState, getState } from '@ir-engine/hyperflux'
+import React, { useMemo, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 
-type DirectionType = 1 | -1
-
-type NavigationProviderType = {
-  navigateTo: (screenKey: string, historyKey: string) => void
-  activeHistoryKey: string
-  sidebarKey: string
-  setSidebarKey: (sidebarKey: string) => void
-  createToggleSidebarKey: (sidebarKey: string) => () => void
-  isSidebarOpen: boolean
-  navigateClose: () => void
-  navigateBack: () => void
-  hasHistory: boolean
-  direction: DirectionType
+interface WithNavigateTo {
+  navigateTo: (path: string, pushToHistory?: boolean) => void
 }
 
-const useSidebarNavigation = () => {
+interface WithNavigateClose {
+  navigateClose: () => void
+}
+
+type ButtonType = WithNavigateTo & {}
+
+export type NavigateFuncProps = WithNavigateTo & WithNavigateClose
+
+export interface RouteType {
+  path: string
+  title: string
+  Component: React.ComponentType<any>
+  Button?: React.ComponentType<ButtonType>
+}
+type DirectionType = 1 | -1
+
+export interface NavigationStateType {
+  routes: Record<string, RouteType>
+}
+
+type NavigationProviderType = NavigationStateType &
+  WithNavigateTo &
+  WithNavigateClose & {
+    current: string
+    history: string[]
+    direction: DirectionType
+
+    navigateBack: () => void
+
+    togglePath_factory: (path: string) => () => void
+
+    isSidebarOpen: boolean
+    hasHistory: boolean
+    hasUp: boolean
+    first: string
+    second: string
+  }
+
+export const NavigationState = defineState({
+  name: 'NavigationState',
+  initial: (): NavigationStateType => ({
+    routes: {}
+  })
+})
+
+export const NavigationService = {
+  addRoutes: (routes: RouteType[]) => {
+    const state = getMutableState(NavigationState)
+    const routesMap = routes.reduce(
+      (all, route) => {
+        all[route.path] = route
+        return all
+      },
+      {} as Record<string, RouteType>
+    )
+
+    state.routes.merge(routesMap)
+  },
+
+  addRoute: (route: RouteType) => {
+    const state = getMutableState(NavigationState)
+
+    state.routes[route.path].set(route)
+  }
+}
+
+const useProvider = () => {
   const [history, setHistory] = useState<string[]>([])
   const [direction, setDirection] = useState<DirectionType>(1) // 1 for forward, -1 for backward
-  const [sidebarKey, setSidebarKey] = useState(``)
 
-  const navigateTo = (screenKey: string, historyKey: string): void => {
-    setSidebarKey(screenKey)
+  const { routes } = getState(NavigationState)
+
+  const { pathname, search } = useLocation()
+  const navigate = useNavigate()
+
+  const [prefix, locationName, current = ''] = useMemo(() => {
+    // remove "location" and ":locationName" from path
+    const [prefix, locationName, ...rest] = pathname.split('/').filter((val) => val)
+
+    return [prefix, locationName, rest.join('/')]
+  }, [pathname])
+
+  const isSidebarOpen = !!current
+  const hasHistory = !!history.length
+  const [first, second] = current.split('/')
+  const up = current.split('/').slice(0, -1).join('/')
+  const hasUp = !!up
+
+  const _navigateWithPrefix = (path) => {
+    navigate({
+      pathname: `/${prefix}/${locationName}/${path}`,
+      search
+    })
+  }
+
+  const addToHistory = (path) => {
     setDirection(1)
-    setHistory([...history, historyKey])
+    setHistory([...history, path])
+  }
+
+  const navigateTo = (path: string, pushToHistory = true): void => {
+    if (pushToHistory) {
+      addToHistory(current)
+    }
+
+    _navigateWithPrefix(path)
   }
 
   const navigateBack = (): void => {
-    if (history.length > 1) {
-      setDirection(-1)
-      setHistory(history.slice(0, -1))
-    } else {
-      closeSidebar()
-    }
-  }
+    setDirection(-1)
 
-  const closeSidebar = () => setSidebarKey(``)
+    if (!hasHistory) {
+      _navigateWithPrefix(up)
+      return
+    }
+
+    const newHistory = [...history]
+    const last = newHistory.pop() || ''
+
+    setHistory(newHistory)
+    _navigateWithPrefix(last)
+  }
 
   const navigateClose = () => {
     setDirection(-1)
-    setHistory([``])
-    closeSidebar()
+    setHistory([])
+    _navigateWithPrefix('')
   }
 
-  const createToggleSidebarKey = (sidebarKey) => () => {
-    setSidebarKey((prev) => {
-      return prev === sidebarKey ? `` : sidebarKey
-    })
-    setHistory([``])
+  const togglePath_factory = (path) => () => {
+    _navigateWithPrefix(current === path ? `` : path)
+    setHistory([])
   }
-
-  const activeHistoryKey = history[history.length - 1]
-  const isSidebarOpen = !!sidebarKey
-  const hasHistory = !!activeHistoryKey
 
   return {
-    activeHistoryKey,
-    navigateBack,
     navigateTo,
+    navigateBack,
     navigateClose,
+
+    togglePath_factory,
+
+    current,
     direction,
+    routes,
     history,
 
-    setSidebarKey,
-    sidebarKey,
+    first,
+    second,
     hasHistory,
-    createToggleSidebarKey,
+    hasUp,
     isSidebarOpen
   }
 }
 
-const MultimediaStateContext = React.createContext({} as NavigationProviderType)
-
-export const useNavigationProvider = () => React.useContext(MultimediaStateContext)
-
-const Provider = MultimediaStateContext.Provider
+const Context = React.createContext({} as NavigationProviderType)
+const Provider = Context.Provider
 
 export const NavigationProvider = ({ children }) => {
-  const state = useSidebarNavigation()
+  const state = useProvider()
 
   return <Provider value={state}>{children}</Provider>
 }
+
+export const useNavigationProvider = () => React.useContext(Context)

--- a/packages/client-core/src/components/Glass/ToolbarAndSidebar.tsx
+++ b/packages/client-core/src/components/Glass/ToolbarAndSidebar.tsx
@@ -38,11 +38,11 @@ type TabProps = {
 }
 
 type HeaderProps = {
-  heading: string
+  title: string
   tabs?: TabProps[]
   handleSidebarClose: () => void
   handleSidebarBack: () => void
-  hasHistory: boolean
+  showBack: boolean
 }
 
 type ToolbarAndSidebarProps = HeaderProps & {
@@ -95,7 +95,6 @@ const headerInnerStyles = `
 
 const buttonContainer_base = `
   absolute z-10
-  right-0
   top-1/2
 
   inline-flex items-center
@@ -151,7 +150,7 @@ const headerBackButtonStyles = `
   lg:block
 `
 
-const Header = ({ tabs = [], heading, handleSidebarClose, handleSidebarBack, hasHistory }: HeaderProps) => {
+const Header = ({ tabs = [], title, handleSidebarClose, handleSidebarBack, showBack }: HeaderProps) => {
   const backButton = (
     <button className={twMerge(smallIconButtonStyles, `shadow`)} onClick={handleSidebarBack}>
       <ChevronLeftMd />
@@ -161,15 +160,15 @@ const Header = ({ tabs = [], heading, handleSidebarClose, handleSidebarBack, has
   return (
     <div className={headerContainerStyles}>
       <div className={headerInnerStyles}>
-        {hasHistory ? <div className={twMerge(buttonContainer_base, backButtonStyles)}>{backButton}</div> : <></>}
+        {showBack ? <div className={twMerge(buttonContainer_base, backButtonStyles)}>{backButton}</div> : <></>}
         <div className={twMerge(buttonContainer_base, closeButtonStyles)}>
           <MenuButton className={`text-3xl`} onClick={handleSidebarClose}>
             <XCloseLg />
           </MenuButton>
         </div>
         <div style={{ textShadow: `0 0.025em 0.08em hsla(0, 0%, 0%, 0.2)` }} className={headingsStyles}>
-          {hasHistory ? <div className={headerBackButtonStyles}>{backButton}</div> : <></>}
-          <h2 className={twMerge(`lg:block`, tabs.length ? `hidden` : ``)}>{heading}</h2>
+          {showBack ? <div className={headerBackButtonStyles}>{backButton}</div> : <></>}
+          <h2 className={twMerge(`lg:block`, tabs.length ? `hidden` : ``)}>{title}</h2>
           {tabs.map((tabProps) => {
             return <Tab {...tabProps} />
           })}
@@ -227,14 +226,14 @@ const contentFakeSpacer = `
 export const ToolbarAndSidebar = ({
   toolbar,
   content,
-  heading,
+  title,
   tabs = [],
   handleSidebarClose,
   handleSidebarBack,
-  hasHistory,
+  showBack,
   isSidebarOpen
 }: ToolbarAndSidebarProps) => {
-  tabs = (tabs as TabProps[]) || [{ heading } as TabProps]
+  tabs = (tabs as TabProps[]) || [{ heading: title } as TabProps]
 
   return (
     <>
@@ -243,8 +242,8 @@ export const ToolbarAndSidebar = ({
         <div className={sidebarContainerStyles}>
           <Header
             tabs={tabs}
-            heading={heading}
-            hasHistory={hasHistory}
+            title={title}
+            showBack={showBack}
             handleSidebarClose={handleSidebarClose}
             handleSidebarBack={handleSidebarBack}
           />

--- a/packages/client-core/src/components/Glass/ToolbarMenu.tsx
+++ b/packages/client-core/src/components/Glass/ToolbarMenu.tsx
@@ -155,7 +155,6 @@ export const VerticalMenu = ({ children }) => {
         top-1/2
         z-10
         -translate-x-full
-        
         -translate-y-1/2
         sm:max-lg:hidden
       `}
@@ -262,7 +261,7 @@ const arrowButtonStyles = `
   sm:max-lg:-mb-2
 `
 
-export const ToolbarMenu = ({ onMessageClick, onShareClick, onSettingsClick, activeKey }) => {
+export const ToolbarMenu = ({ onMessageClick, onShareClick, onSettingsClick, activePath }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const { unreadMessages } = useChatProvider()
   const showMessagesBadge = unreadMessages.value
@@ -320,7 +319,7 @@ export const ToolbarMenu = ({ onMessageClick, onShareClick, onSettingsClick, act
         {showFirstDivider && <Divider />}
 
         <div className={isMultiMediaOpen ? collapsableSectionOpenStyles : collapsableSectionCloseStyles}>
-          <ChatButton badge={{ show: showMessagesBadge }} active={activeKey === `Chat`} onClick={onMessageClick} />
+          <ChatButton badge={{ show: showMessagesBadge }} active={activePath === `chat`} onClick={onMessageClick} />
           <MicButton />
           <CamButton />
           <MultiVideoButton />

--- a/packages/client-core/src/components/Glass/VideoMenu.tsx
+++ b/packages/client-core/src/components/Glass/VideoMenu.tsx
@@ -160,6 +160,7 @@ const Video = ({ peerID, type }: WindowType) => {
   })
 
   const { isCamVideoEnabled, isCamAudioEnabled } = useMultimediaStateProvider()
+
   const { navigateTo } = useNavigationProvider()
 
   const ref = useRef<HTMLVideoElement>(null)
@@ -174,7 +175,7 @@ const Video = ({ peerID, type }: WindowType) => {
 
   const reportUser = () => {
     ReportUserState.setReportedPeerId(peerID)
-    navigateTo('ReportUser', '')
+    navigateTo('report')
   }
 
   return (

--- a/packages/client-core/src/components/Glass/index.tsx
+++ b/packages/client-core/src/components/Glass/index.tsx
@@ -23,14 +23,12 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import React, { useLayoutEffect, useRef } from 'react'
-
 import { TouchGamepad } from '@ir-engine/client-core/src/common/components/TouchGamepad'
 import { EngineState } from '@ir-engine/ecs'
-import { getMutableState, NO_PROXY, useHookstate, useMutableState } from '@ir-engine/hyperflux'
-import { useTranslation } from 'react-i18next'
+import { getMutableState, useHookstate } from '@ir-engine/hyperflux'
+import _ from 'lodash'
+import React, { useLayoutEffect, useRef } from 'react'
 import { LoadingSystemState } from '../../systems/state/LoadingState'
-import { ViewerMenuState } from '../../util/ViewerMenuState'
 import { ARPlacement } from '../ARPlacement'
 import { XRLoading } from '../XRLoading'
 
@@ -40,12 +38,12 @@ import PopupMenu from '@ir-engine/ui/src/primitives/tailwind/PopupMenu'
 import { useMediaWindows } from '../../user/VideoWindows'
 import { useUserMediaWindowsHook } from '../../user/VideoWindows/hook'
 import ReportUserMenu from '../ReportUser'
-import Settings, { screens as settingsScreens } from '../Settings'
+import Settings from '../Settings'
 import { ChatMenu } from './ChatMenu'
 import { ChatProvider } from './ChatProvider'
 import { MultimediaStateProvider } from './MultimediaStateProvider'
 import { VideoCarousel } from './MultiVideo'
-import { NavigationProvider, useNavigationProvider } from './NavigationProvider'
+import { NavigationProvider, NavigationService, useNavigationProvider } from './NavigationProvider'
 import { ToolbarMenu } from './ToolbarMenu'
 import { VideoMenu } from './VideoMenu'
 
@@ -69,91 +67,104 @@ const useIsPortrait = () => {
   return isPortrait
 }
 
+NavigationService.addRoutes([
+  {
+    path: `chat`,
+    title: 'Chat',
+    Component: ChatMenu
+  },
+  {
+    path: `video`,
+    title: 'Video',
+    Component: VideoMenu
+  },
+  {
+    path: `settings`,
+    title: `Settings`,
+    Component: Settings
+  },
+  {
+    path: `report`,
+    title: `Report User`,
+    Component: ReportUserMenu
+  }
+])
+
 const Menu = () => {
   const isPortrait = useIsPortrait()
   const loadingScreenVisible = useHookstate(getMutableState(LoadingSystemState).loadingScreenVisible).value
-  const { t } = useTranslation()
-  const externalInjectedMenus = useMutableState(ViewerMenuState).externalInjectedMenus.get(NO_PROXY)
+
   const locationContainer = useRef<HTMLDivElement>(null)
   const windows = useMediaWindows()
 
   const {
-    activeHistoryKey,
-    sidebarKey,
-    setSidebarKey,
-    createToggleSidebarKey,
+    current,
+    routes,
+    direction,
+    first,
     isSidebarOpen,
-    navigateClose,
-    navigateBack,
     hasHistory,
-    navigateTo
+    hasUp,
+
+    navigateBack,
+    navigateTo,
+    navigateClose,
+    togglePath_factory
   } = useNavigationProvider()
+
+  const { title, Component = () => <></> } = routes[first] || {}
+
+  const injectedButtons = _.filter(routes, ({ Button }) => !!Button).map(({ Button = () => <></> }, index) => {
+    return <Button key={index} navigateTo={navigateTo} />
+  })
+
+  const tabs = {
+    chat: [
+      {
+        heading: `Video`,
+        onClick: () => navigateTo(`video`)
+      },
+      {
+        heading: `Chat`,
+        onClick: () => navigateTo(`chat`),
+        active: true
+      }
+    ],
+    video: [
+      {
+        heading: `Video`,
+        onClick: () => navigateTo(`video`),
+        active: true
+      },
+      {
+        heading: `Chat`,
+        onClick: () => navigateTo(`chat`)
+      }
+    ]
+  }
+
+  const onMessageClick = togglePath_factory(`chat`)
+  const onShareClick = togglePath_factory(`settings/share`)
+  const onFullscreenVideosClick = togglePath_factory(`video`)
+  const onSettingsClick = togglePath_factory(`settings`)
+
+  const sidebarTabs = tabs[current] || []
+
+  const { videoElements, videoMediaStreams } = useUserMediaWindowsHook(windows)
+  const showBack = hasHistory || hasUp
 
   useLayoutEffect(() => {
     if (locationContainer.current) locationContainer.current.style.opacity = '0'
   }, [locationContainer])
 
-  const headings = {
-    Chat: `Chat`,
-    Video: `Video`,
-    Cart: `Cart`,
-    Share: `Share`,
-    Settings: `Settings`,
-    ReportUser: `Report User`
-  }
-
-  const tabs = {
-    Chat: [
-      {
-        heading: `Video`,
-        onClick: () => setSidebarKey(`Video`)
-      },
-      {
-        heading: `Chat`,
-        onClick: () => setSidebarKey(`Chat`),
-        active: true
-      }
-    ],
-    Video: [
-      {
-        heading: `Video`,
-        onClick: () => setSidebarKey(`Video`),
-        active: true
-      },
-      {
-        heading: `Chat`,
-        onClick: () => setSidebarKey(`Chat`)
-      }
-    ]
-  }
-
-  const contents = {
-    Chat: <ChatMenu navigateTo={navigateTo} />,
-    Video: <VideoMenu videos={windows} />,
-    Settings: <Settings />,
-    ReportUser: <ReportUserMenu type="user" />
-  }
-
-  const onMessageClick = createToggleSidebarKey(`Chat`)
-  const onShareClick = createToggleSidebarKey(`Share`)
-  const onFullscreenVideosClick = createToggleSidebarKey(`Video`)
-  const onSettingsClick = createToggleSidebarKey(`Settings`)
-
-  const { videoElements, videoMediaStreams } = useUserMediaWindowsHook(windows)
-
   const toolbar = (
     <ToolbarMenu
       onMessageClick={onMessageClick}
       onShareClick={onShareClick}
-      activeKey={sidebarKey}
       onSettingsClick={onSettingsClick}
+      activePath={current}
     />
   )
-  const sidebarHeadingFromHistory = settingsScreens[activeHistoryKey]?.title
-
-  const sidebarTabs = tabs[sidebarKey] || []
-  const sidebarHeading = sidebarHeadingFromHistory || headings[sidebarKey]
-  const sidebarContent = isSidebarOpen && contents[sidebarKey]
 
   return (
     <div id="location-container" ref={locationContainer} className="fixed h-dvh w-full">
@@ -167,12 +178,14 @@ const Menu = () => {
         handleSidebarClose={navigateClose}
         handleSidebarBack={navigateBack}
         isSidebarOpen={isSidebarOpen}
-        content={sidebarContent}
-        heading={sidebarHeading}
+        content={<Component />}
+        title={title}
         tabs={sidebarTabs}
         toolbar={toolbar}
-        hasHistory={hasHistory}
+        showBack={showBack}
       />
+
+      {injectedButtons}
 
       <ARPlacement />
       <XRLoading />

--- a/packages/client-core/src/components/ReportUser/index.tsx
+++ b/packages/client-core/src/components/ReportUser/index.tsx
@@ -44,7 +44,6 @@ import { LocationState } from '../../social/services/LocationService'
 import { ReportUserState } from '../../util/ReportUserState'
 import { uploadToFeathersService } from '../../util/upload'
 import { smallIconButtonStyles } from '../Glass/Buttons'
-import { useNavigationProvider } from '../Glass/NavigationProvider'
 
 const backButtonStyles = `
   left-4
@@ -82,7 +81,6 @@ const ReportUserMenu = (props: ReportMenuProps) => {
   const currentLocation = getState(LocationState).currentLocation.location
   const reportedLocationId = currentLocation.id
   const userReportsMutation = useMutation(moderationPath)
-  const { activeHistoryKey, sidebarKey, navigateClose, navigateTo } = useNavigationProvider()
 
   const [content, setContent] = useState<string>(REPORT_INPROGRESS) // REPORT_INPROGRESS | REPORT_SUCCESS
   const fileInputRef = useRef<HTMLInputElement>(null)

--- a/packages/client-core/src/components/Settings/AccountSettings.tsx
+++ b/packages/client-core/src/components/Settings/AccountSettings.tsx
@@ -26,27 +26,25 @@ Infinite Reality Engine. All Rights Reserved.
 import React from 'react'
 
 import Divider from '@ir-engine/ui/src/components/viewer/Divider'
+import { NavigateFuncProps } from '../Glass/NavigationProvider'
 import { MenuItem } from './MenuItem'
 import { Section } from './Section'
 
 // Define types for screen components
-interface ScreenProps {
-  navigateTo: (screenKey: string, historyKey: string) => void
-  navigateClose?: () => void
-}
+type ScreenProps = NavigateFuncProps & {}
 
 const AccountSettings: React.FC<ScreenProps> = ({ navigateTo }) => (
   <div className="h-full space-y-4">
     <Section>
-      <MenuItem label="Display Name" onClick={() => navigateTo('Settings', 'displayName')} hasChevron />
+      <MenuItem label="Display Name" onClick={() => navigateTo('settings/display')} hasChevron />
       <Divider />
-      <MenuItem label="Permissions" onClick={() => navigateTo('Settings', 'permissions')} hasChevron />
+      <MenuItem label="Permissions" onClick={() => navigateTo('settings/permissions')} hasChevron />
     </Section>
 
     <Section>
-      <MenuItem label="Single Sign On" onClick={() => navigateTo('Settings', 'sso')} hasChevron />
+      <MenuItem label="Single Sign On" onClick={() => navigateTo('settings/sso')} hasChevron />
       <Divider />
-      <MenuItem label="Delete My Account" onClick={() => navigateTo('Settings', 'deleteAccount')} hasChevron />
+      <MenuItem label="Delete My Account" onClick={() => navigateTo('settings/delete')} hasChevron />
     </Section>
   </div>
 )

--- a/packages/client-core/src/components/Settings/AvatarScreen.tsx
+++ b/packages/client-core/src/components/Settings/AvatarScreen.tsx
@@ -42,13 +42,11 @@ import AvatarCreatorMenu, { SupportedSdks } from '../../user/menus/avatar/Avatar
 import AvatarModifyMenu from '../../user/menus/avatar/AvatarModifyMenu'
 import { AuthService, AuthState } from '../../user/services/AuthService'
 import { AVATAR_PAGE_LIMIT } from '../../user/services/AvatarService'
+import { NavigateFuncProps } from '../Glass/NavigationProvider'
 import { MenuItem } from './MenuItem'
 import { Section } from './Section'
 
-interface AvatarScreenProps {
-  navigateTo: (screen: string) => void
-  onClose?: () => void
-}
+type AvatarScreenProps = NavigateFuncProps & {}
 
 const AvatarScreen: React.FC<AvatarScreenProps> = ({ navigateTo }) => {
   const search = useHookstate('')

--- a/packages/client-core/src/components/Settings/DeleteAccountScreen.tsx
+++ b/packages/client-core/src/components/Settings/DeleteAccountScreen.tsx
@@ -27,12 +27,10 @@ import { useMutableState } from '@ir-engine/hyperflux'
 import { motion } from 'motion/react'
 import React from 'react'
 import { AuthService, AuthState } from '../../user/services/AuthService'
+import { NavigateFuncProps } from '../Glass/NavigationProvider'
 import ButtonGroup from './ButtonGroup'
 
-interface DeleteAccountScreenProps {
-  navigateTo: (screenKey: string, historyKey: string) => void
-  navigateClose: () => void
-}
+type DeleteAccountScreenProps = NavigateFuncProps & {}
 
 const DeleteAccountScreen: React.FC<DeleteAccountScreenProps> = ({ navigateTo, navigateClose }) => {
   const { id } = useMutableState(AuthState).user
@@ -44,7 +42,7 @@ const DeleteAccountScreen: React.FC<DeleteAccountScreenProps> = ({ navigateTo, n
   }
 
   const handleStayHere = () => {
-    navigateTo('Settings', 'account')
+    navigateTo('/settings/account')
   }
 
   return (

--- a/packages/client-core/src/components/Settings/DisplayNameScreen.tsx
+++ b/packages/client-core/src/components/Settings/DisplayNameScreen.tsx
@@ -34,12 +34,11 @@ import React, { useEffect, useMemo } from 'react'
 import { AuthState } from '../../user/services/AuthService'
 import { AvatarService } from '../../user/services/AvatarService'
 import { clientContextParams } from '../../util/ClientContextState'
+import { NavigateFuncProps } from '../Glass/NavigationProvider'
 import FieldItem from './FieldItem'
 import { Section } from './Section'
 
-interface DisplayNameScreenProps {
-  navigateTo: (screenKey: string, historyKey) => void
-}
+type DisplayNameScreenProps = NavigateFuncProps & {}
 const logger = multiLogger.child({ component: 'engine:ecs:DisplayName', modifier: clientContextParams })
 
 const DisplayNameScreen: React.FC<DisplayNameScreenProps> = () => {

--- a/packages/client-core/src/components/Settings/GraphicsSettings.tsx
+++ b/packages/client-core/src/components/Settings/GraphicsSettings.tsx
@@ -31,6 +31,7 @@ import { RendererState } from '@ir-engine/spatial/src/renderer/RendererState'
 import Divider from '@ir-engine/ui/src/components/viewer/Divider'
 import { Dropdown } from '@ir-engine/ui/viewer'
 import { clientContextParams } from '../../util/ClientContextState'
+import { NavigateFuncProps } from '../Glass/NavigationProvider'
 import { Section } from './Section'
 import SliderItem from './SliderItem'
 import ToggleItem from './ToggleItem'
@@ -38,10 +39,7 @@ import ToggleItem from './ToggleItem'
 const logger = multiLogger.child({ component: 'system:settings-menu', modifier: clientContextParams })
 
 // Define types for screen components
-interface ScreenProps {
-  navigateTo: (screenKey: string, historyKey: string) => void
-  navigateClose?: () => void
-}
+type ScreenProps = NavigateFuncProps & {}
 
 const GraphicsSettings: React.FC<ScreenProps> = ({ navigateTo }) => {
   const { qualityLevel, usePostProcessing, useShadows, automatic, shadowMapResolution } = useMutableState(RendererState)

--- a/packages/client-core/src/components/Settings/MainMenu.tsx
+++ b/packages/client-core/src/components/Settings/MainMenu.tsx
@@ -30,6 +30,7 @@ import { useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import Divider from '@ir-engine/ui/src/components/viewer/Divider'
 import { MultiplayerState } from '../../common/services/MultiplayerState'
 import { AuthService, AuthState } from '../../user/services/AuthService'
+import { NavigateFuncProps } from '../Glass/NavigationProvider'
 import ButtonGroup from './ButtonGroup'
 import { MenuItem } from './MenuItem'
 import { Section } from './Section'
@@ -37,10 +38,7 @@ import SliderItem from './SliderItem'
 import ToggleItem from './ToggleItem'
 
 // Define types for screen components
-interface ScreenProps {
-  navigateTo: (screenKey: string, historyKey: string) => void
-  navigateClose?: () => void
-}
+type ScreenProps = NavigateFuncProps & {}
 
 const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
   const audioState = useMutableState(AudioState)
@@ -68,7 +66,7 @@ const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
     <div className="space-y-4">
       {/* Communication Section */}
       <Section>
-        <MenuItem label="Share Space" onClick={() => navigateTo('Settings', 'shareSpace')} hasChevron />
+        <MenuItem label="Share Space" onClick={() => navigateTo('settings/share')} hasChevron />
         <Divider />
         <ToggleItem
           label="Video Communication"
@@ -96,17 +94,17 @@ const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
       <Section>
         <ToggleItem label="Multiplayer" checked={world.value} onClick={() => world.set(!world.value)} />
         <Divider />
-        <MenuItem label="Account" onClick={() => navigateTo('Settings', 'account')} hasChevron />
+        <MenuItem label="Account" onClick={() => navigateTo('settings/account')} hasChevron />
         <Divider />
-        <MenuItem label="Avatar" onClick={() => navigateTo('Settings', 'avatar')} hasChevron />
+        <MenuItem label="Avatar" onClick={() => navigateTo('settings/avatar')} hasChevron />
       </Section>
 
       {/* System Section */}
       <Section>
-        <MenuItem label="Controls" onClick={() => navigateTo('Settings', 'controls')} hasChevron />
+        <MenuItem label="Controls" onClick={() => navigateTo('settings/controls')} hasChevron />
         <Divider />
-        <MenuItem label="Graphics" onClick={() => navigateTo('Settings', 'graphics')} hasChevron />
-        <MenuItem label="Audio" onClick={() => navigateTo('Settings', 'audio')} hasChevron />
+        <MenuItem label="Graphics" onClick={() => navigateTo('settings/graphics')} hasChevron />
+        <MenuItem label="Audio" onClick={() => navigateTo('settings/avatar')} hasChevron />
         {!isGuest && <MenuItem label="Log Out" onClick={() => confirmLogout.set(true)} />}
       </Section>
     </div>

--- a/packages/client-core/src/components/Settings/PermissionsScreen.tsx
+++ b/packages/client-core/src/components/Settings/PermissionsScreen.tsx
@@ -26,12 +26,11 @@ Infinite Reality Engine. All Rights Reserved.
 import { MediaStreamState, useMutableState } from '@ir-engine/hyperflux'
 import Divider from '@ir-engine/ui/src/components/viewer/Divider'
 import React from 'react'
+import { NavigateFuncProps } from '../Glass/NavigationProvider'
 import { Section } from './Section'
 import ToggleItem from './ToggleItem'
 
-interface PermissionsScreenProps {
-  navigateTo: (screen: string) => void
-}
+type PermissionsScreenProps = NavigateFuncProps & {}
 
 const PermissionsScreen: React.FC<PermissionsScreenProps> = () => {
   const { microphoneEnabled, webcamEnabled } = useMutableState(MediaStreamState)

--- a/packages/client-core/src/components/Settings/ShareSpaceScreen.tsx
+++ b/packages/client-core/src/components/Settings/ShareSpaceScreen.tsx
@@ -29,11 +29,10 @@ import { QRCodeSVG } from 'qrcode.react'
 import React from 'react'
 import { createPortal } from 'react-dom'
 import { useShareMenu } from '../../hooks/useShareMenu'
+import { NavigateFuncProps } from '../Glass/NavigationProvider'
 import ShareDrawer from './ShareDrawer'
 
-interface ShareSpaceScreenProps {
-  navigateTo: (screen: string) => void
-}
+type ShareSpaceScreenProps = NavigateFuncProps & {}
 
 const ShareSpaceScreen: React.FC<ShareSpaceScreenProps> = () => {
   const { shareLink, copyLinkToClipboard, questLink, inviteLink } = useShareMenu()

--- a/packages/client-core/src/components/Settings/index.tsx
+++ b/packages/client-core/src/components/Settings/index.tsx
@@ -26,20 +26,13 @@ Infinite Reality Engine. All Rights Reserved.
 import { AnimatePresence, motion, Variant } from 'motion/react'
 import React from 'react'
 
-// Import icons from the icons module
-// Define types for screen components
-interface ScreenProps {
-  navigateTo: (screenKey: string, historyKey: string) => void
-  navigateClose?: () => void
-}
-
 // Import main screen components
 import AccountSettings from './AccountSettings'
 import GraphicsSettings from './GraphicsSettings'
 import MainMenu from './MainMenu'
 
 // Import other screen components
-import { useNavigationProvider } from '../Glass/NavigationProvider'
+import { NavigateFuncProps, useNavigationProvider } from '../Glass/NavigationProvider'
 import AudioScreen from './AudioScreen'
 import AvatarScreen from './AvatarScreen'
 import ControlsScreen from './ControlsScreen'
@@ -49,6 +42,10 @@ import PermissionsScreen from './PermissionsScreen'
 import ShareSpaceScreen from './ShareSpaceScreen'
 import SignUpScreen from './SignUpScreen'
 import SSOScreen from './SSOScreen'
+
+// Import icons from the icons module
+// Define types for screen components
+type ScreenProps = NavigateFuncProps
 
 // Define screen structure type
 interface ScreenDefinition {
@@ -71,7 +68,7 @@ export const screens: Record<string, ScreenDefinition> = {
     title: 'Sign Up',
     component: SignUpScreen
   },
-  shareSpace: {
+  share: {
     component: ShareSpaceScreen,
     title: 'Share Space'
   },
@@ -83,7 +80,7 @@ export const screens: Record<string, ScreenDefinition> = {
     component: ControlsScreen,
     title: 'Controls'
   },
-  displayName: {
+  display: {
     component: DisplayNameScreen,
     title: 'Display Name'
   },
@@ -95,7 +92,7 @@ export const screens: Record<string, ScreenDefinition> = {
     component: SSOScreen,
     title: 'Single Sign On'
   },
-  deleteAccount: {
+  delete: {
     component: DeleteAccountScreen,
     title: 'Delete My Account'
   }
@@ -106,10 +103,10 @@ interface SettingsMenuProps {
   initScreen?: string
 }
 
-const SettingsMenu: React.FC<SettingsMenuProps> = ({ initScreen = 'main' }) => {
-  const { activeHistoryKey, direction, navigateBack, navigateTo, navigateClose } = useNavigationProvider()
+const SettingsMenu = ({ initScreen = 'main' }: SettingsMenuProps) => {
+  const { current, direction, second, navigateTo, navigateClose } = useNavigationProvider()
 
-  const ActiveComponent = screens[activeHistoryKey || initScreen].component
+  const ActiveComponent = screens[second || initScreen].component
 
   // Animation variants for slide transitions
   const variants: Record<string, Variant> = {
@@ -131,7 +128,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ initScreen = 'main' }) => {
     <div data-testid="settings-menu-backdrop" id="settings-menu-backdrop" className="h-full w-full">
       <AnimatePresence initial={false} mode="popLayout" custom={direction}>
         <motion.div
-          key={activeHistoryKey}
+          key={current}
           custom={direction}
           variants={variants}
           initial="enter"

--- a/packages/client/src/pages/location/location.tsx
+++ b/packages/client/src/pages/location/location.tsx
@@ -57,7 +57,7 @@ const LocationRoutes = () => {
     <Suspense>
       {projectsLoaded && (
         <Routes>
-          <Route path=":locationName" element={<LocationPage online={multiplayer.value} />} />
+          <Route path=":locationName/*" element={<LocationPage online={multiplayer.value} />} />
         </Routes>
       )}
       {!ready && (


### PR DESCRIPTION
## Summary

- NavigationProvider needed a way to add dynamic routes so the Shopify Cart could inject itself into the Viewer.
- This makes the routing logic more flexible, allowing for any depth of route, and it connect the routing to the actual React router and URL
- This provides browser history functionality like back and refresh on any sidebar page

https://github.com/user-attachments/assets/635ac19d-428a-4fe3-a855-ca12a0c10ff3


## QA Steps

- Open viewer scene
- Clicking any button that would open the sidebar should open the sidebar
- When the sidebar is open, the url should show the route
- Clicking the back button in the browser should navigate backwards
- When refreshing the page, if the sidebar was open it should be open to the same page
