### PR TITLE
Camera orbit not working in AssetPreviewCameraComponent outside of editor mode

### DIFF
--- a/packages/spatial/src/camera/components/FollowCameraComponent.ts
+++ b/packages/spatial/src/camera/components/FollowCameraComponent.ts
@@ -56,6 +56,7 @@ import { TransformComponent } from '../../transform/components/TransformComponen
 import { CameraSettingsState } from '../CameraSettingsState'
 import { setTargetCameraRotation } from '../functions/CameraFunctions'
 import { FollowCameraMode, FollowCameraShoulderSide } from '../types/FollowCameraMode'
+import { CameraOrbitComponent } from './CameraOrbitComponent'
 import { TargetCameraRotationComponent } from './TargetCameraRotationComponent'
 
 const window = 'window' in globalThis ? globalThis.window : ({} as any as Window)
@@ -267,6 +268,14 @@ export const FollowCameraComponent = defineComponent({
       }
       return mode !== follow.mode.value
     }
+
+    //disable orbit camera used for the editor to prevent conflicts / flickering
+    useImmediateEffect(() => {
+      removeComponent(entity, CameraOrbitComponent)
+      return () => {
+        setComponent(entity, CameraOrbitComponent)
+      }
+    }, [])
 
     useImmediateEffect(() => {
       const cameraSettings = cameraSettingsState.value

--- a/packages/spatial/src/camera/components/FollowCameraComponent.ts
+++ b/packages/spatial/src/camera/components/FollowCameraComponent.ts
@@ -271,9 +271,10 @@ export const FollowCameraComponent = defineComponent({
 
     //disable orbit camera used for the editor to prevent conflicts / flickering
     useImmediateEffect(() => {
-      removeComponent(entity, CameraOrbitComponent)
+      const preexistingOrbit = hasComponent(entity, CameraOrbitComponent)
+      if (preexistingOrbit) removeComponent(entity, CameraOrbitComponent)
       return () => {
-        setComponent(entity, CameraOrbitComponent)
+        if (preexistingOrbit) setComponent(entity, CameraOrbitComponent)
       }
     }, [])
 

--- a/packages/spatial/src/camera/components/PoiCameraComponent.ts
+++ b/packages/spatial/src/camera/components/PoiCameraComponent.ts
@@ -23,7 +23,13 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { defineComponent, removeComponent, setComponent, useEntityContext } from '@ir-engine/ecs/src/ComponentFunctions'
+import {
+  defineComponent,
+  hasComponent,
+  removeComponent,
+  setComponent,
+  useEntityContext
+} from '@ir-engine/ecs/src/ComponentFunctions'
 import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
 import { useImmediateEffect } from '@ir-engine/hyperflux'
 import { CameraOrbitComponent } from './CameraOrbitComponent'
@@ -54,9 +60,10 @@ export const PoiCameraComponent = defineComponent({
 
     //disable orbit camera used for the editor to prevent conflicts / flickering
     useImmediateEffect(() => {
-      removeComponent(entity, CameraOrbitComponent)
+      const preexistingOrbit = hasComponent(entity, CameraOrbitComponent)
+      if (preexistingOrbit) removeComponent(entity, CameraOrbitComponent)
       return () => {
-        setComponent(entity, CameraOrbitComponent)
+        if (preexistingOrbit) setComponent(entity, CameraOrbitComponent)
       }
     }, [])
   }

--- a/packages/spatial/src/camera/components/PoiCameraComponent.ts
+++ b/packages/spatial/src/camera/components/PoiCameraComponent.ts
@@ -23,8 +23,10 @@ All portions of the code written by the Infinite Reality Engine team are Copyrig
 Infinite Reality Engine. All Rights Reserved.
 */
 
-import { defineComponent } from '@ir-engine/ecs/src/ComponentFunctions'
+import { defineComponent, removeComponent, setComponent, useEntityContext } from '@ir-engine/ecs/src/ComponentFunctions'
 import { S } from '@ir-engine/ecs/src/schemas/JSONSchemas'
+import { useImmediateEffect } from '@ir-engine/hyperflux'
+import { CameraOrbitComponent } from './CameraOrbitComponent'
 
 /**
  * Component for Guided (Point of Interest) camera behavior.
@@ -45,5 +47,17 @@ export const PoiCameraComponent = defineComponent({
 
     // Transition state for snapping mode
     isTransitioning: S.Bool({ default: false })
-  })
+  }),
+
+  reactor: () => {
+    const entity = useEntityContext()
+
+    //disable orbit camera used for the editor to prevent conflicts / flickering
+    useImmediateEffect(() => {
+      removeComponent(entity, CameraOrbitComponent)
+      return () => {
+        setComponent(entity, CameraOrbitComponent)
+      }
+    }, [])
+  }
 })

--- a/packages/spatial/src/camera/systems/CameraOrbitSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraOrbitSystem.tsx
@@ -27,14 +27,13 @@ import { Matrix3, Spherical, Vector3 } from 'three'
 
 import {
   defineSystem,
-  EngineState,
   getComponent,
   getMutableComponent,
   getOptionalComponent,
   InputSystemGroup,
   query
 } from '@ir-engine/ecs'
-import { getState, isClient } from '@ir-engine/hyperflux'
+import { isClient } from '@ir-engine/hyperflux'
 import { CameraComponent } from '@ir-engine/spatial/src/camera/components/CameraComponent'
 import { CameraOrbitComponent } from '@ir-engine/spatial/src/camera/components/CameraOrbitComponent'
 import { Vector3_Up } from '@ir-engine/spatial/src/common/constants/MathConstants'
@@ -53,8 +52,6 @@ const orbitCameraQueryTerms = [RendererComponent, CameraOrbitComponent, InputCom
 
 const execute = () => {
   if (!isClient) return
-
-  if (!getState(EngineState).isEditing) return
 
   for (const cameraEid of query(orbitCameraQueryTerms)) {
     const cameraOrbit = getMutableComponent(cameraEid, CameraOrbitComponent)


### PR DESCRIPTION
removed the isEditing conditional in the camera orbit system and replaced with a mount/unmount use effect in the Follow Camera and POI Camera components that remove and re-set the Camera Orbit component, so that it won't conflict with other camera control components ( follow and poi)

## Summary
https://tsu.atlassian.net/browse/IR-11797

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
