### PR TITLE
[Release1.1] IR-1124: Fix group of 3D models disappearing after renaming it

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -481,7 +481,7 @@ const groupObjects = (entities: Entity[]) => {
   const firstEntity = entities[0]
   if (hasComponent(firstEntity, SceneComponent)) return
   const parentEntity = getComponent(firstEntity, EntityTreeComponent).parentEntity
-  const gltfEntity = getAncestorWithComponents(firstEntity, [GLTFComponent])
+  const gltfEntity = getAncestorWithComponents(firstEntity, [GLTFComponent], true, false)
   const newParent = UUIDComponent.create(gltfEntity, UUIDComponent.generateUUID(), Layers.Authoring)
   setComponent(newParent, NameComponent, 'New Group')
   setComponent(newParent, EntityTreeComponent, { parentEntity })

--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -83,7 +83,7 @@ export const duplicateNode = (entity?: Entity) => {
 export const groupNodes = (entity?: Entity) => {
   const entities = getSelectedEntities(entity)
   EditorControlFunctions.groupObjects(entities)
-  AuthoringState.snapshotEntities
+  AuthoringState.snapshotEntities(entities)
 }
 
 export const ungroupNodes = (entity?: Entity) => {


### PR DESCRIPTION
## Summary

Fix group of 3D models disappearing when group is renamed. this was caused by `getAncestorWithComponents` returning 
the first entity in the group as the gltfEntity which is later used to set the entitySourceID of the new parent that represents the group. 

**ticket:** https://tsu.atlassian.net/browse/IR-11240

![Screen Recording 2025-06-25 at 10 16 52 a m](https://github.com/user-attachments/assets/803740c5-30b0-4133-b8ca-b1f9eb684853)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Open an scene in the studio
- Add multiple models to the scene
- Select the previously added entities
- Group them
- rename the new group
**Expected result:** group is successfully renamed