### PR TITLE
IR-11554: fix engine commit and release number mismatch

### DIFF
--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -342,14 +342,16 @@ export const ProjectService = {
     }
   },
 
-  getBuilderInfo: async () => {
-    try {
-      const result = await API.instance.service(builderInfoPath).get()
-      getMutableState(ProjectState).builderInfo.set(result)
-    } catch (err) {
-      logger.error('Error with getting engine info', err)
-      throw err
-    }
+  getBuilderInfo: () => {
+    API.instance
+      .service(builderInfoPath)
+      .get()
+      .then((result) => {
+        getMutableState(ProjectState).builderInfo.set(result)
+      })
+      .catch((err) => {
+        logger.error('Error with getting engine info', err)
+      })
   },
 
   refreshGithubRepoAccess: async () => {

--- a/packages/server-core/src/projects/builder-info/builder-info.class.ts
+++ b/packages/server-core/src/projects/builder-info/builder-info.class.ts
@@ -87,7 +87,7 @@ export class BuilderInfoService implements ServiceInterface<BuilderInfoType> {
               : privateECRRegexExec
               ? privateECRRegexExec[2]
               : gcpArtifactRegistryRegexExec
-              ? gcpArtifactRegistryRegexExec[6]
+              ? gcpArtifactRegistryRegexExec[5] || gcpArtifactRegistryRegexExec[6] || ''
               : ''
         }
       }


### PR DESCRIPTION
## Summary

Fixed unhandled promise causing a release number mismatch. 
Fixed engine commit missing in project state.  

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
