### PR TITLE
Michael/ir 11262 clicking model issues

### DIFF
--- a/packages/editor/src/systems/ActiveHelperSystem.tsx
+++ b/packages/editor/src/systems/ActiveHelperSystem.tsx
@@ -30,6 +30,7 @@ import {
   ComponentJSONIDMap,
   getAuthoringCounterpart,
   getComponent,
+  getOptionalComponent,
   hasComponent,
   removeComponent,
   setComponent,
@@ -186,6 +187,7 @@ const ActiveHelperReactor: React.FC<ComponentHelperEntry> = (helper) => {
     if (studioIconEntity === UndefinedEntity || !entityExists(studioIconEntity)) return
     if (entity === UndefinedEntity || !entityExists(entity)) return
     if (!engineState.isEditing.value || !editorHelperState.gizmoEnabled.value) return
+    if (getOptionalComponent(entity, UUIDComponent)) return
 
     gizmoIconUpdate(entity, studioIconEntity, [...directionalEntitiesState.get(NO_PROXY_STEALTH)], iconSize.value)
 

--- a/packages/editor/src/systems/EditorControlSystem.ts
+++ b/packages/editor/src/systems/EditorControlSystem.ts
@@ -406,7 +406,6 @@ const execute = () => {
     const editorHelperState = getState(EditorHelperState)
     if (!getState(ClickPlacementState).placementEntity && editorHelperState.gizmoEnabled) {
       const selectedEntities = SelectionState.getSelectedEntities()
-      const clickParentEntity = getAncestorWithComponents(clickStartEntity, [GLTFComponent])
 
       if (selectedEntities.length === 1 && selectedEntities[0] === clickStartEntity) {
         onFocusCamera(viewerEntity)

--- a/packages/editor/src/systems/EditorControlSystem.ts
+++ b/packages/editor/src/systems/EditorControlSystem.ts
@@ -359,6 +359,13 @@ const execute = () => {
         closestIntersection = intersection
       }
 
+      const selectedEntities = SelectionState.getSelectedEntities()
+      if (selectedEntities.length > 0) {
+        clickStartEntity = selectedEntities[0]
+      } else {
+        clickStartEntity = UndefinedEntity
+      }
+
       closestIntersection.entity = getAuthoringCounterpart(closestIntersection.entity)
 
       // Get top most parent entity from the GLTF document


### PR DESCRIPTION
## Summary
https://tsu.atlassian.net/browse/IR-11262

Added the early return to the ActiveHelperSystem.tsx if entity is not a helper ( has a UUID Component) 

Updated EditorControlSystem.ts  to use the first index value of the selected entities as the clickStartEntity ( last clicked entity) so if the user bounces between selecting items in the hierarchy and the viewport, the experience will still work as expected


 
## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
