### PR TITLE
avatar flickers when scrolling

### DIFF
--- a/packages/spatial/src/camera/systems/CameraOrbitSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraOrbitSystem.tsx
@@ -27,13 +27,14 @@ import { Matrix3, Spherical, Vector3 } from 'three'
 
 import {
   defineSystem,
+  EngineState,
   getComponent,
   getMutableComponent,
   getOptionalComponent,
   InputSystemGroup,
   query
 } from '@ir-engine/ecs'
-import { isClient } from '@ir-engine/hyperflux'
+import { getState, isClient } from '@ir-engine/hyperflux'
 import { CameraComponent } from '@ir-engine/spatial/src/camera/components/CameraComponent'
 import { CameraOrbitComponent } from '@ir-engine/spatial/src/camera/components/CameraOrbitComponent'
 import { Vector3_Up } from '@ir-engine/spatial/src/common/constants/MathConstants'
@@ -52,6 +53,8 @@ const orbitCameraQueryTerms = [RendererComponent, CameraOrbitComponent, InputCom
 
 const execute = () => {
   if (!isClient) return
+
+  if (!getState(EngineState).isEditing) return
 
   for (const cameraEid of query(orbitCameraQueryTerms)) {
     const cameraOrbit = getMutableComponent(cameraEid, CameraOrbitComponent)


### PR DESCRIPTION
https://tsu.atlassian.net/browse/IR-11574

added an early return if not in editor mode to prevent the orbit system from moving the camera, since the Follow Camera Component is responsible for moving the camera in play mode

This double move per frame was causing the flicker via the avatar dithering  (TransparencyDitheringComponent.tsx)

## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
