### PR TITLE
[Release1.1] Cherry-pick: fix(IR-11489): fix copy/paste array filtering and sourceId validation

### DIFF
--- a/packages/editor/src/panels/hierarchy/helpers.ts
+++ b/packages/editor/src/panels/hierarchy/helpers.ts
@@ -104,8 +104,9 @@ export const pasteNodes = (parentEntity?: Entity) => {
 
   const ProcessEntityData = (parentEntity: Entity | undefined, nodeEntitiesData: EntityCopyDataType[]) => {
     nodeEntitiesData.forEach((nodeEntityData) => {
-      const components = nodeEntityData.components.map((c) => ({ name: c.name, props: c.json }) as ComponentJsonType)
-      delete components[UUIDComponent.jsonID]
+      const components = nodeEntityData.components
+        .filter((c) => c.name !== UUIDComponent.jsonID)
+        .map((c) => ({ name: c.name, props: c.json }) as ComponentJsonType)
 
       const entityData = EditorControlFunctions.createObjectFromSceneElement(
         components,


### PR DESCRIPTION
## Summary
Cherry-pick of PR #2289 to release1.1 branch.

fix(editor): resolve copy/paste issues in hierarchy panel

- Fix array filtering bug where delete components[UUIDComponent.jsonID] was incorrectly trying to delete from array instead of filtering

Fixes issue where:
1. Pasted assets would disappear from viewport when moved/translated
2. Original entities would disappear from hierarchy panel when copied after being transformed
3. Copy/paste would fail for entities with composite sourceIds


Behavior before:

https://github.com/user-attachments/assets/66b78077-c254-402e-9251-403fefd9082b

---

Behavior fixed

https://github.com/user-attachments/assets/b99c5fb2-aea0-4cf5-a34d-a8d52ecbe7fe

## Original PR
This is a cherry-pick of: https://github.com/ir-engine/ir-engine/pull/2289

## Subtasks Checklist
- [x] Cherry-pick commit 7ee73a5728 from dev to release1.1
- [x] Verify fix works correctly in release1.1 context

## Breaking Changes
None

## References
Original issue: IR-11489
Original PR: #2289

## QA Steps
1. Open studio
2. Create new blank scene
3. Drag and drop asset from Asset tab into viewport
4. Copy and paste asset in the Hierarchy panel
5. Move around the pasted asset via gizmo or Translation properties
6. Verify asset does not disappear from viewport
7. Verify original asset remains in hierarchy panel after copying

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author