### PR TITLE
Add Inner to Glass pages

### DIFF
--- a/packages/client-core/src/components/Glass/ChatMenu.tsx
+++ b/packages/client-core/src/components/Glass/ChatMenu.tsx
@@ -30,9 +30,10 @@ import { twMerge } from 'tailwind-merge'
 
 import { Send01Md } from '@ir-engine/ui/src/icons'
 import { AuthState } from '../../user/services/AuthService'
+import { TextButton } from './buttons/TextButton'
 import { useChatProvider } from './ChatProvider'
 import { useNavigationProvider } from './NavigationProvider'
-import { TextButton } from './buttons/TextButton'
+import { Inner } from './ToolbarAndSidebar'
 
 const messageBaseStyles = `
   inline-grid
@@ -148,7 +149,7 @@ export const ChatMenu = () => {
 
   if (isGuest) {
     return (
-      <div className="flex h-full w-full max-w-screen-sm flex-col items-center justify-center gap-8 font-dm-sans">
+      <div className="flex min-h-full w-full max-w-screen-sm flex-col items-center justify-center gap-8 font-dm-sans">
         <HiChatBubbleLeftRight className="mx-auto h-[5.5rem] w-[5.5rem]" />
         <div className="text-shadow font-manrope text-2xl text-white">Want to chat with others?</div>
         <TextButton className={'w-[90%]'} onClick={onCTAClicked}>
@@ -167,7 +168,7 @@ export const ChatMenu = () => {
   const hasInputText = !!composedMessage.value
 
   return (
-    <>
+    <Inner className={`mb-20`}>
       {messageGroupedBySender.map((group, groupIndex) => {
         const [firstMessage] = group
         const isOwnGroup = firstMessage.senderId === user.id.value
@@ -204,6 +205,6 @@ export const ChatMenu = () => {
       </div>
 
       <BottomSpacer />
-    </>
+    </Inner>
   )
 }

--- a/packages/client-core/src/components/Glass/ToolbarAndSidebar.tsx
+++ b/packages/client-core/src/components/Glass/ToolbarAndSidebar.tsx
@@ -184,18 +184,22 @@ const contentStyles = `
 
   flex flex-col items-center
   gap-y-7
-  overflow-y-auto
-  
-  px-6 mb-20 pt-0
 
   text-xl
   text-white
+
   scrollbar-hide
-  
+  overflow-y-auto
+`
+
+export const innerStyles = `
+  px-6 pt-0 pb-12
+
   lg:px-14
   lg:pt-12
-
 `
+
+export const Inner = ({ className, ...props }) => <div className={twMerge(innerStyles, className)} {...props} />
 
 const contentContainerStyles = `
   relative

--- a/packages/client-core/src/components/Settings/AccountSettings.tsx
+++ b/packages/client-core/src/components/Settings/AccountSettings.tsx
@@ -27,6 +27,7 @@ import React from 'react'
 
 import Divider from '@ir-engine/ui/src/components/viewer/Divider'
 import { NavigateFuncProps } from '../Glass/NavigationProvider'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import { MenuItem } from './MenuItem'
 import { Section } from './Section'
 
@@ -34,7 +35,7 @@ import { Section } from './Section'
 type ScreenProps = NavigateFuncProps & {}
 
 const AccountSettings: React.FC<ScreenProps> = ({ navigateTo }) => (
-  <div className="h-full space-y-4">
+  <Inner className="min-h-full space-y-4">
     <Section>
       <MenuItem label="Display Name" onClick={() => navigateTo('settings/display')} hasChevron />
       <Divider />
@@ -46,7 +47,7 @@ const AccountSettings: React.FC<ScreenProps> = ({ navigateTo }) => (
       <Divider />
       <MenuItem label="Delete My Account" onClick={() => navigateTo('settings/delete')} hasChevron />
     </Section>
-  </div>
+  </Inner>
 )
 
 export default AccountSettings

--- a/packages/client-core/src/components/Settings/AudioScreen.tsx
+++ b/packages/client-core/src/components/Settings/AudioScreen.tsx
@@ -30,6 +30,7 @@ import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { clientContextParams } from '../../util/ClientContextState'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import { Section } from './Section'
 import SliderItem from './SliderItem'
 
@@ -41,7 +42,7 @@ export default function AudioScreen() {
   const audioState = useMutableState(AudioState)
 
   return (
-    <div className="flex h-full w-full flex-col gap-4">
+    <Inner className="flex min-h-full w-full flex-col gap-4">
       {isChromeDesktop && (
         <div className="py-2 text-xs">
           {t('user:usermenu.setting.chromeAEC')}
@@ -83,6 +84,6 @@ export default function AudioScreen() {
           }}
         />
       </Section>
-    </div>
+    </Inner>
   )
 }

--- a/packages/client-core/src/components/Settings/AvatarScreen.tsx
+++ b/packages/client-core/src/components/Settings/AvatarScreen.tsx
@@ -43,6 +43,7 @@ import AvatarModifyMenu from '../../user/menus/avatar/AvatarModifyMenu'
 import { AuthService, AuthState } from '../../user/services/AuthService'
 import { AVATAR_PAGE_LIMIT } from '../../user/services/AvatarService'
 import { NavigateFuncProps } from '../Glass/NavigationProvider'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import { MenuItem } from './MenuItem'
 import { Section } from './Section'
 
@@ -96,7 +97,7 @@ const AvatarScreen: React.FC<AvatarScreenProps> = ({ navigateTo }) => {
   }
 
   return (
-    <div className="flex h-full flex-col gap-4">
+    <Inner className="flex min-h-full flex-col gap-4">
       {/* Avatar Display Section */}
       <Section>
         <div className="relative aspect-square max-h-[250px] w-full overflow-hidden ">
@@ -144,7 +145,7 @@ const AvatarScreen: React.FC<AvatarScreenProps> = ({ navigateTo }) => {
           ))}
         </div>
       </div>
-    </div>
+    </Inner>
   )
 }
 

--- a/packages/client-core/src/components/Settings/ButtonGroup.tsx
+++ b/packages/client-core/src/components/Settings/ButtonGroup.tsx
@@ -71,10 +71,7 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({ options, className = '' }) =>
     >
       {options.map((option, index) => (
         <motion.div key={index} variants={itemVariants} className="w-full">
-          <TextButton
-            onClick={option.onClick}
-            className="w-full rounded-xl py-3.5 font-medium text-white transition-all hover:scale-105"
-          >
+          <TextButton onClick={option.onClick} className="w-full text-white transition-all hover:scale-105">
             {option.label}
           </TextButton>
         </motion.div>

--- a/packages/client-core/src/components/Settings/ControlsScreen.tsx
+++ b/packages/client-core/src/components/Settings/ControlsScreen.tsx
@@ -30,13 +30,14 @@ import React from 'react'
 import ControllerMappingImage from '../../user/menus/images/controller-mapping.png'
 import KeyboardMappingImage from '../../user/menus/images/keyboard-mapping.png'
 import MouseMappingImage from '../../user/menus/images/mouse-mapping.png'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 
 export default function ControlsScreen() {
   const xrSupportedModes = useMutableState(XRState).supportedSessionModes
   const xrSupported = xrSupportedModes['immersive-ar'].value || xrSupportedModes['immersive-vr'].value
 
   return (
-    <div className="flex flex-col">
+    <Inner className="flex flex-col">
       {!isMobile && !xrSupported && (
         <>
           <img
@@ -62,6 +63,6 @@ export default function ControlsScreen() {
         </>
       )}
       {isMobile && <img src={ControllerMappingImage} alt="Mobile Controls" />}
-    </div>
+    </Inner>
   )
 }

--- a/packages/client-core/src/components/Settings/DeleteAccountScreen.tsx
+++ b/packages/client-core/src/components/Settings/DeleteAccountScreen.tsx
@@ -28,6 +28,7 @@ import { motion } from 'motion/react'
 import React from 'react'
 import { AuthService, AuthState } from '../../user/services/AuthService'
 import { NavigateFuncProps } from '../Glass/NavigationProvider'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import ButtonGroup from './ButtonGroup'
 
 type DeleteAccountScreenProps = NavigateFuncProps & {}
@@ -46,7 +47,7 @@ const DeleteAccountScreen: React.FC<DeleteAccountScreenProps> = ({ navigateTo, n
   }
 
   return (
-    <div className="flex h-full flex-col items-center justify-between space-y-8 pb-4 text-center">
+    <Inner className="flex min-h-full flex-col items-center justify-between space-y-8 text-center">
       {/* Confirmation Message */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
@@ -65,7 +66,7 @@ const DeleteAccountScreen: React.FC<DeleteAccountScreenProps> = ({ navigateTo, n
           { label: 'Delete', onClick: handleDelete }
         ]}
       />
-    </div>
+    </Inner>
   )
 }
 

--- a/packages/client-core/src/components/Settings/DisplayNameScreen.tsx
+++ b/packages/client-core/src/components/Settings/DisplayNameScreen.tsx
@@ -34,6 +34,7 @@ import { AuthState } from '../../user/services/AuthService'
 import { AvatarService } from '../../user/services/AvatarService'
 import { clientContextParams } from '../../util/ClientContextState'
 import { NavigateFuncProps } from '../Glass/NavigationProvider'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import { TextButton } from '../Glass/buttons/TextButton'
 import FieldItem from './FieldItem'
 import { Section } from './Section'
@@ -71,7 +72,7 @@ const DisplayNameScreen: React.FC<DisplayNameScreenProps> = () => {
   }, [saved.value])
 
   return (
-    <div className="flex h-full flex-col justify-between gap-4">
+    <Inner className="flex min-h-full flex-col justify-between gap-4">
       <Section>
         <FieldItem
           label="Display Name"
@@ -86,7 +87,7 @@ const DisplayNameScreen: React.FC<DisplayNameScreenProps> = () => {
       <TextButton disabled={!isUsernameValid} onClick={onSave} className="mx-auto justify-self-end">
         {saved.value ? 'Saved!' : 'Save'}
       </TextButton>
-    </div>
+    </Inner>
   )
 }
 

--- a/packages/client-core/src/components/Settings/GraphicsSettings.tsx
+++ b/packages/client-core/src/components/Settings/GraphicsSettings.tsx
@@ -32,6 +32,7 @@ import Divider from '@ir-engine/ui/src/components/viewer/Divider'
 import { Dropdown } from '@ir-engine/ui/viewer'
 import { clientContextParams } from '../../util/ClientContextState'
 import { NavigateFuncProps } from '../Glass/NavigationProvider'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import { Section } from './Section'
 import SliderItem from './SliderItem'
 import ToggleItem from './ToggleItem'
@@ -74,7 +75,7 @@ const GraphicsSettings: React.FC<ScreenProps> = ({ navigateTo }) => {
   }
 
   return (
-    <div className="space-y-4">
+    <Inner className="space-y-4">
       <Section>
         <SliderItem
           label="Quality Preset"
@@ -101,7 +102,7 @@ const GraphicsSettings: React.FC<ScreenProps> = ({ navigateTo }) => {
           ]}
         />
       </Section>
-    </div>
+    </Inner>
   )
 }
 

--- a/packages/client-core/src/components/Settings/MainMenu.tsx
+++ b/packages/client-core/src/components/Settings/MainMenu.tsx
@@ -31,6 +31,7 @@ import Divider from '@ir-engine/ui/src/components/viewer/Divider'
 import { MultiplayerState } from '../../common/services/MultiplayerState'
 import { AuthService, AuthState } from '../../user/services/AuthService'
 import { NavigateFuncProps } from '../Glass/NavigationProvider'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import ButtonGroup from './ButtonGroup'
 import { MenuItem } from './MenuItem'
 import { Section } from './Section'
@@ -48,7 +49,7 @@ const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
 
   if (confirmLogout.value) {
     return (
-      <div className="mx-auto flex h-full max-w-sm flex-col items-center justify-between pb-2">
+      <Inner className="mx-auto flex min-h-full max-w-sm flex-col items-center justify-between">
         <div className="text-dm-sans m-auto flex w-full flex-1 flex-col justify-center text-center text-2xl text-white">
           Are you sure you want to logout?
         </div>
@@ -58,12 +59,12 @@ const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
             { label: 'Nevermind', onClick: () => confirmLogout.set(false) }
           ]}
         />
-      </div>
+      </Inner>
     )
   }
 
   return (
-    <div className="space-y-4">
+    <Inner className="space-y-4">
       {/* Communication Section */}
       <Section>
         <MenuItem label="Share Space" onClick={() => navigateTo('settings/share')} hasChevron />
@@ -107,7 +108,7 @@ const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
         <MenuItem label="Audio" onClick={() => navigateTo('settings/audio')} hasChevron />
         {!isGuest && <MenuItem label="Log Out" onClick={() => confirmLogout.set(true)} />}
       </Section>
-    </div>
+    </Inner>
   )
 }
 

--- a/packages/client-core/src/components/Settings/PermissionsScreen.tsx
+++ b/packages/client-core/src/components/Settings/PermissionsScreen.tsx
@@ -27,6 +27,7 @@ import { MediaStreamState, useMutableState } from '@ir-engine/hyperflux'
 import Divider from '@ir-engine/ui/src/components/viewer/Divider'
 import React from 'react'
 import { NavigateFuncProps } from '../Glass/NavigationProvider'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import { Section } from './Section'
 import ToggleItem from './ToggleItem'
 
@@ -36,7 +37,7 @@ const PermissionsScreen: React.FC<PermissionsScreenProps> = () => {
   const { microphoneEnabled, webcamEnabled } = useMutableState(MediaStreamState)
 
   return (
-    <div className="flex h-full flex-col justify-between space-y-6">
+    <Inner className="flex min-h-full flex-col justify-between space-y-6">
       {/* Permissions Section */}
       <div className="space-y-4">
         <Section>
@@ -57,7 +58,7 @@ const PermissionsScreen: React.FC<PermissionsScreenProps> = () => {
           />
         </Section>
       </div>
-    </div>
+    </Inner>
   )
 }
 

--- a/packages/client-core/src/components/Settings/SSOScreen.tsx
+++ b/packages/client-core/src/components/Settings/SSOScreen.tsx
@@ -31,6 +31,7 @@ import React from 'react'
 import { FaApple, FaGithub, FaGoogle, FaMinusCircle } from 'react-icons/fa'
 import { useAuthSettings, useOAuthState } from '../../hooks/useAuthSetting'
 import { AuthService } from '../../user/services/AuthService'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import ButtonGroup from './ButtonGroup'
 import { MenuItem } from './MenuItem'
 import { Section } from './Section'
@@ -93,7 +94,7 @@ const SSOScreen: React.FC<SSOScreenProps> = () => {
   }
 
   return (
-    <div className="h-full space-y-4">
+    <Inner className="min-h-full space-y-4">
       {/* Connected Section */}
       {connectedProviders.length > 0 && (
         <>
@@ -138,7 +139,7 @@ const SSOScreen: React.FC<SSOScreenProps> = () => {
           </Section>
         </>
       )}
-    </div>
+    </Inner>
   )
 }
 

--- a/packages/client-core/src/components/Settings/ShareSpaceScreen.tsx
+++ b/packages/client-core/src/components/Settings/ShareSpaceScreen.tsx
@@ -27,49 +27,45 @@ import { useHookstate } from '@hookstate/core'
 import { AnimatePresence } from 'motion/react'
 import { QRCodeSVG } from 'qrcode.react'
 import React from 'react'
-import { createPortal } from 'react-dom'
 import { useShareMenu } from '../../hooks/useShareMenu'
 import { TextButton } from '../Glass/buttons/TextButton'
 import { NavigateFuncProps } from '../Glass/NavigationProvider'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import ShareDrawer from './ShareDrawer'
 
 type ShareSpaceScreenProps = NavigateFuncProps & {}
 
 const ShareSpaceScreen: React.FC<ShareSpaceScreenProps> = () => {
   const { shareLink, copyLinkToClipboard, questLink, inviteLink } = useShareMenu()
-  const contentDiv = document.getElementById('settings-menu-content')!
   const openDrawer = useHookstate(false)
 
-  const portal = createPortal(
-    <AnimatePresence>{openDrawer.value && <ShareDrawer onClose={() => openDrawer.set(false)} />}</AnimatePresence>,
-    contentDiv
-  )
-
   return (
-    <div className="xs:gap-6 flex h-full flex-col items-center justify-between p-4 md:flex-row md:items-start md:justify-center md:gap-5">
-      {/* QR Code */}
-      <div className={' flex flex-1 flex-col justify-center'}>
-        <div className="rounded-lg bg-white p-4">
-          <QRCodeSVG className="h-[130px] w-[130px]" value={shareLink} />
+    <>
+      <Inner className="xs:gap-6 flex flex-col items-center justify-between md:flex-row md:items-start md:justify-center md:gap-5">
+        {/* QR Code */}
+        <div className={' flex flex-1 flex-col justify-center'}>
+          <div className="rounded-lg bg-white p-4">
+            <QRCodeSVG className="h-[130px] w-[130px]" value={shareLink} />
+          </div>
         </div>
-      </div>
 
-      {/* Action Buttons */}
-      <div className="flex w-full flex-col gap-3">
-        <TextButton onClick={() => copyLinkToClipboard(inviteLink)} className="w-full" fade={`lighter`}>
-          Copy Direct Link
-        </TextButton>
+        {/* Action Buttons */}
+        <div className="flex w-full flex-col gap-3">
+          <TextButton onClick={() => copyLinkToClipboard(inviteLink)} className="w-full" fade={`lighter`}>
+            Copy Direct Link
+          </TextButton>
 
-        <TextButton onClick={() => copyLinkToClipboard(questLink)} className="w-full" fade={`lighter`}>
-          Share to Meta Quest
-        </TextButton>
+          <TextButton onClick={() => copyLinkToClipboard(questLink)} className="w-full" fade={`lighter`}>
+            Share to Meta Quest
+          </TextButton>
 
-        <TextButton onClick={() => openDrawer.set(!openDrawer.value)} className="w-full" fade={`lighter`}>
-          Share by email or phone
-        </TextButton>
-      </div>
-      {portal}
-    </div>
+          <TextButton onClick={() => openDrawer.set(!openDrawer.value)} className="w-full" fade={`lighter`}>
+            Share by email or phone
+          </TextButton>
+        </div>
+      </Inner>
+      <AnimatePresence>{openDrawer.value && <ShareDrawer onClose={() => openDrawer.set(false)} />}</AnimatePresence>,
+    </>
   )
 }
 

--- a/packages/client-core/src/components/Settings/SignUpScreen.tsx
+++ b/packages/client-core/src/components/Settings/SignUpScreen.tsx
@@ -36,6 +36,7 @@ import { useAuthSettings, useOAuthState } from '../../hooks/useAuthSetting'
 import { useMagicLink } from '../../hooks/useMagicLink'
 import { AuthService } from '../../user/services/AuthService'
 import { TextButton } from '../Glass/buttons/TextButton'
+import { Inner } from '../Glass/ToolbarAndSidebar'
 import FieldItem from './FieldItem'
 import { MenuItem } from './MenuItem'
 import { Section } from './Section'
@@ -76,7 +77,7 @@ export default function SignupScreen() {
   const disableMagicLink = !agreedToAll || pending.value || sent.value || !isValid.value
 
   return (
-    <div className="flex h-full flex-col gap-4">
+    <Inner className="flex min-h-full flex-col gap-4">
       <div className="font-dm-sans">By signing up, you agree to the following:</div>
       <Section className="font-figtree">
         <ToggleItem checked={tosAgreed} onClick={() => setTosAgreed(!tosAgreed)}>
@@ -127,6 +128,6 @@ export default function SignupScreen() {
           </React.Fragment>
         ))}
       </Section>
-    </div>
+    </Inner>
   )
 }


### PR DESCRIPTION
## Summary

- Provides a way for any screen/page to get the inner padding that is common among sidebar pages without the sidebar itself providing the padding. This allows for the pages to be more opinionated about their content while keeping the styling consistent. This removes the need for the portal to make the ShareDrawer full width
- Remove `h-full` classes that were causes a few bugs in the sidebar pages and replaces them with `min-h-full`
- There was a bug clipping the sidebar page content at the bottom. The original `mb-20` in the sidebar was needed to float the ChatMenu bottom content, but is its only needed on that page.
