### PR TITLE
IR-11130: unsaved changes warning going to dashboard after publish

### DIFF
--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -134,6 +134,9 @@ export const saveSceneGLTF = async (
     projectName,
     sceneAssetID: result.data[0].id
   })
+
+  const sourceID = GLTFComponent.getSourceID(rootEntity)
+  getMutableState(AssetModifiedState)[sourceID].set(none)
 }
 
 export const logNewScene = (authoringApp: string, entryPoint: string = 'editor') => {
@@ -225,9 +228,6 @@ export const onSaveScene = async () => {
   try {
     await saveSceneGLTF(sceneAssetID!, projectName!, sceneName!, abortController.signal)
     NotificationService.dispatchNotify(`${i18n.t('editor:dialog.saveScene.info-save-success')}`, { variant: 'success' })
-    const sourceID = GLTFComponent.getSourceID(rootEntity)
-    getMutableState(AssetModifiedState)[sourceID].set(none)
-
     ModalState.closeModal()
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
## Summary

Fix unsaved changes warning going to dashboard after scene publish. 
![Screen Recording 2025-06-24 at 1 10 32 p m](https://github.com/user-attachments/assets/be75f257-ebfd-4052-aeeb-d0f49e2b2f02)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
