### PR TITLE
IR-11187: Fix translate, rotate, scale buttons, add onClick

### DIFF
--- a/packages/editor/src/panels/viewport/tools/TransformSnapTool.tsx
+++ b/packages/editor/src/panels/viewport/tools/TransformSnapTool.tsx
@@ -23,10 +23,11 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
+import { setTransformMode } from '@ir-engine/editor/src/functions/transformFunctions'
 import { EditorHelperState } from '@ir-engine/editor/src/services/EditorHelperState'
 import { ObjectGridSnapState } from '@ir-engine/editor/src/systems/ObjectGridSnapSystem'
 import { getMutableState, useHookstate } from '@ir-engine/hyperflux'
-import { SnapMode } from '@ir-engine/spatial/src/common/constants/TransformConstants'
+import { SnapMode, TransformMode } from '@ir-engine/spatial/src/common/constants/TransformConstants'
 import { Tooltip } from '@ir-engine/ui'
 import { ViewportButton } from '@ir-engine/ui/editor'
 import { MoveMd, Refresh1Md, Scale02Md } from '@ir-engine/ui/src/icons'
@@ -105,7 +106,12 @@ const TransformSnapTool = () => {
 
       <div className="flex items-center gap-x-2">
         <Tooltip content={t('editor:toolbar.transformSnapTool.lbl-translate')} position="bottom">
-          <ViewportButton lean={true} selected={false} icon={MoveMd} />
+          <ViewportButton
+            lean={true}
+            selected={editorHelperState.transformMode.value === TransformMode.translate}
+            icon={MoveMd}
+            onClick={() => setTransformMode(TransformMode.translate)}
+          />
         </Tooltip>
         <ToolbarDropdown
           tooltipContent={t('editor:toolbar.transformSnapTool.info-translate')}
@@ -121,7 +127,12 @@ const TransformSnapTool = () => {
 
       <div className="flex items-center gap-x-2">
         <Tooltip content={t('editor:toolbar.transformSnapTool.lbl-rotate')} position="bottom">
-          <ViewportButton lean={true} selected={false} icon={Refresh1Md} />
+          <ViewportButton
+            lean={true}
+            selected={editorHelperState.transformMode.value === TransformMode.rotate}
+            icon={Refresh1Md}
+            onClick={() => setTransformMode(TransformMode.rotate)}
+          />
         </Tooltip>
         <ToolbarDropdown
           tooltipContent={t('editor:toolbar.transformSnapTool.info-rotate')}
@@ -137,7 +148,12 @@ const TransformSnapTool = () => {
 
       <div className="flex items-center gap-x-2">
         <Tooltip content={t('editor:toolbar.transformSnapTool.lbl-scale')} position="bottom">
-          <ViewportButton lean={true} selected={false} icon={Scale02Md} />
+          <ViewportButton
+            lean={true}
+            selected={editorHelperState.transformMode.value === TransformMode.scale}
+            icon={Scale02Md}
+            onClick={() => setTransformMode(TransformMode.scale)}
+          />
         </Tooltip>
         <ToolbarDropdown
           tooltipContent={t('editor:toolbar.transformSnapTool.info-scale')}


### PR DESCRIPTION
## Summary
It was reported in [IR-11187](https://tsu.atlassian.net/browse/IR-11187) that the translate, rotate, and scale buttons were broken. This fix adds an onClick and updates the `selected` logic to get the buttons working successfully again when the user clicks to select them. Uses the `setTransformMode` method.

## References
[closes IR-11187](https://tsu.atlassian.net/browse/IR-11187)

## QA Steps
Try clicking and using the Translate, Rotate, and Scale buttons in various scenes. Previously, clicking these buttons wouldn't select that function. Now these buttons work as expected when clicked. Keyboard shortcuts W, E, and R continue to work also.

[IR-11187]: https://tsu.atlassian.net/browse/IR-11187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ