### PR TITLE
fix engine version on first load

### DIFF
--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -27,6 +27,7 @@ import { Paginated } from '@feathersjs/feathers'
 import { useEffect } from 'react'
 
 import { API } from '@ir-engine/common'
+import packageJson from '@ir-engine/common/package.json'
 import multiLogger from '@ir-engine/common/src/logger'
 import {
   builderInfoPath,
@@ -68,7 +69,7 @@ export const ProjectState = defineState({
     failed: false,
     builderTags: [] as Array<ProjectBuilderTagsType>,
     builderInfo: {
-      engineVersion: '1.0.2',
+      engineVersion: packageJson.version,
       engineCommit: ''
     },
     refreshingGithubRepoAccess: false


### PR DESCRIPTION
## Summary

The engine version on dashboard page was showing the incorrect placeholder version.
This PR fixes it by using the version from package.json

closes https://tsu.atlassian.net/browse/IR-10156

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
