### PR TITLE
[IR-11764] Make engine vector database setup optional

### DIFF
--- a/.env.local.default
+++ b/.env.local.default
@@ -90,6 +90,7 @@ MYSQL_TEST_PORT=3305
 MYSQL_TEST_URL=
 
 # PostgreSQL Vector Database variables
+VECTORDB_ENABLED=false
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DATABASE=vector-db
@@ -233,7 +234,7 @@ CHARGEBEE_SITE=ir-engine-test
 CHARGEBEE_API_KEY=
 # --------------------------------
 
-# Redish variables ---------------
+# Redis variables ---------------
 REDIS_ENABLED=true
 REDIS_ADDRESS=localhost
 REDIS_PORT=6379

--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -135,6 +135,7 @@ db.url =
  * Vector Database (PostgreSQL with PGVector)
  */
 export const vectordb = {
+  enabled: process.env.VECTORDB_ENABLED === 'true',
   username: testEnabled ? process.env.POSTGRES_TEST_USER! : process.env.POSTGRES_USER!,
   password: testEnabled ? process.env.POSTGRES_TEST_PASSWORD! : process.env.POSTGRES_PASSWORD!,
   database: testEnabled ? process.env.POSTGRES_TEST_DATABASE! : process.env.POSTGRES_DATABASE!,

--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -272,7 +272,10 @@ export const createFeathersKoaApp = async (
   // Doesn't appear anything else uses it.
   app.set('env', 'production')
   app.configure(mysql)
-  app.configure(postgres)
+
+  if (appConfig.vectordb.enabled) {
+    app.configure(postgres)
+  }
 
   // Enable security, CORS, compression, favicon and body parsing
   app.use(errorHandler()) // in koa no option to pass logger object its a async function instead and must be set first

--- a/packages/server-core/src/media/static-resource-search/static-resource-search.test.ts
+++ b/packages/server-core/src/media/static-resource-search/static-resource-search.test.ts
@@ -40,177 +40,122 @@ import { destroyEngine } from '@ir-engine/ecs'
 import { v4 as uuidv4 } from 'uuid'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Application, HookContext } from '../../../declarations'
+import { default as appConfig } from '../../appconfig'
 import { createFeathersKoaApp, tearDownAPI } from '../../createApp'
 import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 
 describe('static-resource-search service', () => {
-  let app: Application
-  let testUserApiKey: UserApiKeyType
-  let testProject
-  let testStaticResourceId: string
-  let testVectorEntryId: string
+  if (appConfig.vectordb.enabled) {
+    let app: Application
+    let testUserApiKey: UserApiKeyType
+    let testProject
+    let testStaticResourceId: string
+    let testVectorEntryId: string
 
-  const getProjectParams = () => ({
-    provider: 'rest',
-    headers: {
-      authorization: `Bearer ${testUserApiKey.token}`
-    }
-  })
-
-  beforeEach(async () => {
-    app = await createFeathersKoaApp()
-    await app.setup()
-
-    const name = ('test-project-user-name-' + uuidv4()) as UserName
-
-    const testUser = await app.service(userPath).create({
-      name,
-      isGuest: false
+    const getProjectParams = () => ({
+      provider: 'rest',
+      headers: {
+        authorization: `Bearer ${testUserApiKey.token}`
+      }
     })
 
-    await app.service(scopePath).create({ userId: testUser.id, type: 'editor:write' as ScopeType })
+    beforeEach(async () => {
+      app = await createFeathersKoaApp()
+      await app.setup()
 
-    testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
+      const name = ('test-project-user-name-' + uuidv4()) as UserName
 
-    await app.service(identityProviderPath)._create(
-      await identityProviderDataResolver.resolve(
-        {
-          type: 'github',
-          token: `test-token-${Math.round(Math.random() * 1000)}`,
-          userId: testUser.id
-        },
-        {} as HookContext
+      const testUser = await app.service(userPath).create({
+        name,
+        isGuest: false
+      })
+
+      await app.service(scopePath).create({ userId: testUser.id, type: 'editor:write' as ScopeType })
+
+      testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
+
+      await app.service(identityProviderPath)._create(
+        await identityProviderDataResolver.resolve(
+          {
+            type: 'github',
+            token: `test-token-${Math.round(Math.random() * 1000)}`,
+            userId: testUser.id
+          },
+          {} as HookContext
+        )
       )
-    )
 
-    // Create test project
-    const projectName = `testorg/test-project-${uuidv4().slice(0, 8)}`
-    testProject = await app.service(projectPath).create(
-      {
-        name: projectName
-      },
-      getProjectParams()
-    )
+      // Create test project
+      const projectName = `testorg/test-project-${uuidv4().slice(0, 8)}`
+      testProject = await app.service(projectPath).create(
+        {
+          name: projectName
+        },
+        getProjectParams()
+      )
 
-    // Create test static resource
-    const testStaticResource = {
-      key: 'test/red-sports-car.glb',
-      name: 'red-sports-car.glb',
-      description: 'A beautiful red sports car model',
-      type: 'model',
-      mimeType: 'model/gltf-binary',
-      project: testProject.name,
-      hash: 'test-hash-123'
-    }
-
-    const resourceResult = await app.service(staticResourcePath).create(testStaticResource)
-
-    testStaticResourceId = resourceResult.id
-
-    // Create corresponding vector entry
-    const testVectorEntry = {
-      staticResourceId: testStaticResourceId,
-      caption: 'A beautiful red sports car model',
-      material: 'metal',
-      style: 'modern',
-      color: 'red'
-    }
-
-    const vectorResult = await app.service(staticResourceVectorPath).create(testVectorEntry)
-    testVectorEntryId = vectorResult.id
-  })
-
-  afterEach(async () => {
-    // Clean up after each test
-    if (testVectorEntryId) {
-      try {
-        await app.service(staticResourceVectorPath).remove(testVectorEntryId)
-      } catch (error) {
-        // Ignore cleanup errors
+      // Create test static resource
+      const testStaticResource = {
+        key: 'test/red-sports-car.glb',
+        name: 'red-sports-car.glb',
+        description: 'A beautiful red sports car model',
+        type: 'model',
+        mimeType: 'model/gltf-binary',
+        project: testProject.name,
+        hash: 'test-hash-123'
       }
-    }
 
-    if (testStaticResourceId) {
-      try {
-        await app.service(staticResourcePath).remove(testStaticResourceId)
-      } catch (error) {
-        // Ignore cleanup errors
+      const resourceResult = await app.service(staticResourcePath).create(testStaticResource)
+
+      testStaticResourceId = resourceResult.id
+
+      // Create corresponding vector entry
+      const testVectorEntry = {
+        staticResourceId: testStaticResourceId,
+        caption: 'A beautiful red sports car model',
+        material: 'metal',
+        style: 'modern',
+        color: 'red'
       }
-    }
 
-    await tearDownAPI()
-    destroyEngine()
-  })
-
-  it('should be registered', () => {
-    const service = app.service(staticResourceSearchPath)
-    expect(service).toBeTruthy()
-  })
-
-  it('should perform basic semantic search', async () => {
-    const searchService = app.service(staticResourceSearchPath)
-
-    const results = await searchService.find({
-      query: {
-        semanticSearch: 'red car',
-        $limit: 10
-      },
-      isInternal: true
+      const vectorResult = await app.service(staticResourceVectorPath).create(testVectorEntry)
+      testVectorEntryId = vectorResult.id
     })
 
-    expect(results).toBeTruthy()
-    expect(results.data).toBeDefined()
-    expect(Array.isArray(results.data)).toBe(true)
-    expect(results.total).toBeGreaterThanOrEqual(0)
-    expect(results.limit).toBe(10)
-    expect(results.skip).toBe(0)
-  })
+    afterEach(async () => {
+      // Clean up after each test
+      if (testVectorEntryId) {
+        try {
+          await app.service(staticResourceVectorPath).remove(testVectorEntryId)
+        } catch (error) {
+          // Ignore cleanup errors
+        }
+      }
 
-  it('should return search results with proper structure', async () => {
-    const searchService = app.service(staticResourceSearchPath)
+      if (testStaticResourceId) {
+        try {
+          await app.service(staticResourcePath).remove(testStaticResourceId)
+        } catch (error) {
+          // Ignore cleanup errors
+        }
+      }
 
-    const results = await searchService.find({
-      query: {
-        semanticSearch: 'sports car',
-        searchField: 'caption',
-        $limit: 5
-      },
-      isInternal: true
+      await tearDownAPI()
+      destroyEngine()
     })
 
-    if (results.data.length > 0) {
-      const result = results.data[0]
+    it('should be registered', () => {
+      const service = app.service(staticResourceSearchPath)
+      expect(service).toBeTruthy()
+    })
 
-      // Check static resource fields
-      expect(result.id).toBeDefined()
-      expect(result.key).toBeDefined()
-      expect(result.name).toBeDefined()
-      expect(result.type).toBeDefined()
-      expect(result.hash).toBeDefined()
-      expect(result.url).toBeDefined()
-      expect(result.createdAt).toBeDefined()
-      expect(result.updatedAt).toBeDefined()
+    it('should perform basic semantic search', async () => {
+      const searchService = app.service(staticResourceSearchPath)
 
-      // Check search metadata
-      expect(result.searchScore).toBeDefined()
-      expect(typeof result.searchScore).toBe('number')
-      expect(result.searchScore).toBeGreaterThanOrEqual(0)
-      expect(result.searchScore).toBeLessThanOrEqual(1)
-      expect(result.matchedField).toBeDefined()
-    }
-  })
-
-  it('should handle different search fields', async () => {
-    const searchService = app.service(staticResourceSearchPath)
-
-    const searchFields = ['caption', 'material', 'style', 'color', 'combined']
-
-    for (const field of searchFields) {
       const results = await searchService.find({
         query: {
-          semanticSearch: 'test',
-          searchField: field as StaticResourceSearchFieldType,
-          $limit: 5
+          semanticSearch: 'red car',
+          $limit: 10
         },
         isInternal: true
       })
@@ -218,120 +163,180 @@ describe('static-resource-search service', () => {
       expect(results).toBeTruthy()
       expect(results.data).toBeDefined()
       expect(Array.isArray(results.data)).toBe(true)
-    }
-  })
-
-  it('should handle pagination parameters', async () => {
-    const searchService = app.service(staticResourceSearchPath)
-
-    const results = await searchService.find({
-      query: {
-        semanticSearch: 'model',
-        $limit: 3,
-        $skip: 1
-      },
-      isInternal: true
+      expect(results.total).toBeGreaterThanOrEqual(0)
+      expect(results.limit).toBe(10)
+      expect(results.skip).toBe(0)
     })
 
-    expect(results.limit).toBe(3)
-    expect(results.skip).toBe(1)
-    expect(results.data.length).toBeLessThanOrEqual(3)
-  })
+    it('should return search results with proper structure', async () => {
+      const searchService = app.service(staticResourceSearchPath)
 
-  it('should handle similarity threshold', async () => {
-    const searchService = app.service(staticResourceSearchPath)
-
-    const results = await searchService.find({
-      query: {
-        semanticSearch: 'car',
-        similarityThreshold: 0.9, // High threshold
-        $limit: 10
-      },
-      isInternal: true
-    })
-
-    expect(results).toBeTruthy()
-    expect(results.data).toBeDefined()
-    // With high threshold, we might get fewer results
-  })
-
-  it('should handle additional filters', async () => {
-    const searchService = app.service(staticResourceSearchPath)
-
-    const results = await searchService.find({
-      query: {
-        semanticSearch: 'model',
-        type: 'model',
-        project: 'test-project',
-        $limit: 10
-      },
-      isInternal: true
-    })
-
-    expect(results).toBeTruthy()
-    expect(results.data).toBeDefined()
-
-    // All results should match the filters
-    results.data.forEach((result) => {
-      expect(result.type).toBe('model')
-      expect(result.project).toBe('test-project')
-    })
-  })
-
-  it('should throw error for empty query', async () => {
-    const searchService = app.service(staticResourceSearchPath)
-
-    await expect(
-      searchService.find({
+      const results = await searchService.find({
         query: {
-          semanticSearch: '',
+          semanticSearch: 'sports car',
+          searchField: 'caption',
+          $limit: 5
+        },
+        isInternal: true
+      })
+
+      if (results.data.length > 0) {
+        const result = results.data[0]
+
+        // Check static resource fields
+        expect(result.id).toBeDefined()
+        expect(result.key).toBeDefined()
+        expect(result.name).toBeDefined()
+        expect(result.type).toBeDefined()
+        expect(result.hash).toBeDefined()
+        expect(result.url).toBeDefined()
+        expect(result.createdAt).toBeDefined()
+        expect(result.updatedAt).toBeDefined()
+
+        // Check search metadata
+        expect(result.searchScore).toBeDefined()
+        expect(typeof result.searchScore).toBe('number')
+        expect(result.searchScore).toBeGreaterThanOrEqual(0)
+        expect(result.searchScore).toBeLessThanOrEqual(1)
+        expect(result.matchedField).toBeDefined()
+      }
+    })
+
+    it('should handle different search fields', async () => {
+      const searchService = app.service(staticResourceSearchPath)
+
+      const searchFields = ['caption', 'material', 'style', 'color', 'combined']
+
+      for (const field of searchFields) {
+        const results = await searchService.find({
+          query: {
+            semanticSearch: 'test',
+            searchField: field as StaticResourceSearchFieldType,
+            $limit: 5
+          },
+          isInternal: true
+        })
+
+        expect(results).toBeTruthy()
+        expect(results.data).toBeDefined()
+        expect(Array.isArray(results.data)).toBe(true)
+      }
+    })
+
+    it('should handle pagination parameters', async () => {
+      const searchService = app.service(staticResourceSearchPath)
+
+      const results = await searchService.find({
+        query: {
+          semanticSearch: 'model',
+          $limit: 3,
+          $skip: 1
+        },
+        isInternal: true
+      })
+
+      expect(results.limit).toBe(3)
+      expect(results.skip).toBe(1)
+      expect(results.data.length).toBeLessThanOrEqual(3)
+    })
+
+    it('should handle similarity threshold', async () => {
+      const searchService = app.service(staticResourceSearchPath)
+
+      const results = await searchService.find({
+        query: {
+          semanticSearch: 'car',
+          similarityThreshold: 0.9, // High threshold
           $limit: 10
         },
         isInternal: true
       })
-    ).rejects.toThrow()
-  })
 
-  it('should throw error for missing query', async () => {
-    const searchService = app.service(staticResourceSearchPath)
+      expect(results).toBeTruthy()
+      expect(results.data).toBeDefined()
+      // With high threshold, we might get fewer results
+    })
 
-    await expect(
-      searchService.find({
-        //@ts-ignore
+    it('should handle additional filters', async () => {
+      const searchService = app.service(staticResourceSearchPath)
+
+      const results = await searchService.find({
         query: {
+          semanticSearch: 'model',
+          type: 'model',
+          project: 'test-project',
           $limit: 10
         },
         isInternal: true
       })
-    ).rejects.toThrow()
-  })
 
-  it('should handle query length limits', async () => {
-    const searchService = app.service(staticResourceSearchPath)
+      expect(results).toBeTruthy()
+      expect(results.data).toBeDefined()
 
-    // Test very long query
-    const longQuery = 'a'.repeat(600) // Exceeds 500 char limit
-
-    await expect(
-      searchService.find({
-        query: {
-          semanticSearch: longQuery,
-          $limit: 10
-        },
-        isInternal: true
+      // All results should match the filters
+      results.data.forEach((result) => {
+        expect(result.type).toBe('model')
+        expect(result.project).toBe('test-project')
       })
-    ).rejects.toThrow()
-  })
+    })
 
-  it('should not support unsupported methods', async () => {
-    const searchService = app.service(staticResourceSearchPath)
+    it('should throw error for empty query', async () => {
+      const searchService = app.service(staticResourceSearchPath)
 
-    await expect(searchService.get('test-id')).rejects.toThrow('Get method is not supported for search service')
-    await expect(searchService.create({})).rejects.toThrow('Create method is not supported for search service')
-    await expect(searchService.update('test-id', {})).rejects.toThrow(
-      'Update method is not supported for search service'
-    )
-    await expect(searchService.patch('test-id', {})).rejects.toThrow('Patch method is not supported for search service')
-    await expect(searchService.remove('test-id')).rejects.toThrow('Remove method is not supported for search service')
-  })
+      await expect(
+        searchService.find({
+          query: {
+            semanticSearch: '',
+            $limit: 10
+          },
+          isInternal: true
+        })
+      ).rejects.toThrow()
+    })
+
+    it('should throw error for missing query', async () => {
+      const searchService = app.service(staticResourceSearchPath)
+
+      await expect(
+        searchService.find({
+          //@ts-ignore
+          query: {
+            $limit: 10
+          },
+          isInternal: true
+        })
+      ).rejects.toThrow()
+    })
+
+    it('should handle query length limits', async () => {
+      const searchService = app.service(staticResourceSearchPath)
+
+      // Test very long query
+      const longQuery = 'a'.repeat(600) // Exceeds 500 char limit
+
+      await expect(
+        searchService.find({
+          query: {
+            semanticSearch: longQuery,
+            $limit: 10
+          },
+          isInternal: true
+        })
+      ).rejects.toThrow()
+    })
+
+    it('should not support unsupported methods', async () => {
+      const searchService = app.service(staticResourceSearchPath)
+
+      await expect(searchService.get('test-id')).rejects.toThrow('Get method is not supported for search service')
+      await expect(searchService.create({})).rejects.toThrow('Create method is not supported for search service')
+      await expect(searchService.update('test-id', {})).rejects.toThrow(
+        'Update method is not supported for search service'
+      )
+      await expect(searchService.patch('test-id', {})).rejects.toThrow(
+        'Patch method is not supported for search service'
+      )
+      await expect(searchService.remove('test-id')).rejects.toThrow('Remove method is not supported for search service')
+    })
+  }
 })

--- a/packages/server-core/src/media/static-resource-search/static-resource-search.ts
+++ b/packages/server-core/src/media/static-resource-search/static-resource-search.ts
@@ -28,6 +28,7 @@ import {
   staticResourceSearchPath
 } from '@ir-engine/common/src/schemas/media/static-resource-search.schema'
 import { Application } from '../../../declarations'
+import { default as appConfig } from '../../appconfig'
 import { StaticResourceSearchService } from './static-resource-search.class'
 import hooks from './static-resource-search.hooks'
 
@@ -38,14 +39,16 @@ declare module '@ir-engine/common/declarations' {
 }
 
 export default (app: Application): void => {
-  // Initialize our service
-  app.use(staticResourceSearchPath, new StaticResourceSearchService(app), {
-    // Only expose the find method
-    methods: staticResourceSearchMethods,
-    // Custom events for search analytics
-    events: ['search-performed']
-  })
+  if (appConfig.vectordb.enabled) {
+    // Initialize our service
+    app.use(staticResourceSearchPath, new StaticResourceSearchService(app), {
+      // Only expose the find method
+      methods: staticResourceSearchMethods,
+      // Custom events for search analytics
+      events: ['search-performed']
+    })
 
-  // Initialize hooks
-  app.service(staticResourceSearchPath).hooks(hooks)
+    // Initialize hooks
+    app.service(staticResourceSearchPath).hooks(hooks)
+  }
 }

--- a/packages/server-core/src/media/static-resource-vector/static-resource-vector.test.ts
+++ b/packages/server-core/src/media/static-resource-vector/static-resource-vector.test.ts
@@ -30,194 +30,197 @@ import { destroyEngine } from '@ir-engine/ecs/src/Engine'
 import { v4 as uuidv4 } from 'uuid'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { Application } from '../../../declarations'
+import { default as appConfig } from '../../appconfig'
 import { createFeathersKoaApp, tearDownAPI } from '../../createApp'
 
 describe('static-resource-vector service', () => {
-  let app: Application
+  if (appConfig.vectordb.enabled) {
+    let app: Application
 
-  beforeAll(async () => {
-    app = await createFeathersKoaApp()
-    await app.setup()
-  })
+    beforeAll(async () => {
+      app = await createFeathersKoaApp()
+      await app.setup()
+    })
 
-  afterAll(async () => {
-    await tearDownAPI()
-    destroyEngine()
-  })
+    afterAll(async () => {
+      await tearDownAPI()
+      destroyEngine()
+    })
 
-  it('should be registered', () => {
-    const service = app.service(staticResourceVectorPath)
-    expect(service).toBeTruthy()
-  })
+    it('should be registered', () => {
+      const service = app.service(staticResourceVectorPath)
+      expect(service).toBeTruthy()
+    })
 
-  it('should create a vector entry', async () => {
-    const staticResourceId = uuidv4()
-    const vectorData = {
-      staticResourceId,
-      caption: 'A beautiful red sports car',
-      material: 'metal',
-      style: 'modern',
-      color: 'red'
-    }
-
-    const result = await app.service(staticResourceVectorPath).create(vectorData)
-
-    expect(result).toBeTruthy()
-    expect(result.staticResourceId).toBe(staticResourceId)
-    expect(result.caption).toBe('A beautiful red sports car')
-    expect(result.material).toBe('metal')
-    expect(result.style).toBe('modern')
-    expect(result.color).toBe('red')
-  })
-
-  it('should find vector entries', async () => {
-    const results = await app.service(staticResourceVectorPath).find({
-      query: {
-        $limit: 10
+    it('should create a vector entry', async () => {
+      const staticResourceId = uuidv4()
+      const vectorData = {
+        staticResourceId,
+        caption: 'A beautiful red sports car',
+        material: 'metal',
+        style: 'modern',
+        color: 'red'
       }
+
+      const result = await app.service(staticResourceVectorPath).create(vectorData)
+
+      expect(result).toBeTruthy()
+      expect(result.staticResourceId).toBe(staticResourceId)
+      expect(result.caption).toBe('A beautiful red sports car')
+      expect(result.material).toBe('metal')
+      expect(result.style).toBe('modern')
+      expect(result.color).toBe('red')
     })
 
-    expect(results).toBeTruthy()
-    expect(Array.isArray(results.data) || Array.isArray(results)).toBe(true)
-  })
+    it('should find vector entries', async () => {
+      const results = await app.service(staticResourceVectorPath).find({
+        query: {
+          $limit: 10
+        }
+      })
 
-  it('should sync static resource to vector database', async () => {
-    const vectorService = app.service(staticResourceVectorPath)
-    const staticResourceId = uuidv4()
-
-    const mockStaticResource = {
-      id: staticResourceId,
-      name: 'test-model.glb',
-      description: 'A test 3D model',
-      mimeType: 'model/gltf-binary',
-      tags: ['material:wood', 'style:rustic', 'color:brown']
-    }
-
-    /*
-    await vectorService.syncStaticResource(mockStaticResource)
-
-    // Find the synced entry
-    const results = await vectorService.find({
-      query: { staticResourceId }
+      expect(results).toBeTruthy()
+      expect(Array.isArray(results.data) || Array.isArray(results)).toBe(true)
     })
 
-    const syncedEntry = Array.isArray(results) ? results[0] : results.data[0]
-    expect(syncedEntry).toBeTruthy()
-    expect(syncedEntry.staticResourceId).toBe(staticResourceId)
-    expect(syncedEntry.caption).toBe('A test 3D model')
-    */
-  })
+    it('should sync static resource to vector database', async () => {
+      const vectorService = app.service(staticResourceVectorPath)
+      const staticResourceId = uuidv4()
 
-  it('should delete vector entry by static resource ID', async () => {
-    const vectorService = app.service(staticResourceVectorPath)
-    const staticResourceId = uuidv4()
-
-    // Create a vector entry
-    await vectorService.create({
-      staticResourceId,
-      caption: 'Test entry to delete'
-    })
-
-    // Delete by static resource ID
-    await vectorService.deleteByStaticResourceId(staticResourceId)
-
-    // Verify it's deleted
-    const results = await vectorService.find({
-      query: { staticResourceId }
-    })
-
-    const entries = Array.isArray(results) ? results : results.data
-    expect(entries.length).toBe(0)
-  })
-
-  it('should perform semantic search', async () => {
-    const vectorService = app.service(staticResourceVectorPath)
-
-    // Note: This test uses mock embeddings, so results may not be semantically meaningful
-    // In production, this would use real embeddings from an AI service
-    const results = await vectorService.semanticSearch('red car', 'combined', 0.5, 5)
-
-    expect(Array.isArray(results)).toBe(true)
-    // Results may be empty with mock embeddings, which is expected
-  })
-
-  it('should handle semantic search queries through find method', async () => {
-    const vectorService = app.service(staticResourceVectorPath)
-
-    const results = await vectorService.find({
-      query: {
-        semanticSearch: 'wooden furniture',
-        searchField: 'material',
-        similarityThreshold: 0.6,
-        maxResults: 10
+      const mockStaticResource = {
+        id: staticResourceId,
+        name: 'test-model.glb',
+        description: 'A test 3D model',
+        mimeType: 'model/gltf-binary',
+        tags: ['material:wood', 'style:rustic', 'color:brown']
       }
-    })
 
-    expect(results).toBeTruthy()
-    expect(Array.isArray(results) || Array.isArray(results.data)).toBe(true)
-  })
+      /*
+      await vectorService.syncStaticResource(mockStaticResource)
 
-  it('should update static resource reference', async () => {
-    const vectorService = app.service(staticResourceVectorPath)
-    const oldStaticResourceId = uuidv4()
-    const newStaticResourceId = uuidv4()
-
-    // Create a vector entry with old ID
-    await vectorService.create({
-      staticResourceId: oldStaticResourceId,
-      caption: 'Test entry for reference update'
-    })
-
-    // Update the reference
-    await vectorService.updateStaticResourceReference(oldStaticResourceId, newStaticResourceId)
-
-    // Verify the reference was updated
-    const results = await vectorService.find({
-      query: { staticResourceId: newStaticResourceId }
-    })
-
-    const updatedEntry = Array.isArray(results) ? results[0] : results.data[0]
-    expect(updatedEntry).toBeTruthy()
-    expect(updatedEntry.staticResourceId).toBe(newStaticResourceId)
-
-    // Verify old reference no longer exists
-    const oldResults = await vectorService.find({
-      query: { staticResourceId: oldStaticResourceId }
-    })
-
-    const oldEntries = Array.isArray(oldResults) ? oldResults : oldResults.data
-    expect(oldEntries.length).toBe(0)
-  })
-
-  it('should batch sync multiple static resources', async () => {
-    const vectorService = app.service(staticResourceVectorPath)
-
-    const mockResources = [
-      {
-        id: uuidv4(),
-        name: 'model1.glb',
-        description: 'First test model'
-      },
-      {
-        id: uuidv4(),
-        name: 'model2.glb',
-        description: 'Second test model'
-      }
-    ]
-
-    /*
-    await vectorService.batchSyncStaticResources(mockResources)
-
-    // Verify both resources were synced
-    for (const resource of mockResources) {
+      // Find the synced entry
       const results = await vectorService.find({
-        query: { staticResourceId: resource.id }
+        query: { staticResourceId }
       })
 
       const syncedEntry = Array.isArray(results) ? results[0] : results.data[0]
       expect(syncedEntry).toBeTruthy()
-      expect(syncedEntry.staticResourceId).toBe(resource.id)
-    }
-    */
-  })
+      expect(syncedEntry.staticResourceId).toBe(staticResourceId)
+      expect(syncedEntry.caption).toBe('A test 3D model')
+      */
+    })
+
+    it('should delete vector entry by static resource ID', async () => {
+      const vectorService = app.service(staticResourceVectorPath)
+      const staticResourceId = uuidv4()
+
+      // Create a vector entry
+      await vectorService.create({
+        staticResourceId,
+        caption: 'Test entry to delete'
+      })
+
+      // Delete by static resource ID
+      await vectorService.deleteByStaticResourceId(staticResourceId)
+
+      // Verify it's deleted
+      const results = await vectorService.find({
+        query: { staticResourceId }
+      })
+
+      const entries = Array.isArray(results) ? results : results.data
+      expect(entries.length).toBe(0)
+    })
+
+    it('should perform semantic search', async () => {
+      const vectorService = app.service(staticResourceVectorPath)
+
+      // Note: This test uses mock embeddings, so results may not be semantically meaningful
+      // In production, this would use real embeddings from an AI service
+      const results = await vectorService.semanticSearch('red car', 'combined', 0.5, 5)
+
+      expect(Array.isArray(results)).toBe(true)
+      // Results may be empty with mock embeddings, which is expected
+    })
+
+    it('should handle semantic search queries through find method', async () => {
+      const vectorService = app.service(staticResourceVectorPath)
+
+      const results = await vectorService.find({
+        query: {
+          semanticSearch: 'wooden furniture',
+          searchField: 'material',
+          similarityThreshold: 0.6,
+          maxResults: 10
+        }
+      })
+
+      expect(results).toBeTruthy()
+      expect(Array.isArray(results) || Array.isArray(results.data)).toBe(true)
+    })
+
+    it('should update static resource reference', async () => {
+      const vectorService = app.service(staticResourceVectorPath)
+      const oldStaticResourceId = uuidv4()
+      const newStaticResourceId = uuidv4()
+
+      // Create a vector entry with old ID
+      await vectorService.create({
+        staticResourceId: oldStaticResourceId,
+        caption: 'Test entry for reference update'
+      })
+
+      // Update the reference
+      await vectorService.updateStaticResourceReference(oldStaticResourceId, newStaticResourceId)
+
+      // Verify the reference was updated
+      const results = await vectorService.find({
+        query: { staticResourceId: newStaticResourceId }
+      })
+
+      const updatedEntry = Array.isArray(results) ? results[0] : results.data[0]
+      expect(updatedEntry).toBeTruthy()
+      expect(updatedEntry.staticResourceId).toBe(newStaticResourceId)
+
+      // Verify old reference no longer exists
+      const oldResults = await vectorService.find({
+        query: { staticResourceId: oldStaticResourceId }
+      })
+
+      const oldEntries = Array.isArray(oldResults) ? oldResults : oldResults.data
+      expect(oldEntries.length).toBe(0)
+    })
+
+    it('should batch sync multiple static resources', async () => {
+      const vectorService = app.service(staticResourceVectorPath)
+
+      const mockResources = [
+        {
+          id: uuidv4(),
+          name: 'model1.glb',
+          description: 'First test model'
+        },
+        {
+          id: uuidv4(),
+          name: 'model2.glb',
+          description: 'Second test model'
+        }
+      ]
+
+      /*
+      await vectorService.batchSyncStaticResources(mockResources)
+
+      // Verify both resources were synced
+      for (const resource of mockResources) {
+        const results = await vectorService.find({
+          query: { staticResourceId: resource.id }
+        })
+
+        const syncedEntry = Array.isArray(results) ? results[0] : results.data[0]
+        expect(syncedEntry).toBeTruthy()
+        expect(syncedEntry.staticResourceId).toBe(resource.id)
+      }
+      */
+    })
+  }
 })

--- a/packages/server-core/src/media/static-resource-vector/static-resource-vector.ts
+++ b/packages/server-core/src/media/static-resource-vector/static-resource-vector.ts
@@ -28,6 +28,7 @@ import {
   staticResourceVectorPath
 } from '@ir-engine/common/src/schemas/media/static-resource-vector.schema'
 import { Application } from '../../../declarations'
+import { default as appConfig } from '../../appconfig'
 import { StaticResourceVectorService } from './static-resource-vector.class'
 import hooks from './static-resource-vector.hooks'
 
@@ -38,21 +39,23 @@ declare module '@ir-engine/common/declarations' {
 }
 
 export default (app: Application): void => {
-  const options = {
-    name: staticResourceVectorPath,
-    paginate: app.get('paginate'),
-    Model: app.get('vectorDbClient'),
-    multi: true
+  if (appConfig.vectordb.enabled) {
+    const options = {
+      name: staticResourceVectorPath,
+      paginate: app.get('paginate'),
+      Model: app.get('vectorDbClient'),
+      multi: true
+    }
+
+    // Initialize our service with any options it requires
+    app.use(staticResourceVectorPath, new StaticResourceVectorService(options, app), {
+      // A list of all methods this service exposes externally
+      methods: staticResourceVectorMethods,
+      // You can add additional custom events to be sent to clients here
+      events: []
+    })
+
+    // Initialize hooks
+    app.service(staticResourceVectorPath).hooks(hooks)
   }
-
-  // Initialize our service with any options it requires
-  app.use(staticResourceVectorPath, new StaticResourceVectorService(options, app), {
-    // A list of all methods this service exposes externally
-    methods: staticResourceVectorMethods,
-    // You can add additional custom events to be sent to clients here
-    events: []
-  })
-
-  // Initialize hooks
-  app.service(staticResourceVectorPath).hooks(hooks)
 }

--- a/packages/server-core/src/media/static-resource/static-resource.hooks.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.hooks.ts
@@ -33,6 +33,7 @@ import { discardQuery, iff, iffElse, isProvider } from 'feathers-hooks-common'
 import { isEmpty } from 'lodash'
 import { HookContext } from '../../../declarations'
 import logger from '../../ServerLogger'
+import { default as appConfig } from '../../appconfig'
 import allowNullQuery from '../../hooks/allow-null-query'
 import checkScope from '../../hooks/check-scope'
 import enableClientPagination from '../../hooks/enable-client-pagination'
@@ -369,19 +370,21 @@ const addLog = async (context: HookContext<StaticResourceService>, actionType: '
  * Sync static resource to vector database after create/update
  */
 const syncToVectorDatabase = async (context: HookContext<StaticResourceService>) => {
-  try {
-    const vectorService = context.app.service(staticResourceVectorPath)
-    if (vectorService && typeof vectorService.syncStaticResource === 'function') {
-      const staticResource = context.result as StaticResourceType
-      const assetClass = FileToAssetType(staticResource.key)
+  if (appConfig.vectordb.enabled) {
+    try {
+      const vectorService = context.app.service(staticResourceVectorPath)
+      if (vectorService && typeof vectorService.syncStaticResource === 'function') {
+        const staticResource = context.result as StaticResourceType
+        const assetClass = FileToAssetType(staticResource.key)
 
-      if (assetClass === AssetType.Material || assetClass === AssetType.Model) {
-        await vectorService.syncStaticResource(staticResource)
+        if (assetClass === AssetType.Material || assetClass === AssetType.Model) {
+          await vectorService.syncStaticResource(staticResource)
+        }
       }
+    } catch (error) {
+      console.error('Error syncing to vector database:', error)
+      // Don't throw error to avoid breaking the main operation
     }
-  } catch (error) {
-    console.error('Error syncing to vector database:', error)
-    // Don't throw error to avoid breaking the main operation
   }
 }
 
@@ -389,15 +392,17 @@ const syncToVectorDatabase = async (context: HookContext<StaticResourceService>)
  * Remove static resource from vector database after delete
  */
 const removeFromVectorDatabase = async (context: HookContext<StaticResourceService>) => {
-  try {
-    const vectorService = context.app.service(staticResourceVectorPath)
-    if (vectorService && typeof vectorService.deleteByStaticResourceId === 'function') {
-      const staticResourceId = context.id as string
-      await vectorService.deleteByStaticResourceId(staticResourceId)
+  if (appConfig.vectordb.enabled) {
+    try {
+      const vectorService = context.app.service(staticResourceVectorPath)
+      if (vectorService && typeof vectorService.deleteByStaticResourceId === 'function') {
+        const staticResourceId = context.id as string
+        await vectorService.deleteByStaticResourceId(staticResourceId)
+      }
+    } catch (error) {
+      console.error('Error removing from vector database:', error)
+      // Don't throw error to avoid breaking the main operation
     }
-  } catch (error) {
-    console.error('Error removing from vector database:', error)
-    // Don't throw error to avoid breaking the main operation
   }
 }
 

--- a/scripts/docker-compose-core.yml
+++ b/scripts/docker-compose-core.yml
@@ -17,6 +17,7 @@ services:
       - '6379:6379'
   postgres:
     image: pgvector/pgvector:pg16
+    profiles: ["vectordb"] # Only starts in vectordb profile
     container_name: ir-engine_vector_db
     environment:
       POSTGRES_USER: postgres
@@ -29,6 +30,7 @@ services:
 
   ollama:
     image: ollama/ollama:latest
+    profiles: ["vectordb"] # Only starts in vectordb profile
     entrypoint:
       [
         "/bin/bash",

--- a/scripts/docker-compose-test.yml
+++ b/scripts/docker-compose-test.yml
@@ -13,6 +13,7 @@ services:
 
   testdb-vector:
     image: pgvector/pgvector:pg16
+    profiles: ["vectordb"] # Only starts in vectordb profile
     container_name: ir-engine_vector_test_db
     environment:
       POSTGRES_USER: postgres

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - '6379:6379'
   postgres:
     image: pgvector/pgvector:pg16
+    profiles: ["vectordb"] # Only starts in vectordb profile
     container_name: ir-engine_vector_db
     environment:
       POSTGRES_USER: postgres
@@ -48,6 +49,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
   testdb-vector:
     image: pgvector/pgvector:pg16
+    profiles: ["vectordb"] # Only starts in vectordb profile
     container_name: ir-engine_vector_test_db
     environment:
       POSTGRES_USER: postgres
@@ -60,6 +62,7 @@ services:
 
   ollama:
     image: ollama/ollama:latest
+    profiles: ["vectordb"] # Only starts in vectordb profile
     entrypoint:
       [
         "/bin/bash",

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -17,6 +17,11 @@ then
 
     export COMPOSE_IGNORE_ORPHANS=true
 
+    if [[ "${VECTORDB_ENABLED}" == 'true' ]]; then
+        echo -e "\e[32m💾 Enabling VectorDB..."
+        command_to_execute+=" --profile vectordb"
+    fi
+
     eval "$command_to_execute -f docker-compose-core.yml up -d"
     if [[ -z "${DC_minio}" || "${DC_minio}" == 'true' ]]; then
         eval "$command_to_execute -f docker-compose-minio.yml up -d"


### PR DESCRIPTION
## Summary
Make engine vector database setup optional

## Subtasks Checklist

## Breaking Changes
Vector database is not disabled by default:
VECTORDB_ENABLED=false

To enable Vector database, set environment variable:
VECTORDB_ENABLED=true

## References
closes [IR-11764](https://tsu.atlassian.net/browse/IR-11764)

## QA Steps
Set environment variable VECTORDB_ENABLED to true/false to test vector database

[IR-11764]: https://tsu.atlassian.net/browse/IR-11764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ