### PR TITLE
Revert "[IR-10686] fix images rendering upside down (#2160)"

### DIFF
--- a/packages/engine/src/assets/loaders/texture/TextureLoader.ts
+++ b/packages/engine/src/assets/loaders/texture/TextureLoader.ts
@@ -94,7 +94,7 @@ class TextureLoader extends Loader<Texture> {
       if (signal?.aborted) return
       const isBitmap = i instanceof ImageBitmap
       const image = this.maxResolution && isBitmap ? getScaledBitmap(i, this.maxResolution) : i
-      texture.flipY = isBitmap ? !this.flipped : this.flipped
+      if (!isBitmap) texture.flipY = this.flipped
       texture.source.data = image
       texture.needsUpdate = true
       onLoad(texture)


### PR DESCRIPTION
## Summary
images are rendering upside down again with the introduction of https://github.com/ir-engine/ir-engine/pull/2182 ... so now reverting commit 24df81c01a965bf7649ae8b54931daa266ffa79c in this PR to flip images back to their expected orientation alongside skyboxes


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
