### PR TITLE
IR-11738 modifying pre-commit hook in shared-hooks

### DIFF
--- a/shared-hooks/pre-commit
+++ b/shared-hooks/pre-commit
@@ -4,15 +4,24 @@
 # This hook runs the same checks as the root project
 # Compatible with Mac, Windows (Git Bash), and Linux
 
-# Find the root project directory (MT WHATEVER)
+# Find the root project directory (ir-engine)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Determine if we're running in the main repo or a nested repo
+CURRENT_REPO="$(pwd)"
+IS_MAIN_REPO=false
+
+if [ "$CURRENT_REPO" = "$ROOT_PROJECT_DIR" ]; then
+    IS_MAIN_REPO=true
+    echo "Running pre-commit hooks in MAIN repository: $ROOT_PROJECT_DIR"
+else
+    echo "Running pre-commit hooks in NESTED repository: $CURRENT_REPO"
+    echo "Main repository: $ROOT_PROJECT_DIR"
+fi
+
 # Change to root project directory to access node_modules and scripts
 cd "$ROOT_PROJECT_DIR"
-
-# Run the same pre-commit checks as the root project
-echo "Running shared pre-commit hooks from: $ROOT_PROJECT_DIR"
 
 # Determine the correct executable extension for Windows
 if [ -f "./node_modules/.bin/ts-node.cmd" ]; then
@@ -25,13 +34,17 @@ else
     LINT_STAGED="./node_modules/.bin/lint-staged"
 fi
 
-# Run add-license-headers
-echo "Adding license headers..."
-"$TS_NODE" --swc scripts/add-license-headers.ts
-RESULT=$?
-if [ $RESULT -ne 0 ]; then
-    echo "License header check failed"
-    exit 1
+# Run add-license-headers (only in main repository)
+if [ "$IS_MAIN_REPO" = true ]; then
+    echo "Adding license headers (main repo only)..."
+    "$TS_NODE" --swc scripts/add-license-headers.ts
+    RESULT=$?
+    if [ $RESULT -ne 0 ]; then
+        echo "License header check failed"
+        exit 1
+    fi
+else
+    echo "Skipping license headers (nested repo - handled by main repo)"
 fi
 
 # Run format-staged (lint-staged)

--- a/shared-hooks/pre-commit.js
+++ b/shared-hooks/pre-commit.js
@@ -10,21 +10,34 @@ const fs = require('fs');
 // Find the root project directory
 const scriptDir = __dirname;
 const rootProjectDir = path.resolve(scriptDir, '..');
+const currentRepo = process.cwd();
 
-// Change to root project directory
+// Determine if we're running in the main repo or a nested repo
+const isMainRepo = currentRepo === rootProjectDir;
+
+if (isMainRepo) {
+    console.log(`Running pre-commit hooks in MAIN repository: ${rootProjectDir}`);
+} else {
+    console.log(`Running pre-commit hooks in NESTED repository: ${currentRepo}`);
+    console.log(`Main repository: ${rootProjectDir}`);
+}
+
+// Change to root project directory to access node_modules and scripts
 process.chdir(rootProjectDir);
 
-console.log(`Running shared pre-commit hooks from: ${rootProjectDir}`);
-
 try {
-    // Run add-license-headers
-    console.log('Adding license headers...');
-    execSync('npm run add-license-headers', { stdio: 'inherit' });
-    
+    // Run add-license-headers (only in main repository)
+    if (isMainRepo) {
+        console.log('Adding license headers (main repo only)...');
+        execSync('npm run add-license-headers', { stdio: 'inherit' });
+    } else {
+        console.log('Skipping license headers (nested repo - handled by main repo)');
+    }
+
     // Run format-staged (lint-staged)
     console.log('Running lint-staged...');
     execSync('npm run format-staged', { stdio: 'inherit' });
-    
+
     console.log('All pre-commit checks passed');
     process.exit(0);
 } catch (error) {


### PR DESCRIPTION
## Summary
modifying pre-commit hook in shared-hooks to only fire when called from the engine root repository, not the projects repositories

## References
[https://tsu.atlassian.net/browse/IR-11738](https://tsu.atlassian.net/browse/IR-11738)