### PR TITLE
[IR-11639] Material glTF assets are not importing correctly

### DIFF
--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -901,11 +901,10 @@ const RenderMaterialThumbnail = (props: RenderThumbnailProps) => {
   const { src, project, onError } = props
   const [entity, lightEntity, skyboxEntity, cameraEntity] = useRenderEntities(src)
   const gltfEntity = useGLTFComponent(src, entity)
-  const loaded = GLTFComponent.useSceneLoaded(gltfEntity ?? UndefinedEntity)
   const errors = ErrorComponent.useComponentErrors(gltfEntity ?? UndefinedEntity, GLTFComponent)
 
   useEffect(() => {
-    if (!entity || !lightEntity || !skyboxEntity || !cameraEntity || !gltfEntity || !loaded) return
+    if (!entity || !lightEntity || !skyboxEntity || !cameraEntity || !gltfEntity) return
 
     const materialEntity = getChildrenWithComponents(gltfEntity, [MaterialStateComponent])[0]
     if (!materialEntity) {
@@ -918,16 +917,13 @@ const RenderMaterialThumbnail = (props: RenderThumbnailProps) => {
       return
     }
 
-    /** @todo Remove the setTimeout when the GLTF loader refactor has been completed */
-    setTimeout(() => {
-      const sphere = new Mesh(new SphereGeometry(1), material)
-      if (Object.hasOwn(sphere.material, 'flatShading')) {
-        ;(sphere.material as Material & { flatShading: boolean }).flatShading = false
-      }
-      setComponent(entity, MeshComponent, sphere)
-      renderThumbnail(entity, lightEntity, skyboxEntity, cameraEntity, props)
-    }, 1000)
-  }, [entity, lightEntity, skyboxEntity, cameraEntity, gltfEntity, loaded])
+    const sphere = new Mesh(new SphereGeometry(1), material)
+    if (Object.hasOwn(sphere.material, 'flatShading')) {
+      ;(sphere.material as Material & { flatShading: boolean }).flatShading = false
+    }
+    setComponent(entity, MeshComponent, sphere)
+    renderThumbnail(entity, lightEntity, skyboxEntity, cameraEntity, props)
+  }, [entity, lightEntity, skyboxEntity, cameraEntity, gltfEntity])
 
   useEffect(() => {
     if (!errors) return

--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -901,10 +901,11 @@ const RenderMaterialThumbnail = (props: RenderThumbnailProps) => {
   const { src, project, onError } = props
   const [entity, lightEntity, skyboxEntity, cameraEntity] = useRenderEntities(src)
   const gltfEntity = useGLTFComponent(src, entity)
+  const loaded = GLTFComponent.useSceneLoaded(gltfEntity ?? UndefinedEntity)
   const errors = ErrorComponent.useComponentErrors(gltfEntity ?? UndefinedEntity, GLTFComponent)
 
   useEffect(() => {
-    if (!entity || !lightEntity || !skyboxEntity || !cameraEntity || !gltfEntity) return
+    if (!entity || !lightEntity || !skyboxEntity || !cameraEntity || !gltfEntity || !loaded) return
 
     const materialEntity = getChildrenWithComponents(gltfEntity, [MaterialStateComponent])[0]
     if (!materialEntity) {
@@ -926,7 +927,7 @@ const RenderMaterialThumbnail = (props: RenderThumbnailProps) => {
       setComponent(entity, MeshComponent, sphere)
       renderThumbnail(entity, lightEntity, skyboxEntity, cameraEntity, props)
     }, 1000)
-  }, [entity, lightEntity, skyboxEntity, cameraEntity, gltfEntity])
+  }, [entity, lightEntity, skyboxEntity, cameraEntity, gltfEntity, loaded])
 
   useEffect(() => {
     if (!errors) return

--- a/packages/editor/src/panels/materials/helpers.tsx
+++ b/packages/editor/src/panels/materials/helpers.tsx
@@ -86,11 +86,11 @@ export async function saveMaterial(sourcePath: string, materialUUID: EntityUUID)
     sourcePath += '.material.gltf'
   }
   const relativePath = pathJoin('assets', sourcePath)
-  const gltf = (await exportMaterialsGLTF([UUIDComponent.getEntityByUUID(materialUUID, Layers.Authoring)], {
+  const gltf = await exportMaterialsGLTF([UUIDComponent.getEntityByUUID(materialUUID, Layers.Authoring)], {
     binary: false,
     relativePath,
     projectName
-  })!) as { [key: string]: any }
+  })!
   const blob = [JSON.stringify(gltf)]
   const file = new File(blob, sourcePath)
   const importSettings = getState(ImportSettingsState)

--- a/packages/editor/src/panels/scenes/index.tsx
+++ b/packages/editor/src/panels/scenes/index.tsx
@@ -29,7 +29,6 @@ import { StaticResourceType, fileBrowserPath, staticResourcePath } from '@ir-eng
 import { confirmSceneSaveIfModified } from '@ir-engine/editor/src/components/toolbar/Toolbar'
 import { onNewScene } from '@ir-engine/editor/src/functions/sceneFunctions'
 import { EditorState } from '@ir-engine/editor/src/services/EditorServices'
-import { GLTFComponent } from '@ir-engine/engine/src/gltf/GLTFComponent'
 import { getMutableState, getState, useHookstate, useMutableState } from '@ir-engine/hyperflux'
 import { Button } from '@ir-engine/ui'
 import { AddScene } from '@ir-engine/ui/src/components/editor/AddScene/AddScene'
@@ -53,8 +52,7 @@ function ScenesPanel() {
   const scenesLoading = scenesQuery.status === 'pending'
 
   const onClickScene = async (scene: StaticResourceType) => {
-    const sceneLoaded = GLTFComponent.isSceneLoaded(getState(EditorState).rootEntity)
-    if (!(await confirmSceneSaveIfModified()) || !sceneLoaded) return
+    if (!(await confirmSceneSaveIfModified())) return
 
     getMutableState(EditorState).merge({
       scenePath: scene.key

--- a/packages/engine/src/assets/functions/exportMaterialsGLTF.ts
+++ b/packages/engine/src/assets/functions/exportMaterialsGLTF.ts
@@ -34,6 +34,7 @@ import {
   UUIDComponent
 } from '@ir-engine/ecs'
 
+import { GLTF } from '@gltf-transform/core'
 import { TransformComponent } from '@ir-engine/spatial'
 import { exportGLTFScene } from '../../gltf/exportGLTFScene'
 
@@ -44,7 +45,7 @@ export default async function exportMaterialsGLTF(
     relativePath: string
     projectName: string
   }
-): Promise<ArrayBuffer | { [key: string]: any } | undefined> {
+): Promise<GLTF.IGLTF | undefined> {
   if (materialEntities.length === 0) return
   const rootEntity = createEntity()
   setComponent(rootEntity, UUIDComponent, {
@@ -55,6 +56,6 @@ export default async function exportMaterialsGLTF(
   setComponent(rootEntity, EntityTreeComponent)
   // hacky way to set the root entity as the parent of all material entities
   getComponent(rootEntity, EntityTreeComponent).children = [...materialEntities]
-  const gltf = await exportGLTFScene(rootEntity, exporterArgs.projectName, exporterArgs.relativePath, false)
+  const [gltf] = await exportGLTFScene(rootEntity, exporterArgs.projectName, exporterArgs.relativePath, false)
   return gltf
 }

--- a/packages/engine/src/assets/loaders/texture/TextureMemoryManager.ts
+++ b/packages/engine/src/assets/loaders/texture/TextureMemoryManager.ts
@@ -52,6 +52,11 @@ export async function offloadTextureData(texture: Texture): Promise<boolean> {
     return false
   }
 
+  if ((texture.source as DiscardableSource).discarded) {
+    console.warn(`Texture is already offloaded: ${url}`)
+    return false
+  }
+
   const mipmaps = texture.mipmaps
   const data = texture.source.data
   texture.mipmaps = []
@@ -148,11 +153,21 @@ export async function restoreTextureData(texture: Texture): Promise<boolean> {
   }
 
   if (!ResourceCache) return false
-  ;(texture.source as DiscardableSource).discarded = false
+
+  const finished = () => {
+    ;(texture.source as DiscardableSource).discarded = false
+  }
+
+  const fallbackLoad = async () => {
+    const loaded = await loadFromURL(texture)
+    finished()
+    return loaded
+  }
+
   try {
     const textureData = await ResourceCache.getTexture(url)
     if (!textureData) {
-      return await loadFromURL(texture)
+      return await fallbackLoad()
     }
 
     if ((texture as CompressedTexture).isCompressedTexture) {
@@ -165,11 +180,12 @@ export async function restoreTextureData(texture: Texture): Promise<boolean> {
           compressedTexture.format = textureData.format as CompressedPixelFormat
           compressedTexture.type = textureData.type
           compressedTexture.needsUpdate = true
+          finished()
           return true
         }
       } catch (e) {
         console.error(`Error parsing texture data: ${e}`)
-        return await loadFromURL(texture)
+        return await fallbackLoad()
       }
     } else {
       try {
@@ -179,14 +195,15 @@ export async function restoreTextureData(texture: Texture): Promise<boolean> {
 
         texture.source.data = imageBitmap
         texture.needsUpdate = true
+        finished()
         return true
       } catch (e) {
-        return await loadFromURL(texture)
+        return await fallbackLoad()
       }
     }
   } catch (error) {
     console.error(`Error restoring texture data: ${error}`)
-    return await loadFromURL(texture)
+    return await fallbackLoad()
   }
 
   return false

--- a/packages/engine/src/gltf/MaterialExtensionComponents.tsx
+++ b/packages/engine/src/gltf/MaterialExtensionComponents.tsx
@@ -67,8 +67,12 @@ export type MaterialValue =
   | MaterialVec3Value
   | MaterialVec2Value
 
-const colorValueToTupleValue = (colorValue: MaterialColorValue) =>
-  colorValue.contents.toArray() as [number, number, number]
+const colorValueToTupleValue = (colorValue: MaterialColorValue) => {
+  if (colorValue.contents.isColor) return colorValue.contents.toArray() as [number, number, number]
+  else {
+    return new Color(colorValue.contents).toArray() as [number, number, number]
+  }
+}
 
 type MaterialExtension<Comp extends Component> = {
   [Key in keyof ComponentType<Comp>]?: MaterialValue['contents']
@@ -119,7 +123,7 @@ export const KHRUnlitExtensionComponent = defineComponent({
         materialParams.opacity = array[3]
       }
 
-      if (metallicRoughness.baseColorTexture !== undefined) {
+      if (metallicRoughness.baseColorTexture != undefined) {
         pending = GLTFLoaderFunctions.assignTexture(options, metallicRoughness.baseColorTexture).then((map) => {
           materialParams.map = map
           if (map) map.colorSpace = SRGBColorSpace
@@ -147,7 +151,7 @@ export const KHREmissiveStrengthExtensionComponent = defineComponent({
     >
     const emissiveStrength = extension.emissiveStrength
 
-    if (emissiveStrength !== undefined) {
+    if (emissiveStrength != undefined) {
       materialParams.emissiveIntensity = emissiveStrength
     }
 
@@ -192,11 +196,11 @@ export const KHRClearcoatExtensionComponent = defineComponent({
       typeof KHRClearcoatExtensionComponent
     >
 
-    if (extension.clearcoatFactor !== undefined) {
+    if (extension.clearcoatFactor != undefined) {
       materialParams.clearcoat = extension.clearcoatFactor
     }
 
-    if (extension.clearcoatTexture !== undefined) {
+    if (extension.clearcoatTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.clearcoatTexture).then((map) => {
           materialParams.clearcoatMap = map
@@ -204,11 +208,11 @@ export const KHRClearcoatExtensionComponent = defineComponent({
       )
     }
 
-    if (extension.clearcoatRoughnessFactor !== undefined) {
+    if (extension.clearcoatRoughnessFactor != undefined) {
       materialParams.clearcoatRoughness = extension.clearcoatRoughnessFactor
     }
 
-    if (extension.clearcoatRoughnessTexture !== undefined) {
+    if (extension.clearcoatRoughnessTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.clearcoatRoughnessTexture).then((map) => {
           materialParams.clearcoatRoughnessMap = map
@@ -216,14 +220,14 @@ export const KHRClearcoatExtensionComponent = defineComponent({
       )
     }
 
-    if (extension.clearcoatNormalTexture?.index !== undefined) {
+    if (extension.clearcoatNormalTexture?.index != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.clearcoatNormalTexture).then((map) => {
           materialParams.clearcoatNormalMap = map
         })
       )
 
-      if (extension.clearcoatNormalTexture.scale !== undefined) {
+      if (extension.clearcoatNormalTexture.scale != undefined) {
         const scale = extension.clearcoatNormalTexture.scale
 
         materialParams.clearcoatNormalScale = new Vector2(scale, scale)
@@ -291,11 +295,11 @@ export const KHRIridescenceExtensionComponent = defineComponent({
     const extension = materialDef.extensions![KHRIridescenceExtensionComponent.jsonID] as ComponentType<
       typeof KHRIridescenceExtensionComponent
     >
-    if (extension.iridescenceFactor !== undefined) {
+    if (extension.iridescenceFactor != undefined) {
       materialParams.iridescence = extension.iridescenceFactor
     }
 
-    if (extension.iridescenceTexture !== undefined) {
+    if (extension.iridescenceTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.iridescenceTexture).then((map) => {
           materialParams.iridescenceMap = map
@@ -303,7 +307,7 @@ export const KHRIridescenceExtensionComponent = defineComponent({
       )
     }
 
-    if (extension.iridescenceIor !== undefined) {
+    if (extension.iridescenceIor != undefined) {
       materialParams.iridescenceIOR = extension.iridescenceIor
     }
 
@@ -311,15 +315,15 @@ export const KHRIridescenceExtensionComponent = defineComponent({
       materialParams.iridescenceThicknessRange = [100, 400]
     }
 
-    if (extension.iridescenceThicknessMinimum !== undefined) {
+    if (extension.iridescenceThicknessMinimum != undefined) {
       materialParams.iridescenceThicknessRange[0] = extension.iridescenceThicknessMinimum
     }
 
-    if (extension.iridescenceThicknessMaximum !== undefined) {
+    if (extension.iridescenceThicknessMaximum != undefined) {
       materialParams.iridescenceThicknessRange[1] = extension.iridescenceThicknessMaximum
     }
 
-    if (extension.iridescenceThicknessTexture !== undefined) {
+    if (extension.iridescenceThicknessTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.iridescenceThicknessTexture).then((map) => {
           materialParams.iridescenceThicknessMap = map
@@ -388,16 +392,16 @@ export const KHRSheenExtensionComponent = defineComponent({
       typeof KHRSheenExtensionComponent
     >
 
-    if (extension.sheenColorFactor !== undefined) {
+    if (extension.sheenColorFactor != undefined) {
       const colorFactor = extension.sheenColorFactor
       materialParams.sheenColor.setRGB(colorFactor[0], colorFactor[1], colorFactor[2], LinearSRGBColorSpace)
     }
 
-    if (extension.sheenRoughnessFactor !== undefined) {
+    if (extension.sheenRoughnessFactor != undefined) {
       materialParams.sheenRoughness = extension.sheenRoughnessFactor
     }
 
-    if (extension.sheenColorTexture !== undefined) {
+    if (extension.sheenColorTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.sheenColorTexture).then((map) => {
           materialParams.sheenColorMap = map
@@ -406,7 +410,7 @@ export const KHRSheenExtensionComponent = defineComponent({
       )
     }
 
-    if (extension.sheenRoughnessTexture !== undefined) {
+    if (extension.sheenRoughnessTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.sheenRoughnessTexture).then((map) => {
           materialParams.sheenRoughnessMap = map
@@ -464,11 +468,11 @@ export const KHRTransmissionExtensionComponent = defineComponent({
     const extension = materialDef.extensions![KHRTransmissionExtensionComponent.jsonID] as ComponentType<
       typeof KHRTransmissionExtensionComponent
     >
-    if (extension.transmissionFactor !== undefined) {
+    if (extension.transmissionFactor != undefined) {
       materialParams.transmission = extension.transmissionFactor
     }
 
-    if (extension.transmissionTexture !== undefined) {
+    if (extension.transmissionTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.transmissionTexture).then((map) => {
           materialParams.transmissionMap = map
@@ -519,9 +523,9 @@ export const KHRVolumeExtensionComponent = defineComponent({
     const extension = materialDef.extensions![KHRVolumeExtensionComponent.jsonID] as ComponentType<
       typeof KHRVolumeExtensionComponent
     >
-    materialParams.thickness = extension.thicknessFactor !== undefined ? extension.thicknessFactor : 0
+    materialParams.thickness = extension.thicknessFactor != undefined ? extension.thicknessFactor : 0
 
-    if (extension.thicknessTexture !== undefined) {
+    if (extension.thicknessTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.thicknessTexture).then((map) => {
           materialParams.thicknessMap = map
@@ -585,7 +589,7 @@ export const KHRIorExtensionComponent = defineComponent({
     const extension = materialDef.extensions![KHRIorExtensionComponent.jsonID] as ComponentType<
       typeof KHRIorExtensionComponent
     >
-    materialParams.ior = extension.ior !== undefined ? extension.ior : 1.5
+    materialParams.ior = extension.ior != undefined ? extension.ior : 1.5
 
     return Promise.resolve()
   },
@@ -625,7 +629,7 @@ export const KHRSpecularExtensionComponent = defineComponent({
     const extension = materialDef.extensions![KHRSpecularExtensionComponent.jsonID] as ComponentType<
       typeof KHRSpecularExtensionComponent
     >
-    materialParams.specularIntensity = extension.specularFactor !== undefined ? extension.specularFactor : 1.0
+    materialParams.specularIntensity = extension.specularFactor != undefined ? extension.specularFactor : 1.0
 
     if (extension?.specularTexture) {
       pending.push(
@@ -696,9 +700,9 @@ export const EXTBumpExtensionComponent = defineComponent({
     const extension = materialDef.extensions![EXTBumpExtensionComponent.jsonID] as ComponentType<
       typeof EXTBumpExtensionComponent
     >
-    materialParams.bumpScale = extension.bumpFactor !== undefined ? extension.bumpFactor : 1.0
+    materialParams.bumpScale = extension.bumpFactor != undefined ? extension.bumpFactor : 1.0
 
-    if (extension.bumpTexture !== undefined) {
+    if (extension.bumpTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.bumpTexture).then((map) => {
           materialParams.bumpMap = map
@@ -716,7 +720,7 @@ export const EXTBumpExtensionComponent = defineComponent({
       delete materialValues.bumpScale
     }
     if (materialValues.bumpMap != undefined) {
-      extension.bumpTexture = materialValues.bumpMap.contents
+      if (materialValues.bumpMap.contents != undefined) extension.bumpTexture = materialValues.bumpMap.contents
       delete materialValues.bumpMap
     }
 
@@ -748,15 +752,15 @@ export const KHRAnisotropyExtensionComponent = defineComponent({
     const extension = materialDef.extensions![KHRAnisotropyExtensionComponent.jsonID] as ComponentType<
       typeof KHRAnisotropyExtensionComponent
     >
-    if (extension.anisotropyStrength !== undefined) {
+    if (extension.anisotropyStrength != undefined) {
       materialParams.anisotropy = extension.anisotropyStrength
     }
 
-    if (extension.anisotropyRotation !== undefined) {
+    if (extension.anisotropyRotation != undefined) {
       materialParams.anisotropyRotation = extension.anisotropyRotation
     }
 
-    if (extension.anisotropyTexture !== undefined) {
+    if (extension.anisotropyTexture != undefined) {
       pending.push(
         GLTFLoaderFunctions.assignTexture(options, extension.anisotropyTexture).then((map) => {
           materialParams.anisotropyMap = map
@@ -823,19 +827,19 @@ export const KHRTextureTransformExtensionComponent = defineComponent({
     /** @todo this throws hookstate 109... */
     // texture = texture.clone()
 
-    if (transform.texCoord !== undefined) {
+    if (transform.texCoord != undefined) {
       texture.channel = transform.texCoord
     }
 
-    if (transform.offset !== undefined) {
+    if (transform.offset != undefined) {
       texture.offset.fromArray(transform.offset)
     }
 
-    if (transform.rotation !== undefined) {
+    if (transform.rotation != undefined) {
       texture.rotation = transform.rotation
     }
 
-    if (transform.scale !== undefined) {
+    if (transform.scale != undefined) {
       texture.repeat.fromArray(transform.scale)
     }
 

--- a/packages/engine/src/gltf/MaterialExtensionComponents.tsx
+++ b/packages/engine/src/gltf/MaterialExtensionComponents.tsx
@@ -690,10 +690,6 @@ export const EXTBumpExtensionComponent = defineComponent({
     bumpTexture: S.Optional(TextureInfoSchema)
   }),
 
-  getMaterialType() {
-    return MeshPhysicalMaterial
-  },
-
   extendMaterialParams(options: GLTFParserOptions, materialParams: any, materialDef: GLTF.IMaterial) {
     const pending = [] as Promise<any>[]
 

--- a/packages/engine/src/gltf/exportGLTFScene.ts
+++ b/packages/engine/src/gltf/exportGLTFScene.ts
@@ -877,28 +877,14 @@ export const materialExtensions = [
   KHRAnisotropyExtensionComponent
 ]
 
-const exportMaterial = async (
-  entity: Entity,
-  gltf: GLTF.IGLTF,
-  context: GLTFSceneExportContext
-): Promise<number | null> => {
-  const material = getComponent(entity, MaterialStateComponent).material
-
-  const cache = context.cache.materials
-  if (cache.has(material)) return cache.get(material)!
-
-  const materialEntityUUID = getComponent(entity, UUIDComponent)
-
-  //do not export fallback material
-  if (
-    materialEntityUUID.entityID === MaterialStateComponent.fallbackMaterialUUIDPair.entityID &&
-    materialEntityUUID.entitySourceID === MaterialStateComponent.fallbackMaterialUUIDPair.entitySourceID
-  )
-    return null
-
+export const materialToMaterialDef = async (
+  material: Material,
+  name: string,
+  handleTexture: ((texture: Texture, field: string) => Promise<number | void> | undefined) | null = null
+) => {
   const materialDef: GLTF.IMaterial = {}
 
-  materialDef.name = getComponent(entity, NameComponent)
+  materialDef.name = name
 
   if (material.transparent) {
     materialDef.alphaMode = 'BLEND'
@@ -923,10 +909,8 @@ const exportMaterial = async (
       }
       const texture = value as Texture
 
-      if (texture.isTexture) {
-        if (field === 'envMap') return //for skipping environment maps which cause errors
-        if ((texture as CubeTexture).isCubeTexture) return //for skipping environment maps which cause errors
-        const textureIndex = await exportTexture(texture, gltf, context)
+      if (texture.isTexture && handleTexture) {
+        const textureIndex = await handleTexture(texture, field)
         if (typeof textureIndex !== 'number') return
         argEntry.contents = {
           index: textureIndex,
@@ -955,6 +939,39 @@ const exportMaterial = async (
     }
   }
 
+  return materialDef
+}
+
+const exportMaterial = async (
+  entity: Entity,
+  gltf: GLTF.IGLTF,
+  context: GLTFSceneExportContext
+): Promise<number | null> => {
+  const material = getComponent(entity, MaterialStateComponent).material
+
+  const cache = context.cache.materials
+  if (cache.has(material)) return cache.get(material)!
+
+  const materialEntityUUID = getComponent(entity, UUIDComponent)
+
+  //do not export fallback material
+  if (
+    materialEntityUUID.entityID === MaterialStateComponent.fallbackMaterialUUIDPair.entityID &&
+    materialEntityUUID.entitySourceID === MaterialStateComponent.fallbackMaterialUUIDPair.entitySourceID
+  )
+    return null
+
+  const materialDef: GLTF.IMaterial = await materialToMaterialDef(
+    material,
+    getComponent(entity, NameComponent),
+    (texture, field) => {
+      if (field === 'envMap') return //for skipping environment maps which cause errors
+      if ((texture as CubeTexture).isCubeTexture) return //for skipping environment maps which cause errors
+      return exportTexture(texture, gltf, context)
+    }
+  )
+
+  materialDef.extensions ??= {}
   const components = getAllComponents(entity)
   for (const component of components) {
     if (!component.jsonID) continue

--- a/packages/engine/src/gltf/exportGLTFScene.ts
+++ b/packages/engine/src/gltf/exportGLTFScene.ts
@@ -826,7 +826,10 @@ const _builtinMaterialDefs = {
   color: (materialDef: GLTF.IMaterial, value: MaterialColorValue) => {
     if (!materialDef.pbrMetallicRoughness) materialDef.pbrMetallicRoughness = {}
     // Set RGB array
-    materialDef.pbrMetallicRoughness.baseColorFactor = value.contents.toArray()
+    if (value.contents.isColor) materialDef.pbrMetallicRoughness.baseColorFactor = value.contents.toArray()
+    else {
+      materialDef.pbrMetallicRoughness.baseColorFactor = new Color(value.contents).toArray()
+    }
     // Set A channel to GLTF default because color is just RGB
     materialDef.pbrMetallicRoughness.baseColorFactor[3] = 1
   },
@@ -854,7 +857,10 @@ const _builtinMaterialDefs = {
     materialDef.pbrMetallicRoughness.metallicRoughnessTexture = value.contents
   },
   emissive: (materialDef: GLTF.IMaterial, value: MaterialColorValue) => {
-    materialDef.emissiveFactor = value.contents.toArray()
+    if (value.contents.isColor) materialDef.emissiveFactor = value.contents.toArray()
+    else {
+      materialDef.emissiveFactor = new Color(value.contents).toArray()
+    }
   },
   emissiveMap: (materialDef: GLTF.IMaterial, value: MaterialTextureValue) => {
     materialDef.emissiveTexture = value.contents
@@ -876,6 +882,30 @@ export const materialExtensions = [
   EXTBumpExtensionComponent,
   KHRAnisotropyExtensionComponent
 ]
+
+export const materialValuesToMaterialDef = (materialValues: Record<string, MaterialValue>) => {
+  const materialDef: GLTF.IMaterial = {}
+
+  for (const key in _builtinMaterialDefs) {
+    const resultValue = materialValues[key]
+    if (resultValue?.contents != null) {
+      _builtinMaterialDefs[key](materialDef, resultValue)
+      delete materialValues[key]
+    }
+  }
+
+  materialDef.extensions ??= {}
+  for (const ext of materialExtensions) {
+    if (typeof ext.exportMaterialExtension === 'function') {
+      const extension = ext.exportMaterialExtension(materialValues)
+      if (extension && Object.keys(extension).length > 0) {
+        materialDef.extensions[ext.jsonID] = extension
+      }
+    }
+  }
+
+  return materialDef
+}
 
 export const materialToMaterialDef = async (
   material: Material,
@@ -921,25 +951,7 @@ export const materialToMaterialDef = async (
     })
   )
 
-  for (const key in _builtinMaterialDefs) {
-    const resultValue = result[key]
-    if (resultValue?.contents != null) {
-      _builtinMaterialDefs[key](materialDef, resultValue)
-      delete result[key]
-    }
-  }
-
-  materialDef.extensions ??= {}
-  for (const ext of materialExtensions) {
-    if (typeof ext.exportMaterialExtension === 'function') {
-      const extension = ext.exportMaterialExtension(result)
-      if (extension && Object.keys(extension).length > 0) {
-        materialDef.extensions[ext.jsonID] = extension
-      }
-    }
-  }
-
-  return materialDef
+  return { ...materialDef, ...materialValuesToMaterialDef(result) }
 }
 
 const exportMaterial = async (

--- a/packages/engine/src/gltf/exportGLTFScene.ts
+++ b/packages/engine/src/gltf/exportGLTFScene.ts
@@ -366,7 +366,7 @@ export async function exportGLTFScene(
   relativePath: string,
   exportRoot = true,
   exportExtensionTypes: ExportExtension[] = defaultExportExtensionList.map((ext) => ext())
-) {
+): Promise<[GLTF.IGLTF, ...File[]]> {
   const exportExtensions = exportExtensionTypes //.map((ext) => new ext())
 
   const gltf = {
@@ -463,8 +463,6 @@ export async function exportGLTFScene(
 
   // destroy hookstate store
   destroy(context.materialPromises)
-
-  if (!gltf) return []
 
   // const blob = [new Blob([JSON.stringify(gltf, null, 2)], { type: 'application/gltf+json' })]
   // const gltfFile = new File(blob, relativePath)

--- a/packages/engine/src/gltf/migrateEEMaterial.ts
+++ b/packages/engine/src/gltf/migrateEEMaterial.ts
@@ -66,7 +66,6 @@ export const migrateEEMaterial = (gltf: GLTF.IGLTF) => {
     const converted = materialValuesToMaterialDef(eeMaterial.args)
     delete material.extensions.EE_material
     Object.assign(material, converted)
-    console.log(material)
   }
 
   return gltf

--- a/packages/engine/src/gltf/migrateEEMaterial.ts
+++ b/packages/engine/src/gltf/migrateEEMaterial.ts
@@ -24,6 +24,7 @@ Infinite Reality Engine. All Rights Reserved.
 */
 
 import { GLTF } from '@gltf-transform/core'
+import { materialValuesToMaterialDef } from './exportGLTFScene'
 
 export const EEMaterialMigrationRegistry = {} as Record<string, string> // prototype name to jsonID
 
@@ -60,26 +61,12 @@ export const migrateEEMaterial = (gltf: GLTF.IGLTF) => {
   for (const material of gltf.materials || []) {
     if (!material.extensions) continue
     const eeMaterial = material.extensions!.EE_material as any
-    if (!eeMaterial?.prototype) continue
-    if (!EEMaterialMigrationRegistry[eeMaterial.prototype]) continue
-    if (eeMaterial.prototype === 'MeshBasicMaterial') {
-      material.extensions.KHR_materials_unlit = {}
-      continue
-    } else if (eeMaterial.prototype === 'MeshPhysicalMaterial') {
-      material.extensions.KHR_materials_specular = {
-        specularFactor: eeMaterial.args.specularIntensity,
-        specularTexture: eeMaterial.args.specularIntensityMap,
-        specularColorFactor: eeMaterial.args.specularColor,
-        specularColorTexture: eeMaterial.args.specularColorMap
-      }
-      continue
-    }
-    const jsonID = EEMaterialMigrationRegistry[eeMaterial.prototype]
-    material.extensions[jsonID] = {
-      ...Object.fromEntries(
-        Object.entries(eeMaterial.args).map(([k, v]: [string, { type: string; contents: any }]) => [k, v.contents])
-      )
-    }
+    if (!eeMaterial?.args) continue
+
+    const converted = materialValuesToMaterialDef(eeMaterial.args)
+    delete material.extensions.EE_material
+    Object.assign(material, converted)
+    console.log(material)
   }
 
   return gltf


### PR DESCRIPTION
## Summary
Migrate all extensions from EE_material
Fix exportMaterialsGLTF returning an array and being serialized as an array
Bump map extension doesn't require a MeshPhysicalMaterial
Prevent textures in the process of being restored from being uploaded in the render loop

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
