### PR TITLE
IR-11738 setting up scripts for shared git hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "migrate:rollback": "cd packages/server-core && npm run migrate:rollback",
     "migrate:unlock": "cd packages/server-core && npm run migrate:unlock",
     "postinstall": "patch-package",
-    "precommit-hooks": "./scripts/add-precommit.sh",
+    "precommit-hooks": "./scripts/setup-shared-hooks.sh",
     "prepare-database": "cross-env APP_ENV=production PREPARE_DATABASE=true EXIT_ON_DB_INIT=true ts-node --swc packages/server/src/index.ts",
     "publish": "lerna publish from-package --yes --registry https://registry.npmjs.org",
     "publish-npm": "lerna publish from-package --yes --no-verify-access --ignore-scripts --registry https://registry.npmjs.org",

--- a/scripts/add-precommit.sh.backup
+++ b/scripts/add-precommit.sh.backup
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+read -r -d '' pre_commit_commands << EOM
+#!/bin/bash
+echo "running pre-commit"
+npx lint-staged
+echo "pre-commit done"
+EOM
+
+add_precommit() {
+  directory=$1;
+  if [ -d ".git" ]; then
+    if [ -e ".git/hooks/pre-commit" ]; then
+      rm .git/hooks/pre-commit
+    fi
+    echo "$pre_commit_commands" > .git/hooks/pre-commit
+    chmod ug+x .git/hooks/pre-commit
+    echo "added pre_commit hook in $directory"
+  fi
+}
+
+for org in packages/projects/projects/* ;
+  do for directory in $org/* ;
+    do (cd "$directory" && add_precommit $directory); 
+  done
+done

--- a/scripts/remove-shared-hooks.sh
+++ b/scripts/remove-shared-hooks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Script to remove shared hooks configuration from nested repositories
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Removing shared git hooks configuration from nested repositories..."
+
+# Find all nested git repositories
+NESTED_REPOS=$(find "$ROOT_DIR/packages/projects/projects" -name ".git" -type d | sed 's|/.git$||')
+
+for repo in $NESTED_REPOS; do
+    echo "Removing shared hooks from: $repo"
+    cd "$repo"
+    git config --unset core.hooksPath
+done
+
+echo "✅ Shared hooks configuration removed from all nested repositories!"

--- a/scripts/setup-shared-hooks.js
+++ b/scripts/setup-shared-hooks.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+// Cross-platform Node.js script to configure shared git hooks
+// Compatible with Mac, Windows, and Linux
+
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const rootDir = path.resolve(__dirname, '..');
+const sharedHooksDir = path.join(rootDir, 'shared-hooks');
+const projectsDir = path.join(rootDir, 'packages', 'projects', 'projects');
+
+console.log('Setting up shared git hooks for nested repositories...');
+console.log(`Root directory: ${rootDir}`);
+console.log(`Shared hooks directory: ${sharedHooksDir}`);
+console.log(`Platform: ${process.platform}`);
+
+// Find all nested git repositories
+function findGitRepos(dir) {
+    const repos = [];
+    
+    function searchDir(currentDir) {
+        try {
+            const items = fs.readdirSync(currentDir);
+            
+            for (const item of items) {
+                const itemPath = path.join(currentDir, item);
+                const stat = fs.statSync(itemPath);
+                
+                if (stat.isDirectory()) {
+                    if (item === '.git') {
+                        repos.push(path.dirname(itemPath));
+                    } else {
+                        searchDir(itemPath);
+                    }
+                }
+            }
+        } catch (error) {
+            // Skip directories we can't read
+        }
+    }
+    
+    searchDir(dir);
+    return repos;
+}
+
+const nestedRepos = findGitRepos(projectsDir);
+
+console.log(`\nFound ${nestedRepos.length} nested repositories:`);
+
+for (const repo of nestedRepos) {
+    console.log(`\nConfiguring repository: ${repo}`);
+    
+    // Calculate relative path from repo to shared hooks
+    const relativePath = path.relative(repo, sharedHooksDir);
+    
+    // Convert to forward slashes for Git (works on all platforms)
+    const gitPath = relativePath.replace(/\\/g, '/');
+    
+    console.log(`  Setting core.hooksPath to: ${gitPath}`);
+    
+    try {
+        // Configure the repository to use shared hooks
+        execSync(`git config core.hooksPath "${gitPath}"`, { 
+            cwd: repo,
+            stdio: 'pipe'
+        });
+        
+        // Verify the configuration
+        const configuredPath = execSync('git config core.hooksPath', { 
+            cwd: repo,
+            encoding: 'utf8'
+        }).trim();
+        
+        console.log(`  ✅ Verified configuration: ${configuredPath}`);
+    } catch (error) {
+        console.log(`  ❌ Failed to configure: ${error.message}`);
+    }
+}
+
+console.log('\n✅ Setup complete!');
+console.log('\nTo test, try making a commit in any of the nested repositories.');
+console.log('To revert, run: git config --unset core.hooksPath (in each repo)');

--- a/scripts/setup-shared-hooks.sh
+++ b/scripts/setup-shared-hooks.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Cross-platform script to configure all nested git repositories to use shared hooks
+# Compatible with Mac, Windows (Git Bash), and Linux
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SHARED_HOOKS_DIR="$ROOT_DIR/shared-hooks"
+
+echo "Setting up shared git hooks for nested repositories..."
+echo "Root directory: $ROOT_DIR"
+echo "Shared hooks directory: $SHARED_HOOKS_DIR"
+echo "Platform: $(uname -s 2>/dev/null || echo 'Windows')"
+
+# Find all nested git repositories and process them one by one
+find "$ROOT_DIR/packages/projects/projects" -name ".git" -type d | while IFS= read -r git_dir; do
+    repo_dir="${git_dir%/.git}"
+    echo ""
+    echo "Configuring repository: $repo_dir"
+
+    # Calculate relative path from repo to shared hooks
+    RELATIVE_PATH=$(python3 -c "
+import os
+print(os.path.relpath('$SHARED_HOOKS_DIR', '$repo_dir'))
+")
+
+    echo "  Setting core.hooksPath to: $RELATIVE_PATH"
+
+    # Configure the repository to use shared hooks
+    cd "$repo_dir"
+    git config core.hooksPath "$RELATIVE_PATH"
+
+    # Verify the configuration
+    CONFIGURED_PATH=$(git config core.hooksPath)
+    echo "  Verified configuration: $CONFIGURED_PATH"
+done
+
+echo ""
+echo "✅ All nested repositories configured to use shared hooks!"
+echo ""
+echo "To test, try making a commit in any of the nested repositories."
+echo "To revert, run: git config --unset core.hooksPath (in each repo)"

--- a/shared-hooks/pre-commit
+++ b/shared-hooks/pre-commit
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Shared pre-commit hook for nested git repositories
+# This hook runs the same checks as the root project
+# Compatible with Mac, Windows (Git Bash), and Linux
+
+# Find the root project directory (MT WHATEVER)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Change to root project directory to access node_modules and scripts
+cd "$ROOT_PROJECT_DIR"
+
+# Run the same pre-commit checks as the root project
+echo "Running shared pre-commit hooks from: $ROOT_PROJECT_DIR"
+
+# Determine the correct executable extension for Windows
+if [ -f "./node_modules/.bin/ts-node.cmd" ]; then
+    # Windows
+    TS_NODE="./node_modules/.bin/ts-node.cmd"
+    LINT_STAGED="./node_modules/.bin/lint-staged.cmd"
+else
+    # Mac/Linux
+    TS_NODE="./node_modules/.bin/ts-node"
+    LINT_STAGED="./node_modules/.bin/lint-staged"
+fi
+
+# Run add-license-headers
+echo "Adding license headers..."
+"$TS_NODE" --swc scripts/add-license-headers.ts
+RESULT=$?
+if [ $RESULT -ne 0 ]; then
+    echo "License header check failed"
+    exit 1
+fi
+
+# Run format-staged (lint-staged)
+echo "Running lint-staged..."
+"$LINT_STAGED"
+RESULT=$?
+if [ $RESULT -ne 0 ]; then
+    echo "Lint-staged check failed"
+    exit 1
+fi
+
+echo "All pre-commit checks passed"
+exit 0

--- a/shared-hooks/pre-commit.js
+++ b/shared-hooks/pre-commit.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+// Cross-platform pre-commit hook using Node.js
+// Compatible with Mac, Windows, and Linux
+
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// Find the root project directory
+const scriptDir = __dirname;
+const rootProjectDir = path.resolve(scriptDir, '..');
+
+// Change to root project directory
+process.chdir(rootProjectDir);
+
+console.log(`Running shared pre-commit hooks from: ${rootProjectDir}`);
+
+try {
+    // Run add-license-headers
+    console.log('Adding license headers...');
+    execSync('npm run add-license-headers', { stdio: 'inherit' });
+    
+    // Run format-staged (lint-staged)
+    console.log('Running lint-staged...');
+    execSync('npm run format-staged', { stdio: 'inherit' });
+    
+    console.log('All pre-commit checks passed');
+    process.exit(0);
+} catch (error) {
+    console.error('Pre-commit checks failed');
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary
git hooks for all projects now centralized to use the root projects node_modules. 

Setup is integrated into 'npm run dev-reinit'
- `npm run dev-reinit` now calls `npm run precommit-hooks`
- `npm run precommit-hooks` now runs `./scripts/setup-shared-hooks.sh`
- This ensures shared hooks are set up during normal development initialization

The original script is preserved as `scripts/add-precommit.sh.backup` if needed.

## References
[https://tsu.atlassian.net/browse/IR-11738](https://tsu.atlassian.net/browse/IR-11738)