### PR TITLE
IR-9745: unset particles emission over time & removed unsupported fields

### DIFF
--- a/packages/engine/src/scene/types/ParticleSystemTypes.ts
+++ b/packages/engine/src/scene/types/ParticleSystemTypes.ts
@@ -623,6 +623,8 @@ const BlendingSchema = S.LiteralUnion(
   { default: AdditiveBlending }
 )
 
+export const DEFAULT_EMISSION_OVER_TIME = 400
+
 export const DEFAULT_PARTICLE_SYSTEM_PARAMETERS = S.Object({
   version: S.String({ default: '1.0' }),
   autoDestroy: S.Bool({ default: false }),
@@ -688,7 +690,7 @@ export const DEFAULT_PARTICLE_SYSTEM_PARAMETERS = S.Object({
   }),
   emissionOverTime: S.Object({
     type: S.String({ default: 'ConstantValue' }),
-    value: S.Number({ default: 400 }),
+    value: S.Number({ default: DEFAULT_EMISSION_OVER_TIME }),
     a: S.Number({ default: 0 }),
     b: S.Number({ default: 1 }),
     functions: S.Array(S.Type<BezierFunctionJSON>())

--- a/packages/ui/src/components/editor/properties/particle/index.tsx
+++ b/packages/ui/src/components/editor/properties/particle/index.tsx
@@ -49,6 +49,7 @@ import {
   BurstParametersJSON,
   CONE_SHAPE_DEFAULT,
   ColorGeneratorJSON,
+  DEFAULT_EMISSION_OVER_TIME,
   DONUT_SHAPE_DEFAULT,
   MESH_SHAPE_DEFAULT,
   POINT_SHAPE_DEFAULT,
@@ -141,6 +142,13 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
       probability: 1
     }
     const data = [...JSON.parse(JSON.stringify(particleSystem.systemParameters.emissionBursts)), nuBurst]
+
+    // unset emission over time so it doesn't override the bursts
+    onSetState('systemParameters.emissionOverTime')({
+      type: 'ConstantValue',
+      value: 0
+    })
+
     commitProperty(ParticleSystemComponent, 'systemParameters.emissionBursts' as any)(data)
   }, [])
 
@@ -152,6 +160,13 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
         )
       )
       commitProperty(ParticleSystemComponent, 'systemParameters.emissionBursts' as any)(data)
+      if (data.length === 0) {
+        // set default emission over time.
+        onSetState('systemParameters.emissionOverTime')({
+          type: 'ConstantValue',
+          value: DEFAULT_EMISSION_OVER_TIME
+        })
+      }
     }
   }, [])
 
@@ -225,22 +240,10 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
                 />
               </InputGroup>
 
-              <InputGroup name="Cycle" label={t('editor:properties.particle-system.burst.cycle')}>
-                <NumericInput
-                  value={burst.cycle.value}
-                  onChange={onSetState(`systemParameters.emissionBursts.${index}.cycle`)}
-                />
-              </InputGroup>
-
-              <InputGroup name="Interval" label={t('editor:properties.particle-system.burst.interval')}>
-                <NumericInput
-                  value={burst.interval.value}
-                  onChange={onSetState(`systemParameters.emissionBursts.${index}.interval`)}
-                />
-              </InputGroup>
-
               <InputGroup name="Probability" label={t('editor:properties.particle-system.burst.probability')}>
                 <NumericInput
+                  max={1}
+                  min={0}
                   value={burst.probability.value}
                   onChange={onSetState(`systemParameters.emissionBursts.${index}.probability`)}
                 />


### PR DESCRIPTION
## Summary

- removed interval and cycle fields from particle bursts  form since they are not supported by three quarks (library used for particle systems)
- unset emission over time when adding a burst so it doesn't override the burst

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
