### PR TITLE
IndexedDB cache invalidation logic for GLTF resources Release 1.1

### DIFF
--- a/packages/engine/src/assets/loaders/base/ResourceCache.ts
+++ b/packages/engine/src/assets/loaders/base/ResourceCache.ts
@@ -186,7 +186,6 @@ class ResourceCacheDatabase extends Dexie {
   async invalidateGLTFDependencies(url: string): Promise<void> {
     const normalizedUrl = normalizeURLForCache(url)
     const metadata = await this.getGLTFMetadata(normalizedUrl)
-    console.log('Invalidating gltf dependencies', normalizedUrl, metadata)
     if (!metadata) return
 
     let deletePromises = [] as Promise<void>[]

--- a/packages/engine/src/assets/loaders/base/ResourceCache.ts
+++ b/packages/engine/src/assets/loaders/base/ResourceCache.ts
@@ -26,6 +26,32 @@ Infinite Reality Engine. All Rights Reserved.
 import Dexie from 'dexie'
 import { CompressedPixelFormat, PixelFormat, TextureDataType } from 'three'
 
+/**
+ * Normalize URL by removing hash parameters for consistent cache keys
+ * @param url The URL with potential hash parameters
+ * @returns The normalized URL without hash parameters
+ */
+export function normalizeURLForCache(url: string): string {
+  try {
+    const urlObj = new URL(url)
+    urlObj.searchParams.delete('hash')
+    return urlObj.toString()
+  } catch (error) {
+    console.warn('Error normalizing URL for cache:', error)
+    return url
+  }
+}
+
+/**
+ * Extract hash from URL search parameters
+ * @param url The URL with hash parameter
+ * @returns The hash string or null if not found
+ */
+export function extractHashFromURL(url: string): string | null {
+  const urlObj = new URL(url)
+  return urlObj.searchParams.get('hash') || null
+}
+
 export interface TextureData {
   data: Array<any> | ArrayBuffer
   width: number
@@ -36,17 +62,19 @@ export interface TextureData {
 
 /**
  * ResourceCache using IndexedDB via Dexie
- * Provides storage for assets and resources
+ * Provides storage for assets and resources with hash-based invalidation
  */
 class ResourceCacheDatabase extends Dexie {
   resources: Dexie.Table<{ key: string; value: ArrayBuffer; timestamp: number }, string>
   textures: Dexie.Table<{ key: string; value: TextureData; timestamp: number }, string>
+  gltfMetadata: Dexie.Table<{ url: string; hash: string; dependencies: string[]; timestamp: number }, string>
 
   constructor() {
     super('ir-engine-cache', { cache: 'disabled' })
-    this.version(1).stores({
+    this.version(2).stores({
       resources: 'key',
-      textures: 'key'
+      textures: 'key',
+      gltfMetadata: 'url'
     })
   }
 
@@ -119,6 +147,72 @@ class ResourceCacheDatabase extends Dexie {
 
   async clearTextures(): Promise<void> {
     await this.textures.clear()
+  }
+
+  /**
+   * Store GLTF metadata for cache invalidation
+   * @param url The GLTF URL (will be normalized to remove hash parameters)
+   * @param hash The hash of the GLTF file (extracted from URL)
+   * @param dependencies Array of dependency URLs referenced by this GLTF
+   */
+  async putGLTFMetadata(url: string, hash: string, dependencies: string[]): Promise<void> {
+    const normalizedUrl = normalizeURLForCache(url)
+    // Also normalize dependency URLs
+    const normalizedDependencies = dependencies.map((dep) => normalizeURLForCache(dep))
+
+    await this.gltfMetadata.put({
+      url: normalizedUrl,
+      hash,
+      dependencies: normalizedDependencies,
+      timestamp: Date.now()
+    })
+  }
+
+  /**
+   * Get GLTF metadata for cache validation
+   * @param url The GLTF URL (will be normalized to remove hash parameters)
+   * @returns The metadata or null if not found
+   */
+  async getGLTFMetadata(url: string): Promise<{ hash: string; dependencies: string[] } | null> {
+    const normalizedUrl = normalizeURLForCache(url)
+    const metadata = await this.gltfMetadata.get(normalizedUrl)
+    return metadata ? { hash: metadata.hash, dependencies: metadata.dependencies } : null
+  }
+
+  /**
+   * Invalidate all resources referenced by a GLTF file
+   * @param url The GLTF URL (will be normalized to remove hash parameters)
+   */
+  async invalidateGLTFDependencies(url: string): Promise<void> {
+    const normalizedUrl = normalizeURLForCache(url)
+    const metadata = await this.getGLTFMetadata(normalizedUrl)
+    console.log('Invalidating gltf dependencies', normalizedUrl, metadata)
+    if (!metadata) return
+
+    let deletePromises = [] as Promise<void>[]
+    for (let i = 0; i < metadata.dependencies.length; i++) {
+      const depUrl = metadata.dependencies[i]
+      deletePromises.push(this.deleteResource(depUrl))
+      deletePromises.push(this.deleteTexture(depUrl))
+    }
+
+    deletePromises.push(this.deleteResource(normalizedUrl))
+
+    await Promise.all(deletePromises)
+    // Remove the GLTF metadata itself
+    await this.gltfMetadata.delete(normalizedUrl)
+  }
+
+  /**
+   * Check if a GLTF file's cache is still valid
+   * @param url The GLTF URL (will be normalized to remove hash parameters)
+   * @param currentHash The current hash of the GLTF file
+   * @returns True if cache is valid, false if invalidated
+   */
+  async isGLTFCacheValid(url: string, currentHash: string): Promise<boolean> {
+    const normalizedUrl = normalizeURLForCache(url)
+    const metadata = await this.gltfMetadata.get(normalizedUrl)
+    return metadata ? metadata.hash === currentHash : false
   }
 }
 

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -85,7 +85,7 @@ import { AnimationComponent } from '../avatar/components/AnimationComponent'
 import { ErrorComponent } from '../scene/components/ErrorComponent'
 import { SceneDynamicLoadComponent } from '../scene/components/SceneDynamicLoadComponent'
 import { addError, removeError } from '../scene/functions/ErrorFunctions'
-import { GLTFLoaderFunctions, GLTFParserOptions } from './GLTFLoaderFunctions'
+import { GLTFLoaderFunctions, GLTFParserOptions, validateGLTFCache } from './GLTFLoaderFunctions'
 import { AssetState } from './GLTFState'
 import { migrateEEMaterial } from './migrateEEMaterial'
 import { OVERRIDE_EXTENSION_NAME } from './overrideExporterExtension'
@@ -533,8 +533,16 @@ const useGLTFDocument = (entity: Entity) => {
       url,
       ResourceType.ArrayBuffer,
       entity,
-      (response) => {
+      async (response) => {
         if (signal.aborted) return
+
+        // dropped this validation into the gltf component for now,
+        // just needs to happen before anything gets loaded
+        const cacheValid = await validateGLTFCache(url)
+        if (!cacheValid) {
+          console.log(`Cache invalidated for GLTF: ${url}`)
+        }
+
         const [gltf, body] = parseGLTFFile(response, onError)
 
         if (gltf) {

--- a/packages/engine/src/gltf/GLTFComponent.tsx
+++ b/packages/engine/src/gltf/GLTFComponent.tsx
@@ -85,7 +85,7 @@ import { AnimationComponent } from '../avatar/components/AnimationComponent'
 import { ErrorComponent } from '../scene/components/ErrorComponent'
 import { SceneDynamicLoadComponent } from '../scene/components/SceneDynamicLoadComponent'
 import { addError, removeError } from '../scene/functions/ErrorFunctions'
-import { GLTFLoaderFunctions, GLTFParserOptions, validateGLTFCache } from './GLTFLoaderFunctions'
+import { GLTFLoaderFunctions, GLTFParserOptions } from './GLTFLoaderFunctions'
 import { AssetState } from './GLTFState'
 import { migrateEEMaterial } from './migrateEEMaterial'
 import { OVERRIDE_EXTENSION_NAME } from './overrideExporterExtension'
@@ -533,15 +533,8 @@ const useGLTFDocument = (entity: Entity) => {
       url,
       ResourceType.ArrayBuffer,
       entity,
-      async (response) => {
+      (response) => {
         if (signal.aborted) return
-
-        // dropped this validation into the gltf component for now,
-        // just needs to happen before anything gets loaded
-        const cacheValid = await validateGLTFCache(url)
-        if (!cacheValid) {
-          console.log(`Cache invalidated for GLTF: ${url}`)
-        }
 
         const [gltf, body] = parseGLTFFile(response, onError)
 

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -1653,6 +1653,8 @@ const loadScene = async (options: GLTFParserOptions, sceneIndex: number) => {
     DependencyCache.set(`${rootEntity}${options.url}`, new Map<string, Promise<any>>())
   }
 
+  // Validate GLTF cache and then store metadata for future validation
+  await validateGLTFCache(options.url)
   await storeGLTFMetadata(options.url, json)
 
   migrateSceneDeltas(rootEntity, options.document)

--- a/packages/engine/src/gltf/GLTFLoaderFunctions.ts
+++ b/packages/engine/src/gltf/GLTFLoaderFunctions.ts
@@ -107,7 +107,7 @@ import {
 import { loadResource, unloadResource } from '../assets/functions/resourceLoaderFunctions'
 import { FileLoader } from '../assets/loaders/base/FileLoader'
 import { Loader } from '../assets/loaders/base/Loader'
-import { ResourceCache } from '../assets/loaders/base/ResourceCache'
+import { ResourceCache, extractHashFromURL } from '../assets/loaders/base/ResourceCache'
 import { TextureLoader } from '../assets/loaders/texture/TextureLoader'
 import { AssetLoaderState } from '../assets/state/AssetLoaderState'
 import { ResourceCacheState } from '../assets/state/ResourceCacheState'
@@ -152,6 +152,81 @@ export function getImageURIMimeType(uri) {
   if (uri.search(/\.webp($|\?)/i) > 0 || uri.search(/^data:image\/webp/) === 0) return 'image/webp'
 
   return 'image/png'
+}
+
+/**
+ * Validate GLTF cache and invalidate if necessary
+ * @param url The GLTF URL with hash parameter
+ * @returns Promise resolving to true if cache was valid, false if invalidated
+ */
+export async function validateGLTFCache(url: string): Promise<boolean> {
+  try {
+    const currentHash = extractHashFromURL(url)
+    if (!currentHash) {
+      return false
+    }
+
+    const isValid = await ResourceCache?.isGLTFCacheValid(url, currentHash)
+
+    if (!isValid) {
+      await ResourceCache?.invalidateGLTFDependencies(url)
+      return false
+    }
+
+    return true
+  } catch (error) {
+    console.warn('Error validating GLTF cache:', error)
+    return false
+  }
+}
+
+/**
+ * Store GLTF metadata for future cache validation
+ * @param url The GLTF URL with hash parameter
+ * @param document The parsed GLTF document
+ */
+export async function storeGLTFMetadata(url: string, document: GLTF.IGLTF): Promise<void> {
+  try {
+    const hash = extractHashFromURL(url)
+    if (!hash) {
+      console.warn('No hash found in GLTF URL, cannot store metadata:', url)
+      return
+    }
+
+    const dependencies = extractGLTFDependencies(url, document)
+    await ResourceCache?.putGLTFMetadata(url, hash, dependencies)
+  } catch (error) {
+    console.warn('Error storing GLTF metadata:', error)
+  }
+}
+
+/**
+ * Extract all dependency URLs from a GLTF document
+ * @param baseUrl The base URL of the GLTF file
+ * @param document The GLTF document
+ * @returns Array of dependency URLs
+ */
+function extractGLTFDependencies(baseUrl: string, document: GLTF.IGLTF): string[] {
+  const dependencies: string[] = []
+  const basePath = LoaderUtils.extractUrlBase(baseUrl)
+
+  if (document.buffers) {
+    for (const buffer of document.buffers) {
+      if (buffer.uri && !buffer.uri.startsWith('data:')) {
+        dependencies.push(LoaderUtils.resolveURL(buffer.uri, basePath))
+      }
+    }
+  }
+
+  if (document.images) {
+    for (const image of document.images) {
+      if (image.uri && !image.uri.startsWith('data:')) {
+        dependencies.push(LoaderUtils.resolveURL(image.uri, basePath))
+      }
+    }
+  }
+
+  return dependencies
 }
 
 const loadPrimitives = async (options: GLTFParserOptions, meshIndex: number): Promise<[BufferGeometry, Entity[]]> => {
@@ -1578,6 +1653,8 @@ const loadScene = async (options: GLTFParserOptions, sceneIndex: number) => {
     DependencyCache.set(`${rootEntity}${options.url}`, new Map<string, Promise<any>>())
   }
 
+  await storeGLTFMetadata(options.url, json)
+
   migrateSceneDeltas(rootEntity, options.document)
 
   const overrides = json.extensions?.[OVERRIDE_EXTENSION_NAME]
@@ -1678,7 +1755,8 @@ export const GLTFLoaderFunctions = {
   loadNode,
   loadScene,
   loadSkin,
-  unloadScene
+  unloadScene,
+  validateGLTFCache
 }
 
 export const DependencyCache = new Map<string, Map<string, Promise<any>>>()


### PR DESCRIPTION
## Summary
Adds basic cache invalidation logic for gltf resources when its hash URL parameter changes.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-11346

## QA Steps
