### PR TITLE
change magic link text

### DIFF
--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -37,7 +37,7 @@
       "agree": "I agree to the ",
       "terms": "Terms & Conditions",
       "lbl-submit": "Send Login Link",
-      "email-sent-msg": "A login magic link has been sent. Please check your email.",
+      "email-sent-msg": "Check your inbox - we've just sent you a magic link",
       "success-msg": "A login magic link has been sent. Please check your email or SMS.",
       "sms-sent-msg": "A login magic link has been sent. Please check your SMS."
     },

--- a/packages/client-core/src/common/services/NotificationService.tsx
+++ b/packages/client-core/src/common/services/NotificationService.tsx
@@ -23,14 +23,11 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { SnackbarKey, SnackbarProvider, VariantType, closeSnackbar } from 'notistack'
+import { SnackbarKey, SnackbarProvider, VariantType } from 'notistack'
 import React, { CSSProperties, Fragment, useEffect, useRef } from 'react'
 
 import multiLogger from '@ir-engine/common/src/logger'
 import { defineState, getState, useMutableState } from '@ir-engine/hyperflux'
-
-import { MdClose } from 'react-icons/md'
-import InviteSnackbarActions from '../../components/InviteToast/InviteSnackbarActions'
 
 const logger = multiLogger.child({ component: 'client-core:Notification' })
 
@@ -51,22 +48,10 @@ export type NotificationOptions = {
 }
 
 export const defaultAction = (key: SnackbarKey, content?: React.ReactNode) => {
-  return (
-    <Fragment>
-      {content}
-      <button onClick={() => closeSnackbar(key)}>
-        <MdClose size="1.2rem" />
-      </button>
-    </Fragment>
-  )
+  return <Fragment>{content}</Fragment>
 }
 export const inviteActions = (key: SnackbarKey, content?: React.ReactNode) => {
-  return (
-    <Fragment>
-      {content}
-      <InviteSnackbarActions closeSnackbar={() => closeSnackbar(key)} />
-    </Fragment>
-  )
+  return <Fragment>{content}</Fragment>
 }
 
 export const NotificationActions = {


### PR DESCRIPTION
## Summary
[IR-11116](https://tsu.atlassian.net/browse/IR-11116)

- Magic link toast notification should not have an X/close icon
- Duplicate magic link (blue text) should not show

## Subtasks Checklist

## Breaking Changes

## References
[IR-11116](https://tsu.atlassian.net/browse/IR-11116)

## QA Steps
- Go to welcome/signup/signin page
- Select magic link
- Check age verification
- Submit a magic link and look for notification

![image](https://github.com/user-attachments/assets/276b2acb-e06c-4b40-b103-404fcda099c9)


[IR-11116]: https://tsu.atlassian.net/browse/IR-11116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IR-11116]: https://tsu.atlassian.net/browse/IR-11116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ