### PR TITLE
fix(IR-11489): fix copy/paste array filtering and sourceId validation

### DIFF
--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -104,8 +104,9 @@ export const pasteNodes = (parentEntity?: Entity) => {
 
   const ProcessEntityData = (parentEntity: Entity | undefined, nodeEntitiesData: EntityCopyDataType[]) => {
     nodeEntitiesData.forEach((nodeEntityData) => {
-      const components = nodeEntityData.components.map((c) => ({ name: c.name, props: c.json }) as ComponentJsonType)
-      delete components[UUIDComponent.jsonID]
+      const components = nodeEntityData.components
+        .filter((c) => c.name !== UUIDComponent.jsonID)
+        .map((c) => ({ name: c.name, props: c.json }) as ComponentJsonType)
 
       const entityData = EditorControlFunctions.createObjectFromSceneElement(
         components,


### PR DESCRIPTION
## Summary
fix(editor): resolve copy/paste issues in hierarchy panel

- Fix array filtering bug where delete components[UUIDComponent.jsonID] was incorrectly trying to delete from array instead of filtering

Fixes issue where:
1. Pasted assets would disappear from viewport when moved/translated
2. Original entities would disappear from hierarchy panel when copied after being transformed
3. Copy/paste would fail for entities with composite sourceIds


Behavior before:

https://github.com/user-attachments/assets/66b78077-c254-402e-9251-403fefd9082b

---

Behavior fixed

https://github.com/user-attachments/assets/b99c5fb2-aea0-4cf5-a34d-a8d52ecbe7fe


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
