### PR TITLE
Feature Update] Thumbnails should only be generated the first time a user publishes a world, unless they "click generate"

### DIFF
--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -393,8 +393,11 @@ export default function AddEditLocationModal(props: AddEditLocationModalProps) {
 
     try {
       if (updateSceneID && getState(ReferenceSpaceState).originEntity !== UndefinedEntity) {
-        await SceneThumbnailState.createThumbnail()
-        await SceneThumbnailState.uploadThumbnail()
+        const thumbnailInfo = await SceneThumbnailState.getThumbnail()
+        if (!thumbnailInfo) {
+          await SceneThumbnailState.createThumbnail()
+          await SceneThumbnailState.uploadThumbnail()
+        }
       }
     } catch (e) {
       errors.serverError.set(e.message)

--- a/packages/editor/src/services/SceneThumbnailState.tsx
+++ b/packages/editor/src/services/SceneThumbnailState.tsx
@@ -92,7 +92,6 @@ export const SceneThumbnailState = defineState({
     }
 
     try {
-      // First, find the main resource
       const resourceQuery = await API.instance.service(staticResourcePath).find({
         query: { key }
       })
@@ -103,8 +102,6 @@ export const SceneThumbnailState = defineState({
       }
 
       const resource = resourceQuery.data[0]
-
-      // If the resource has a thumbnailKey, fetch the thumbnail resource
       if (resource.thumbnailKey) {
         const thumbnailQuery = await API.instance.service(staticResourcePath).find({
           query: {
@@ -124,8 +121,6 @@ export const SceneThumbnailState = defineState({
           }
         }
       }
-
-      // Return resource info even if no thumbnail is found
       return null
     } catch (error) {
       console.error('Error fetching thumbnail from StaticResources:', error)

--- a/packages/editor/src/services/SceneThumbnailState.tsx
+++ b/packages/editor/src/services/SceneThumbnailState.tsx
@@ -82,6 +82,76 @@ export const SceneThumbnailState = defineState({
       thumbnail: file
     })
   },
+  getThumbnail: async (resourceKey?: string) => {
+    const editorState = getState(EditorState)
+    const key = resourceKey || editorState.scenePath
+
+    if (!key) {
+      console.warn('No resource key or scene path provided for getThumbnail')
+      return null
+    }
+
+    try {
+      // First, find the main resource
+      const resourceQuery = await API.instance.service(staticResourcePath).find({
+        query: { key }
+      })
+
+      if (!resourceQuery.data || resourceQuery.data.length === 0) {
+        console.warn(`No static resource found for key: ${key}`)
+        return null
+      }
+
+      const resource = resourceQuery.data[0]
+
+      // If the resource has a thumbnailKey, fetch the thumbnail resource
+      if (resource.thumbnailKey) {
+        const thumbnailQuery = await API.instance.service(staticResourcePath).find({
+          query: {
+            key: resource.thumbnailKey,
+            type: 'thumbnail'
+          }
+        })
+
+        if (thumbnailQuery.data && thumbnailQuery.data.length > 0) {
+          const thumbnailResource = thumbnailQuery.data[0]
+          return {
+            thumbnailURL: thumbnailResource.url,
+            thumbnailKey: resource.thumbnailKey,
+            thumbnailMode: resource.thumbnailMode,
+            resource: resource,
+            thumbnailResource: thumbnailResource
+          }
+        }
+      }
+
+      // Return resource info even if no thumbnail is found
+      return null
+    } catch (error) {
+      console.error('Error fetching thumbnail from StaticResources:', error)
+      return null
+    }
+  },
+  initializeThumbnailFromStaticResources: async () => {
+    const editorState = getState(EditorState)
+    const scenePath = editorState.scenePath
+
+    if (!scenePath) return
+
+    try {
+      const thumbnailInfo = await SceneThumbnailState.getThumbnail(scenePath)
+
+      if (thumbnailInfo?.thumbnailURL) {
+        const sceneThumbnailState = getMutableState(SceneThumbnailState)
+        sceneThumbnailState.merge({
+          thumbnailURL: thumbnailInfo.thumbnailURL,
+          oldThumbnailURL: sceneThumbnailState.thumbnailURL.value
+        })
+      }
+    } catch (error) {
+      console.error('Error initializing thumbnail from StaticResources:', error)
+    }
+  },
   uploadThumbnail: async (entity?) => {
     const sceneThumbnailState = getMutableState(SceneThumbnailState)
     if (!sceneThumbnailState.thumbnail.value) return
@@ -185,6 +255,7 @@ export const SceneThumbnailState = defineState({
         thumbnail: null,
         loadingScreenImageData: null
       })
+      SceneThumbnailState.initializeThumbnailFromStaticResources()
     }, [editorState.scenePath])
     return null
   }

--- a/packages/ui/src/components/editor/Modal/AddEditLocationModalStudioSections.tsx
+++ b/packages/ui/src/components/editor/Modal/AddEditLocationModalStudioSections.tsx
@@ -40,6 +40,7 @@ export default function AddEditLocationModalStudioSections() {
     try {
       isGenerating.set(true)
       await SceneThumbnailState.createThumbnail()
+      await SceneThumbnailState.uploadThumbnail()
     } catch (e) {
       NotificationService.dispatchNotify(e, { variant: 'error' })
       console.log(e)


### PR DESCRIPTION
## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-10693

## QA Steps
