### PR TITLE
Vector DB setup: make docker compose use the environment variables

### DIFF
--- a/scripts/delete-database.sh
+++ b/scripts/delete-database.sh
@@ -24,7 +24,7 @@ PGUSER="postgres"
 PGPASSWORD="postgres"
 
 # PostgreSQL port
-PGPORT="5432"
+PGPORT="5431"
 
 # Database name to drop
 PGDB="vector-db"

--- a/scripts/delete-database.sh
+++ b/scripts/delete-database.sh
@@ -1,17 +1,28 @@
 #!/bin/bash
 
-# MySQL username and password
-DB_USER="server"
-DB_PASSWORD="password"
+# Load environment variables from .env.local
+if [ -f "../../.env.local" ]; then
+    export $(grep -v '^#' ../../.env.local | xargs)
+elif [ -f ".env.local" ]; then
+    export $(grep -v '^#' .env.local | xargs)
+else
+    echo "Warning: .env.local file not found. Using default values."
+fi
+
+# MySQL username and password (use environment variables or defaults)
+DB_USER="${MYSQL_USER:-server}"
+DB_PASSWORD="${MYSQL_PASSWORD:-password}"
+DB_HOST="${MYSQL_HOST:-127.0.0.1}"
+DB_PORT="${MYSQL_PORT:-3306}"
 
 # Database name to drop
-DB_NAME="ir-engine"
+DB_NAME="${MYSQL_DATABASE:-ir-engine}"
 
 # Change to the "packages/server-core" directory
 cd packages/server-core
 
 # Run MySQL and provide the password
-mysql -h 127.0.0.1 -u "$DB_USER" -p"$DB_PASSWORD" <<EOF
+mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" <<EOF
 
 # Drop the database
 DROP DATABASE IF EXISTS $DB_NAME;
@@ -19,15 +30,14 @@ DROP DATABASE IF EXISTS $DB_NAME;
 # Exit from the MySQL shell
 EOF
 
-# PostgreSQL username and password
-PGUSER="postgres"
-PGPASSWORD="postgres"
-
-# PostgreSQL port
-PGPORT="5431"
+# PostgreSQL username and password (use environment variables or defaults)
+PGUSER="${POSTGRES_USER:-postgres}"
+PGPASSWORD="${POSTGRES_PASSWORD:-postgres}"
+PGHOST="${POSTGRES_HOST:-127.0.0.1}"
+PGPORT="${POSTGRES_PORT:-5431}"
 
 # Database name to drop
-PGDB="vector-db"
+PGDB="${POSTGRES_DATABASE:-vector-db}"
 
 # Change to the "packages/server-core" directory
 cd packages/server-core
@@ -36,7 +46,7 @@ cd packages/server-core
 export PGPASSWORD
 
 # Run PostgreSQL and provide the password
-psql -h 127.0.0.1 -U "$PGUSER" -p "$PGPORT" <<EOF
+psql -h "$PGHOST" -U "$PGUSER" -p "$PGPORT" <<EOF
 
 # Drop the database
 DROP DATABASE IF EXISTS $PGDB;

--- a/scripts/docker-compose-core.yml
+++ b/scripts/docker-compose-core.yml
@@ -19,11 +19,11 @@ services:
     image: pgvector/pgvector:pg16
     container_name: ir-engine_vector_db
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DATABASE: vector-db
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DATABASE: ${POSTGRES_DATABASE:-vector-db}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -39,11 +39,11 @@ services:
     image: pgvector/pgvector:pg16
     container_name: ir-engine_vector_db
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DATABASE: vector-db
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DATABASE: ${POSTGRES_DATABASE:-vector-db}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
   testdb-vector:

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 test -f ../.env.local && . ../.env.local
+export POSTGRES_PORT POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DATABASE
 
 if which docker > /dev/null 2>&1
 then


### PR DESCRIPTION
The environment variables for postgres user, port, password were not being referenced in the docker compose, and so if they were changed it would cause issues with intialization
