### PR TITLE
[IR-11241] Make sidebar visible on desktop so users can get to moderation

### DIFF
--- a/packages/client-core/src/components/Glass/ToolbarAndSidebar.tsx
+++ b/packages/client-core/src/components/Glass/ToolbarAndSidebar.tsx
@@ -117,13 +117,13 @@ const backButtonStyles = `
 
 const Tab = ({ onClick, heading, active }: TabProps) => {
   return (
-    <button className={`group lg:hidden`} onClick={onClick}>
-      <h2 className={`grid gap-y-1`}>
+    <button className={`group`} onClick={onClick}>
+      <h2 className={`lg:text-shadow-md grid gap-y-1`}>
         {heading}
         <div
           className={twMerge(
-            `h-[0.14em] w-full rounded-full group-hover:bg-white/80`,
-            active ? `bg-white/80` : `bg-transparent`
+            `h-[0.14em] w-full rounded-full group-hover:bg-white/80 lg:h-[0.08em]`,
+            active ? `bg-white/80 lg:bg-white/90 lg:shadow-md` : `bg-transparent`
           )}
         />
       </h2>
@@ -134,7 +134,7 @@ const Tab = ({ onClick, heading, active }: TabProps) => {
 const headingsStyles = `
   flex items-center justify-center
 
-  gap-x-12
+  gap-x-8
   py-8
   text-2xl
   
@@ -142,7 +142,7 @@ const headingsStyles = `
   lg:py-4
   lg:pl-2
   lg:text-5xl
-  lg:gap-x-4
+  lg:gap-x-8
 `
 
 const headerBackButtonStyles = `
@@ -157,6 +157,8 @@ const Header = ({ tabs = [], title, handleSidebarClose, handleSidebarBack, showB
     </IconButton>
   )
 
+  const hasTabs = !!tabs.length
+
   return (
     <div className={headerContainerStyles}>
       <div className={headerInnerStyles}>
@@ -168,10 +170,13 @@ const Header = ({ tabs = [], title, handleSidebarClose, handleSidebarBack, showB
         </div>
         <div style={{ textShadow: `0 0.025em 0.08em hsla(0, 0%, 0%, 0.2)` }} className={headingsStyles}>
           {showBack ? <div className={headerBackButtonStyles}>{backButton}</div> : <></>}
-          <h2 className={twMerge(`lg:block`, tabs.length ? `hidden` : ``)}>{title}</h2>
-          {tabs.map((tabProps) => {
-            return <Tab {...tabProps} />
-          })}
+          {hasTabs ? (
+            tabs.map((tabProps) => {
+              return <Tab {...tabProps} />
+            })
+          ) : (
+            <h2 className={twMerge(`lg:block`, tabs.length ? `hidden` : ``)}>{title}</h2>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

To make it easier for users to get the the moderation page this changes how the sidebar heading works and shows the previously mobile-only heading tabs on desktop

<img width="881" alt="image" src="https://github.com/user-attachments/assets/4b5f3610-2410-4eb1-b4ba-e35a05b0547d" />

<img width="881" alt="image" src="https://github.com/user-attachments/assets/02f2e3b4-5fa4-4bdd-b388-87d906ae764f" />

## QA Steps

- Open Viewer
- Go to chat or video page
- The heading should be a tab system on mobile and on desktop


