### PR TITLE
[IR-11269] Dark glassmorphism

### DIFF
--- a/packages/client-core/src/components/Glass/buttons/Button.styles.ts
+++ b/packages/client-core/src/components/Glass/buttons/Button.styles.ts
@@ -41,7 +41,7 @@ export const fadeVariant = {
     border-2
     bg-black/10
     border-white/[0.05]
-    hover:bg-transparent
+    hover:bg-black/5
     active:bg-white/10
   `,
   clear: `

--- a/packages/client-core/src/components/ReportUser/index.tsx
+++ b/packages/client-core/src/components/ReportUser/index.tsx
@@ -55,8 +55,8 @@ const actionButtonStyles = `
   items-center self-stretch
   text-white
   rounded-full
-  bg-[rgba(255,255,255,0.2)]
-  shadow-[inset_0px_1px_1px_rgba(255,255,255,0.25),inset_0px_-1px_1px_rgba(255,255,255,0.1),0px_8px_6px_rgba(0,0,0,0.05)]
+  bg-black/10
+  shadow-md
 `
 
 const baseContainerStyles = `
@@ -220,7 +220,7 @@ const ReportUserMenu = (props: ReportMenuProps) => {
           onChange={(e) => handleChange(e.target.value, 'details')}
           placeholder={fieldOptions.details.placeholder}
           className={twMerge(
-            'transparent-1/2 min-h-[120px] w-full border-0 bg-black/20 backdrop-blur-xl',
+            'transparent-1/2 min-h-[120px] w-full border-0 bg-black/20 backdrop-blur-xl placeholder:text-white/70',
             errors.details.value && 'border-ui-error'
           )}
         />

--- a/packages/client-core/src/components/Settings/ButtonGroup.tsx
+++ b/packages/client-core/src/components/Settings/ButtonGroup.tsx
@@ -71,7 +71,11 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({ options, className = '' }) =>
     >
       {options.map((option, index) => (
         <motion.div key={index} variants={itemVariants} className="w-full">
-          <TextButton onClick={option.onClick} className="w-full text-white transition-all hover:scale-105">
+          <TextButton
+            fade={`dark`}
+            onClick={option.onClick}
+            className="w-full text-white transition-all hover:scale-105"
+          >
             {option.label}
           </TextButton>
         </motion.div>

--- a/packages/client-core/src/components/Settings/FieldItem.tsx
+++ b/packages/client-core/src/components/Settings/FieldItem.tsx
@@ -49,7 +49,7 @@ const FieldItem: React.FC<FieldItemProps> = ({
           ref.current?.setSelectionRange(value.length, value.length)
         }
       }}
-      className={`flex w-full items-center justify-between px-4 py-3.5 text-white/90 transition-colors hover:bg-white/5 ${className}`}
+      className={`flex w-full items-center justify-between bg-black/10 px-4 py-3.5 text-white/90 transition-colors hover:bg-black/5 ${className}`}
     >
       <span className="text-sm font-medium">{label}</span>
       <InputField

--- a/packages/client-core/src/components/Settings/GraphicsSettings.tsx
+++ b/packages/client-core/src/components/Settings/GraphicsSettings.tsx
@@ -91,6 +91,7 @@ const GraphicsSettings: React.FC<ScreenProps> = ({ navigateTo }) => {
         <ToggleItem label="Shadows" checked={useShadows.value} onClick={onShadowToggle} />
         <Divider />
         <Dropdown
+          backgroundColor={`black`}
           onChange={onShadowMapResolutionChange}
           value={shadowMapResolution.value}
           options={[

--- a/packages/client-core/src/components/Settings/MainMenu.tsx
+++ b/packages/client-core/src/components/Settings/MainMenu.tsx
@@ -97,8 +97,14 @@ const MainMenu: React.FC<ScreenProps> = ({ navigateTo }) => {
         <MenuItem label="Controls" onClick={() => navigateTo('settings/controls')} hasChevron />
         <Divider />
         <MenuItem label="Graphics" onClick={() => navigateTo('settings/graphics')} hasChevron />
+        <Divider />
         <MenuItem label="Audio" onClick={() => navigateTo('settings/audio')} hasChevron />
-        {!isGuest && <MenuItem label="Log Out" onClick={() => confirmLogout.set(true)} />}
+        {!isGuest && (
+          <>
+            <Divider />
+            <MenuItem label="Log Out" onClick={() => confirmLogout.set(true)} />
+          </>
+        )}
       </Section>
     </Inner>
   )

--- a/packages/client-core/src/components/Settings/MenuItem.tsx
+++ b/packages/client-core/src/components/Settings/MenuItem.tsx
@@ -44,7 +44,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   className
 }) => (
   <div
-    className={`flex cursor-pointer items-center justify-between px-4 py-3.5 text-white/90 transition-colors hover:bg-white/5 ${className}`}
+    className={`flex cursor-pointer items-center justify-between bg-black/10 px-4 py-3.5 text-white/90 transition-colors hover:bg-black/5 ${className}`}
     onClick={onClick}
   >
     <span className="flex items-center gap-3">

--- a/packages/client-core/src/components/Settings/ShareSpaceScreen.tsx
+++ b/packages/client-core/src/components/Settings/ShareSpaceScreen.tsx
@@ -51,15 +51,15 @@ const ShareSpaceScreen: React.FC<ShareSpaceScreenProps> = () => {
 
         {/* Action Buttons */}
         <div className="flex w-full flex-col gap-3">
-          <TextButton onClick={() => copyLinkToClipboard(inviteLink)} className="w-full" fade={`lighter`}>
+          <TextButton onClick={() => copyLinkToClipboard(inviteLink)} className="w-full" fade={`dark`}>
             Copy Direct Link
           </TextButton>
 
-          <TextButton onClick={() => copyLinkToClipboard(questLink)} className="w-full" fade={`lighter`}>
+          <TextButton onClick={() => copyLinkToClipboard(questLink)} className="w-full" fade={`dark`}>
             Share to Meta Quest
           </TextButton>
 
-          <TextButton onClick={() => openDrawer.set(!openDrawer.value)} className="w-full" fade={`lighter`}>
+          <TextButton onClick={() => openDrawer.set(!openDrawer.value)} className="w-full" fade={`dark`}>
             Share by email or phone
           </TextButton>
         </div>

--- a/packages/client-core/src/components/Settings/SliderItem.tsx
+++ b/packages/client-core/src/components/Settings/SliderItem.tsx
@@ -38,7 +38,7 @@ interface SliderItemProps {
 
 const SliderItem: React.FC<SliderItemProps> = ({ label, value = 0, onChange, min = 0, max = 100, step = 1 }) => {
   return (
-    <div className="flex items-center justify-between px-4 py-3.5 text-white/90">
+    <div className="flex items-center justify-between bg-black/10 px-4 py-3.5 text-white/90">
       <span className="flex-1 font-medium">{label}</span>
       <div className="flex flex-1 items-center space-x-3">
         <Slider value={value} min={min} max={max} step={step} onChange={onChange} />

--- a/packages/client-core/src/components/Settings/ToggleItem.tsx
+++ b/packages/client-core/src/components/Settings/ToggleItem.tsx
@@ -34,7 +34,7 @@ interface ToggleItemProps extends React.PropsWithChildren {
 
 const ToggleItem: React.FC<ToggleItemProps> = ({ label, checked = false, onClick, children }) => {
   return (
-    <div className="flex items-center justify-between px-4 py-3.5 text-white/90">
+    <div className="flex items-center justify-between bg-black/10 px-4 py-3.5 text-white/90">
       {children || <span className="font-medium">{label}</span>}
       <Toggle checked={checked} onChange={onClick} />
     </div>


### PR DESCRIPTION
## Summary

Swaps the Settings screen to use a black fade on items, fields, and buttons instead of a white or transparent fade.

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/747d7c4e-e0a3-40d4-b6da-10c308ad9b33" />

## QA Steps

- Open Viewer
- Go to the settings page
- Go to any sub page
- The MenuItems, toggle, sliders, and page buttons should all have a background color that is a black fade, making the text more legible