### PR TITLE
IR-11052: Fix lookdev prefab export and applying lookdev prefab to scene

### DIFF
--- a/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
@@ -30,7 +30,6 @@ import config from '@ir-engine/common/src/config'
 import { staticResourcePath } from '@ir-engine/common/src/schema.type.module'
 import { isValidFileName } from '@ir-engine/common/src/utils/validateFileName'
 import {
-  Component,
   createEntity,
   Entity,
   EntityID,
@@ -47,12 +46,10 @@ import {
 import PrefabConfirmationPanelDialog from '@ir-engine/editor/src/components/dialogs/PrefabConfirmationPanelDialog'
 import { pathJoin } from '@ir-engine/engine/src/assets/functions/miscUtils'
 import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
-import { SkyboxComponent } from '@ir-engine/engine/src/scene/components/SkyboxComponent'
 import { getMutableState, getState, NO_PROXY, none, startReactor, useHookstate } from '@ir-engine/hyperflux'
-import { HemisphereLightComponent, TransformComponent } from '@ir-engine/spatial'
+import { TransformComponent } from '@ir-engine/spatial'
 import { NameComponent } from '@ir-engine/spatial/src/common/NameComponent'
 import { ObjectComponent } from '@ir-engine/spatial/src/renderer/components/ObjectComponent'
-import { PostProcessingComponent } from '@ir-engine/spatial/src/renderer/components/PostProcessingComponent'
 import { Button, Input } from '@ir-engine/ui'
 import Modal from '@ir-engine/ui/src/primitives/tailwind/Modal'
 import { uniqueId } from 'lodash'
@@ -60,7 +57,7 @@ import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiOutlineXMark } from 'react-icons/hi2'
 import { Quaternion, Scene, Vector3 } from 'three'
-import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
+import { EditorControlFunctions, lookDevComponent } from '../../functions/EditorControlFunctions'
 import { exportRelativeGLTF } from '../../functions/exportGLTF'
 import { AssetsRefreshState } from '../../panels/assets/hooks'
 import { EditorState } from '../../services/EditorServices'
@@ -95,8 +92,6 @@ export default function CreatePrefabPanel({ entity, isExportLookDev }: { entity?
   }
 
   const exportLookDevPrefab = async (srcProject: string, fileName: string) => {
-    const lookDevComponent: Component[] = [SkyboxComponent, HemisphereLightComponent, PostProcessingComponent]
-
     const prefabEntity = createEntity()
     const sceneObject = new Scene()
 

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -141,7 +141,7 @@ const modifyProperty = <C extends Component<any, any>>(
   return affectedNodes
 }
 
-const lookDevComponent: Component[] = [
+export const lookDevComponent: Component[] = [
   SkyboxComponent,
   HemisphereLightComponent,
   DirectionalLightComponent,
@@ -160,10 +160,16 @@ const overwriteLookdevObject = (
     const sceneEntitiesWithComponent = getChildrenWithComponents(parentEntity, [lookDevComp])
     if (sceneEntitiesWithComponent.length) {
       deserializeComponent(sceneEntitiesWithComponent[0], lookDevComp, props)
-      EditorState.markModifiedScene(parentEntity)
     } else {
-      createObjectFromSceneElement(componentJson, parentEntity, beforeEntity)
+      const vec3 = new Vector3()
+      createObjectFromSceneElement(
+        [comp, { name: TransformComponent.jsonID, props: { position: vec3 } }],
+        parentEntity,
+        beforeEntity,
+        name?.split('_').slice(1).join('-')
+      )
     }
+    EditorState.markModifiedScene(parentEntity)
   }
 }
 

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -33,6 +33,7 @@ import {
   getChildrenWithComponents,
   iterateEntityNode,
   removeEntity,
+  removeEntityNodeRecursively,
   UUIDComponent
 } from '@ir-engine/ecs'
 import {
@@ -224,13 +225,12 @@ export async function addMediaNode(
       /**
        * Load the lookdev object and override or attach it to the current scene
        */
-      AssetState.loadAsync(url, false, UUIDComponent.generateUUID(), UndefinedEntity, Layers.Authoring as LayerID).then(
+      AssetState.loadAsync(url, false, UUIDComponent.generate(), UndefinedEntity, Layers.Authoring as LayerID).then(
         (entity) => {
           const firstChild = getComponent(entity, EntityTreeComponent).children[0]
           const json = serializeEntity(firstChild)
-
           EditorControlFunctions.overwriteLookdevObject([...json, ...extraComponentJson], parent!, before)
-          removeEntity(entity)
+          removeEntityNodeRecursively(entity)
           const rootEntity = getState(EditorState).rootEntity
           const newSource = GLTFComponent.getSourceID(rootEntity)
           AuthoringState.snapshot(newSource)


### PR DESCRIPTION
 - Added directional light component to lookdev prefab export 
 - Fix lookdev prefab not overriding components in scene when dragged into the viewport

**ticket:** https://tsu.atlassian.net/browse/IR-11052
![Screen Recording 2025-06-26 at 3 47 16 p m](https://github.com/user-attachments/assets/43dc1b78-eb8e-406d-957c-28ec832509f0)


## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

Open studio project
Create new blank scene
Make changes to Skybox, Directional light, Hemisphere light, and Postprocessing effects
Select Files menu (IR logo) dropdown > Export Lookdev Prefab
Name custom prefab and confirm
Refresh or add new blank scene
Find the customized prefab in Files tab
Drag prefab into the viewport
Verify the lookdev changes have been applied
Published location and load into the instance
Verify the lookdev changes have been applied