### PR TITLE
IR-11523: Fix link component options

### DIFF
--- a/packages/ui/src/components/editor/properties/link/index.tsx
+++ b/packages/ui/src/components/editor/properties/link/index.tsx
@@ -65,17 +65,27 @@ export const LinkNodeEditor: EditorComponentType = (props) => {
         ]
       })
     } else {
+      // We should preserve the user's settings, such as uiActivationType
+      const existingComponent = getComponent(props.entity, InteractableComponent)
+      const hasLinkCallback = existingComponent.callbacks.some(
+        (callback) => callback.callbackID === LinkComponent.linkCallbackName
+      )
+
       EditorControlFunctions.modifyProperty([props.entity], InteractableComponent, {
         label: LinkComponent.interactMessage,
         uiInteractable: false,
         clickInteract: true,
-        uiActivationType: XRUIActivationType.hover,
-        callbacks: [
-          {
-            callbackID: LinkComponent.linkCallbackName,
-            target: getComponent(props.entity, UUIDComponent).entityID
-          }
-        ]
+        ...(hasLinkCallback
+          ? {}
+          : {
+              callbacks: [
+                ...existingComponent.callbacks,
+                {
+                  callbackID: LinkComponent.linkCallbackName,
+                  target: getComponent(props.entity, UUIDComponent).entityID
+                }
+              ]
+            })
       })
     }
   }, [])


### PR DESCRIPTION
https://tsu.atlassian.net/browse/IR-11523

## Summary
Problem: Interactable component - 'Activation type' field stays in 'Hover' option with 'Link' component

Solution: Preserve the user's settings. So if  'Activation type' field is updated by the user to 'Proximity' then that selection will remain when the user select another entity and then later comes back to the interactable component. 

## QA Steps
1. Enter to Studio editor in any scene

2. Add any model to scene

3. Properties > “Add Component” > “Interactable” > “Link”

4. Properties > Navigate to “Interactable” component and locate the “Activation Type” dropdown menu

5. Change option from “Hover” to “Proximity” 

6. Choose another entity from Hierarchy tab and then selected again previous entity with “Interactable” component

7. Check “Activation Type” option, confirm it still has the "Proximity" option.

https://tsu.atlassian.net/browse/IR-11523
