### PR TITLE
Refactor useEngineCanvas for improved canvas reference management

### DIFF
--- a/packages/spatial/src/renderer/functions/useEngineCanvas.ts
+++ b/packages/spatial/src/renderer/functions/useEngineCanvas.ts
@@ -27,15 +27,17 @@ import { Engine, getComponent, getOptionalMutableComponent, hasComponent } from 
 import { getState, none, useMutableState } from '@ir-engine/hyperflux'
 import { ReferenceSpaceState } from '@ir-engine/spatial'
 import { destroySpatialViewer, initializeSpatialViewer } from '@ir-engine/spatial/src/initializeEngine'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { RendererComponent } from '../components/RendererComponent'
 
 export const useEngineCanvas = (ref: React.RefObject<HTMLElement> | null) => {
+  const canvasRef = useRef(document.getElementById('engine-renderer-canvas') as HTMLCanvasElement)
+
   useEffect(() => {
     if (!ref) return
     const parent = ref.current as HTMLElement
     if (!parent) return
-    const canvas = document.getElementById('engine-renderer-canvas') as HTMLCanvasElement
+    const canvas = (document.getElementById('engine-renderer-canvas') as HTMLCanvasElement) ?? canvasRef.current
 
     const originalParent = canvas.parentElement!
     canvas.hidden = false
@@ -60,6 +62,7 @@ export const useEngineCanvas = (ref: React.RefObject<HTMLElement> | null) => {
 
   useEffect(() => {
     const canvas = document.getElementById('engine-renderer-canvas') as HTMLCanvasElement
+    canvasRef.current = canvas
     initializeSpatialViewer(canvas)
     return () => {
       if (!Engine.instance) return

--- a/packages/spatial/src/renderer/functions/useEngineCanvas.ts
+++ b/packages/spatial/src/renderer/functions/useEngineCanvas.ts
@@ -31,7 +31,7 @@ import { useEffect, useRef } from 'react'
 import { RendererComponent } from '../components/RendererComponent'
 
 export const useEngineCanvas = (ref: React.RefObject<HTMLElement> | null) => {
-  const canvasRef = useRef(document.getElementById('engine-renderer-canvas') as HTMLCanvasElement)
+  const canvasRef = useRef(document.getElementById('engine-renderer-canvas') as HTMLCanvasElement | null)
 
   useEffect(() => {
     if (!ref) return
@@ -66,6 +66,7 @@ export const useEngineCanvas = (ref: React.RefObject<HTMLElement> | null) => {
     initializeSpatialViewer(canvas)
     return () => {
       if (!Engine.instance) return
+      canvasRef.current = null
       destroySpatialViewer()
     }
   }, [])


### PR DESCRIPTION
Utilize `useRef` for managing the canvas reference in `useEngineCanvas`, enhancing performance and reliability.