### PR TITLE
fixed issue with the top down camera follow

### DIFF
--- a/packages/spatial/src/camera/components/FollowCameraComponent.ts
+++ b/packages/spatial/src/camera/components/FollowCameraComponent.ts
@@ -478,12 +478,13 @@ const computeCameraFollow = (cameraEntity: Entity, referenceEntity: Entity) => {
 
   if (follow.mode === FollowCameraMode.FirstPerson) {
     follow.effectiveMinDistance = follow.effectiveMaxDistance = 0
-  } else if (follow.mode === FollowCameraMode.ThirdPerson || follow.mode === FollowCameraMode.ShoulderCam) {
+  } else if (
+    follow.mode === FollowCameraMode.ThirdPerson ||
+    follow.mode === FollowCameraMode.ShoulderCam ||
+    follow.mode === FollowCameraMode.TopDown
+  ) {
     follow.effectiveMaxDistance = Math.min(obstacleDistance * (obstacleHit ? 0.8 : 1), follow.maxDistance)
     follow.effectiveMinDistance = Math.min(follow.minDistance, follow.effectiveMaxDistance)
-  } else if (follow.mode === FollowCameraMode.TopDown) {
-    follow.effectiveMaxDistance = Math.min(obstacleDistance * (obstacleHit ? 0.8 : 1), follow.maxDistance)
-    follow.effectiveMinDistance = Math.min(obstacleDistance * (obstacleHit ? 0.9 : 1), follow.minDistance)
   }
 
   let newZoomDistance = Math.max(
@@ -654,7 +655,7 @@ const computeCameraFollow = (cameraEntity: Entity, referenceEntity: Entity) => {
     if (triggerZoomShift) {
       follow.accumulatedZoomTriggerDebounceTime = -1
       const isExitingTopDown =
-        newZoomDistance < follow.effectiveMaxDistance &&
+        follow.targetDistance < follow.effectiveMaxDistance &&
         Math.abs(follow.lastZoomStartDistance - follow.effectiveMinDistance) < transitionDistanceThreshold
       if (follow.allowedModes.includes(FollowCameraMode.ThirdPerson) && isExitingTopDown) {
         switchToThirdPerson()


### PR DESCRIPTION
## Summary
https://tsu.atlassian.net/browse/IR-11047

fixed issue where in in template environments like Aurelia, when entering Top Down follow camera state, you can't exit it.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
