### PR TITLE
[Release1.1] IR-11248: fixed hierarchy panel breaking when current scene is renamed

### DIFF
--- a/packages/ecs/src/EntityTree.tsx
+++ b/packages/ecs/src/EntityTree.tsx
@@ -489,13 +489,15 @@ export function useAncestorTree(entity: Entity) {
       const tree = useOptionalComponent(props.entity, EntityTreeComponent)
       useEffect(() => {
         if (!tree) return
+        // capture value to use in the cleanup function to prevent errors
+        const parentEntityValue = tree.parentEntity.value
         ancestors.set((prev) => {
-          if (prev.indexOf(tree.parentEntity.value) < 0) prev.push(tree.parentEntity.value)
+          if (prev.indexOf(parentEntityValue) < 0) prev.push(parentEntityValue)
           return prev
         })
         return () => {
           if (unmounted) return
-          ancestors.set((prev) => prev.filter((e) => e !== tree.parentEntity.value))
+          ancestors.set((prev) => prev.filter((e) => e !== parentEntityValue))
         }
       }, [tree?.parentEntity?.value])
       if (!tree?.parentEntity?.value) return null

--- a/packages/editor/src/panels/hierarchy/hooks.tsx
+++ b/packages/editor/src/panels/hierarchy/hooks.tsx
@@ -31,12 +31,12 @@ import {
   getAncestorWithComponents,
   getChildrenWithComponents,
   getComponent,
+  getOptionalComponent,
   hasComponent,
   isAncestor,
   Layers,
   traverseEntityNode,
   UndefinedEntity,
-  useComponent,
   useQuery,
   UUIDComponent
 } from '@ir-engine/ecs'
@@ -148,23 +148,23 @@ const HierarchySnapshotReactor = (props: { children?: ReactNode; rootEntity: Ent
 
   const ChildEntityReactor = (props: { entity: Entity }) => {
     const entity = props.entity
-    const entityTreeComponent = useComponent(entity, EntityTreeComponent)
-    const [parentEntity, setParentEntity] = useState(entityTreeComponent.value.parentEntity)
-    const [childIndex, setChildIndex] = useState(entityTreeComponent.value.childIndex)
+    const entityTreeComponent = getOptionalComponent(entity, EntityTreeComponent)
+    const parentEntity = useHookstate(entityTreeComponent?.parentEntity ?? UndefinedEntity)
+    const childIndex = useHookstate(entityTreeComponent?.childIndex ?? undefined)
 
     useEffect(() => {
-      if (entityTreeComponent.value.parentEntity !== parentEntity) {
-        setParentEntity(entityTreeComponent.value.parentEntity)
+      if (entityTreeComponent && entityTreeComponent.parentEntity !== parentEntity.value) {
+        parentEntity.set(entityTreeComponent.parentEntity)
         reparentRefresh.set((reparentRefresh.value + 1) % 1000)
       }
-    }, [entityTreeComponent.parentEntity.value])
+    }, [entityTreeComponent?.parentEntity])
 
     useEffect(() => {
-      if (entityTreeComponent.value.childIndex !== childIndex) {
-        setChildIndex(entityTreeComponent.value.childIndex)
+      if (entityTreeComponent && entityTreeComponent.childIndex !== childIndex.value) {
+        childIndex.set(entityTreeComponent.childIndex)
         childIndexRefresh.set((childIndexRefresh.value + 1) % 1000)
       }
-    }, [entityTreeComponent.value.childIndex])
+    }, [entityTreeComponent?.childIndex])
 
     return null
   }
@@ -178,7 +178,8 @@ const HierarchySnapshotReactor = (props: { children?: ReactNode; rootEntity: Ent
       entities,
       childEntities,
       reparentRefresh,
-      childIndexRefresh
+      childIndexRefresh,
+      rootEntity
     ]
   )
 
@@ -198,7 +199,7 @@ const HierarchySnapshotReactor = (props: { children?: ReactNode; rootEntity: Ent
 
   useEffect(() => {
     hierarchyTreeState.expandedNodes.set({ [sourceID]: { [rootEntity]: true } })
-  }, [sourceID])
+  }, [sourceID, rootEntity])
 
   useEffect(() => {
     if (!selectionState.selectedEntities.value.length) {

--- a/packages/editor/src/panels/scenes/index.tsx
+++ b/packages/editor/src/panels/scenes/index.tsx
@@ -108,7 +108,9 @@ function ScenesPanel() {
                   }}
                   disableDeleteScene={editorState.sceneAssetID.value === scene.id}
                   onRenameScene={(newName) => {
-                    editorState.scenePath.set(newName)
+                    if (editorState.sceneAssetID.value === scene.id) {
+                      editorState.scenePath.set(newName)
+                    }
                   }}
                   handleOpenScene={() => onClickScene(scene)}
                   refetchProjectsData={scenesQuery.refetch}


### PR DESCRIPTION
## Summary

- Fixed hierarchy panel breaking when renaming current scene
- Prevent scene change when renaming a non-active scene

**ticket:** https://tsu.atlassian.net/browse/IR-11248
![Screen Recording 2025-06-27 at 2 32 02 p m](https://github.com/user-attachments/assets/d4db62c5-4111-4d25-975d-f40beba13284)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Open Studio
- Open any scene
- Go to Scene panel → rename a scene
- Observe the Hierarchy panel after renaming
