### PR TITLE
Viewport: The "Render Mode" options can't be displayed when it's inside of "Preview Scene" display option

### DIFF
--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -391,7 +391,6 @@ const Select = ({
       contentStyle={{
         padding: '0px',
         border: 'none',
-        zIndex: 60,
         ...positionStyle
       }}
       onOpen={() => onOpen?.(true)}


### PR DESCRIPTION
## Summary
https://tsu.atlassian.net/browse/IR-11480

removed the z index for the select box that was added for IR-11492 to prevent the select box popup from being hidden under the toolbar "more options" popup

checked the issue from https://tsu.atlassian.net/browse/IR-11492 to make sure it didn't regress

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
