### PR TITLE
fix(gcs): fixed rename empty folder

### DIFF
--- a/packages/server-core/src/media/storageprovider/gcs.storage.ts
+++ b/packages/server-core/src/media/storageprovider/gcs.storage.ts
@@ -473,10 +473,9 @@ export class GCSStorage extends BaseStorageProvider implements StorageProviderIn
    * @param isCopy If true it will create a copy of object.
    */
   async moveObject(oldName: string, newName: string, oldPath: string, newPath: string, isCopy = false) {
-    const isDirectory = await this.isDirectory(oldName, oldPath)
     const oldFilePath = path.join(oldPath, oldName)
     const newFilePath = path.join(newPath, newName)
-    const listResponse = await this.listObjects(oldFilePath + (isDirectory ? '/' : ''), false, undefined, isDirectory)
+    const listResponse = await this.listObjects(oldFilePath, false, undefined, false)
 
     if (listResponse.Contents.length > 0) {
       return await Promise.all([
@@ -484,10 +483,15 @@ export class GCSStorage extends BaseStorageProvider implements StorageProviderIn
           const relativePath = file.Key.replace(oldFilePath, '')
           const key = newFilePath + relativePath
 
-          if (file.Type === 'folder') {
+          if (file.Type === 'folder' && isCopy) {
             return await this.putObject({ Key: key } as StorageObjectInterface, {
               isDirectory: true
             })
+          } else if (file.Type === 'folder' && !isCopy) {
+            await this.putObject({ Key: key } as StorageObjectInterface, {
+              isDirectory: true
+            })
+            return await this.deleteResources([file.Key])
           }
 
           if (isCopy) return await this.provider.bucket(this.bucket).file(file.Key).copy(key, {})


### PR DESCRIPTION
## Summary

Fixed ability to rename empty folders. Updated parameters used to invoke listObjects since using delimiter retrieves the elements under the specified folder, not the folder object itself. 

![Screen Recording 2025-07-08 at 10 03 39 a m](https://github.com/user-attachments/assets/0c20702c-fa07-488a-9fc7-20cdc8d6b50c)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
