### PR TITLE
Adding rigidbody in PLAY/SIMULATION mode breaks skybox rendering

### DIFF
--- a/packages/engine/src/scene/components/SkyboxComponent.ts
+++ b/packages/engine/src/scene/components/SkyboxComponent.ts
@@ -110,6 +110,13 @@ export const SkyboxComponent = defineComponent({
     }, [])
 
     useEffect(() => {
+      if (!texture) return
+      return () => {
+        texture.dispose()
+      }
+    }, [texture])
+
+    useEffect(() => {
       if (skyboxState.backgroundType.value !== SkyTypeEnum.equirectangular || !texture) return
 
       texture.colorSpace = SRGBColorSpace
@@ -117,9 +124,6 @@ export const SkyboxComponent = defineComponent({
       texture.minFilter = LinearFilter
       texture.generateMipmaps = false
       setComponent(entity, BackgroundComponent, texture)
-      return () => {
-        texture.dispose()
-      }
     }, [texture, skyboxState.backgroundType])
 
     useEffect(() => {


### PR DESCRIPTION

## Summary
https://tsu.atlassian.net/browse/IR-11677

moved the texture dispose to it's own unmount call so it is not unmounted when the background type is updated

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
