### PR TITLE
Fix scene override normal map color space

### DIFF
--- a/packages/engine/src/authoring/AuthoringState.tsx
+++ b/packages/engine/src/authoring/AuthoringState.tsx
@@ -469,7 +469,7 @@ export const applyCommandsToECS = (sourceID: SourceID, currentState: SourceData,
                 if (texture?.isTexture) {
                   texture.flipY = false
                   texture.needsUpdate = true
-                  texture.colorSpace = SRGBColorSpace
+                  if (key !== 'normalMap') texture.colorSpace = SRGBColorSpace
                   materialComponent.material[key].set(texture ?? null)
                 }
                 if (!asyncUpdateCount) (materialComponent.material.get(NO_PROXY) as Material).needsUpdate = true


### PR DESCRIPTION
## Summary
Tentative check to stop normal maps getting their color space overrided to SRGB causing the busted normals shown below
![image](https://github.com/user-attachments/assets/11bbbdd0-1ba7-481d-b84b-ba9b58fa434a)

## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-11242

## QA Steps
