### PR TITLE
Scene switch crashing

### DIFF
--- a/packages/editor/src/panels/scenes/index.tsx
+++ b/packages/editor/src/panels/scenes/index.tsx
@@ -29,6 +29,7 @@ import { StaticResourceType, fileBrowserPath, staticResourcePath } from '@ir-eng
 import { confirmSceneSaveIfModified } from '@ir-engine/editor/src/components/toolbar/Toolbar'
 import { onNewScene } from '@ir-engine/editor/src/functions/sceneFunctions'
 import { EditorState } from '@ir-engine/editor/src/services/EditorServices'
+import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { getMutableState, getState, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import { AddScene } from '@ir-engine/ui/src/components/editor/AddScene/AddScene'
@@ -52,7 +53,8 @@ function ScenesPanel() {
   const scenesLoading = scenesQuery.status === 'pending'
 
   const onClickScene = async (scene: StaticResourceType) => {
-    if (!(await confirmSceneSaveIfModified())) return
+    const sceneLoaded = GLTFComponent.isSceneLoaded(getState(EditorState).rootEntity)
+    if (!(await confirmSceneSaveIfModified()) || !sceneLoaded) return
 
     getMutableState(EditorState).merge({
       scenePath: scene.key

--- a/packages/engine/src/scene/components/SkyboxComponent.ts
+++ b/packages/engine/src/scene/components/SkyboxComponent.ts
@@ -117,6 +117,9 @@ export const SkyboxComponent = defineComponent({
       texture.minFilter = LinearFilter
       texture.generateMipmaps = false
       setComponent(entity, BackgroundComponent, texture)
+      return () => {
+        texture.dispose()
+      }
     }, [texture, skyboxState.backgroundType])
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
Disposes of background textures on unmount to prevent webgl context loss due to memory useage, and prevents editor scene switching if the current one is not done loading to prevent breaking system/reactor errors if scenes are switched in quick succession.

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-11558

## QA Steps
