### PR TITLE
move color picker to show on viewport

### DIFF
--- a/packages/ui/src/primitives/tailwind/Color/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Color/index.tsx
@@ -55,6 +55,7 @@ export function ColorInput({
   const [isPickerOpen, setIsPickerOpen] = useState(false)
   const pickerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLDivElement>(null)
+  const [openUp, setOpenUp] = useState<boolean>(false)
 
   const handleTogglePicker = () => {
     if (!isPickerOpen) {
@@ -92,6 +93,17 @@ export function ColorInput({
     }
   }, [hexColor, onRelease])
 
+  // Color picker to pop up depending on placement of the window's inner
+  useEffect(() => {
+    if (!pickerRef.current) return
+
+    const rect = pickerRef.current.getBoundingClientRect()
+    const spaceBelow = window.innerHeight - rect.bottom
+    const spaceAbove = rect.top
+
+    setOpenUp(spaceBelow < 300 && spaceAbove > 300)
+  }, [pickerRef.current])
+
   return (
     <div
       tabIndex={0} // Make the div focusable
@@ -110,7 +122,7 @@ export function ColorInput({
         {isPickerOpen && ( //state to track open/close of color picker
           <div ref={pickerRef}>
             <SketchPicker
-              className={twMerge('absolute right-4 z-10 mt-5 ', sketchPickerClassName)}
+              className={twMerge('absolute right-4 z-10 mt-5 ', openUp ? 'bottom-full' : 'mt-5', sketchPickerClassName)}
               color={hexColor}
               onChange={handleChange}
               disableAlpha={true}


### PR DESCRIPTION
## Summary
[IR-10680](https://tsu.atlassian.net/browse/IR-10680)

**Actual Result:**
Color panel is not fully visible when user wants to change skybox color, user can access it

**Expected Result:**
Color panel should be fully displayed to the user

## Subtasks Checklist

## Breaking Changes

## References
[IR-10680](https://tsu.atlassian.net/browse/IR-10680)

## QA Steps
- In studio editor's hierarchy list, select skybox
- Scroll to properties and select Color in Sky Type
- Select color (color picker should be popping above the bottom viewport


<img width="558" height="556" alt="image" src="https://github.com/user-attachments/assets/d4c31dbf-c0e7-4d54-9ce5-d4e85c2576c5" />


[IR-10680]: https://tsu.atlassian.net/browse/IR-10680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IR-10680]: https://tsu.atlassian.net/browse/IR-10680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ