### PR TITLE
add workflow to sync dev with release

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,26 @@
+name: On Release, Sync to Dev
+on:
+  push:
+    branches: [release*]
+permissions: 
+  contents: write
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Git User
+        run: |
+          git config user.name ${{ github.event.pusher.name }}
+          git config user.email "${{ github.event.pusher.email }}"
+
+      - name: Update Test Branch
+        run: |
+          git fetch origin
+          git switch dev
+          git cherry-pick ${{ github.event.after }}
+          git push origin dev

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,26 +1,38 @@
 name: On Release, Sync to Dev
 on:
-  push:
+  pull_request:
     branches: [release*]
+    types: [closed]
 permissions: 
   contents: write
 jobs:
   sync:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.IR_REPO_AUTH_APP_ID }}
+          private-key: ${{ secrets.IR_REPO_AUTH_PRIVATE_KEY }}
+          owner: ir-engine
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Git User
         run: |
-          git config user.name ${{ github.event.pusher.name }}
-          git config user.email "${{ github.event.pusher.email }}"
+          git config user.name ${{ github.event.pull_request.merged_by.name }}
+          git config user.email "${{ github.event.pull_request.merged_by.email }}"
 
       - name: Update Test Branch
+        env:
+          token: ${{ steps.app-token.outputs.token }}
         run: |
           git fetch origin
           git switch dev
-          git cherry-pick ${{ github.event.after }}
+          git cherry-pick ${{ github.event.pull_request.merge_commit_sha }}
           git push origin dev


### PR DESCRIPTION
## Summary
So the idea is that every commit to Release is squashed and so this should cherry-pick the commit to dev immediately on update. There's so many ways to accomplish this. Branch merge, rebase, etc... 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
