### PR TITLE
IR-11273: set default position for hemisphere light in prefab

### DIFF
--- a/packages/projects/default-project/assets/prefabs/hemisphere-light.prefab.gltf
+++ b/packages/projects/default-project/assets/prefabs/hemisphere-light.prefab.gltf
@@ -15,6 +15,24 @@
   "nodes": [
     {
       "name": "Hemisphere Light",
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0,
+        1
+      ],
       "extensions": {
         "EE_uuid": "ec27fd9e-6ab9-46dd-a49e-9c0edff54cd4",
         "EE_visible": true,


### PR DESCRIPTION
## Summary

Set default position for Hemisphere Light in prefab
**ticket:** https://tsu.atlassian.net/browse/IR-11273
![Screen Recording 2025-06-30 at 4 04 24 p m](https://github.com/user-attachments/assets/825daca3-401c-4006-b5fd-c28b9b9ba5cf)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
