### PR TITLE
IR-11547: fixed component search in editor

### DIFF
--- a/packages/editor/src/panels/properties/elementlist.tsx
+++ b/packages/editor/src/panels/properties/elementlist.tsx
@@ -158,7 +158,6 @@ const SceneElementListItem = ({
 }
 
 const useComponentShelfCategories = (search: string) => {
-  useMutableState(ComponentShelfCategoriesState).value
   const hasRenderSettingsEntites = useQuery([RenderSettingsComponent]).length > 0
   const hasSceneSettingsEntites = useQuery([SceneSettingsComponent]).length > 0
   const hasCameraSettingsEntites = useQuery([CameraSettingsComponent]).length > 0
@@ -181,9 +180,13 @@ const useComponentShelfCategories = (search: string) => {
     return Object.entries(getState(ComponentShelfCategoriesState))
       .map(([category, items]) => {
         const filteredItems = items.filter((item) =>
-          ((item.jsonID ? labelRemapping[item.jsonID] : undefined) || item.name)
+          (
+            (item.jsonID ? labelRemapping[item.jsonID] : undefined) ||
+            item.jsonID?.split('_').slice(1).join(' ') ||
+            item.name
+          )
             .toLowerCase()
-            .includes(search.toLowerCase())
+            .includes(search.toLowerCase().trim())
         )
         return [category, filteredItems] as [string, Component[]]
       })


### PR DESCRIPTION
## Summary
Fixed component search in the editor. Previously, some components with composed names like 'Mount Point' or 'Ambient Light' wouldn't appear in search results if spaces were used. Others, like 'Model', didn't show up at all unless only a single letter (e.g., 'm') was typed.

**ticket:** https://tsu.atlassian.net/browse/IR-11547

![Screen Recording 2025-07-10 at 10 48 35 a m](https://github.com/user-attachments/assets/eaffcb2f-51ba-4e3e-a0fa-2de296052a5d)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Open an scene
- View hierarchy tab on the right side → “Add Entity“
- Add an entity (e.g. “Empty“)
- Navigate to components and try to find some components (e.g. which contains space as “Spawn Point“, or exact “Model“ component)