### PR TITLE
fixed(IR-11779): MT-INT bug file browser icon view for files all in single column

### DIFF
--- a/packages/editor/src/panels/files/filebrowser.tsx
+++ b/packages/editor/src/panels/files/filebrowser.tsx
@@ -179,6 +179,7 @@ export function Browser() {
           onScrollBottom={() => {
             filesQuery?.setLimit(filesQuery.limit + FILES_PAGE_LIMIT)
           }}
+          className={!isListView ? 'grid w-full grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-2' : ''}
         >
           {isListView ? <FileItemsInsideTable /> : <FileItemsRender />}
         </InfiniteScroll>
@@ -188,7 +189,10 @@ export function Browser() {
 
   return (
     <div
-      className={twMerge('h-full overflow-y-auto bg-surface-1', isFileDropOver ? 'border-2 border-gray-300' : '')}
+      className={twMerge(
+        'h-full w-full overflow-y-auto bg-surface-1',
+        isFileDropOver ? 'border-2 border-gray-300' : ''
+      )}
       ref={fileDropRef}
       onContextMenu={(event) => {
         event.preventDefault()
@@ -198,16 +202,14 @@ export function Browser() {
       }}
     >
       <div
-        className={twMerge('mb-2 h-auto pb-6 text-gray-400 ', !isListView && 'flex py-8')}
+        className={twMerge('mb-2 h-auto pb-6 text-gray-400 ', !isListView && 'w-full py-8')}
         onClick={(event) => {
           event.stopPropagation()
           selectedFiles.set([])
           ClickPlacementState.resetSelectedAsset()
         }}
       >
-        <div className={twMerge(!isListView && 'flex flex-wrap gap-2')}>
-          <FileItems />
-        </div>
+        <FileItems />
       </div>
       <FileContextMenu anchorEvent={anchorEvent} setAnchorEvent={setAnchorEvent} />
     </div>


### PR DESCRIPTION
## Summary

<img width="1800" height="1222" alt="2025-07-15-154051_hyprshot" src="https://github.com/user-attachments/assets/2e145bc4-aeb6-461b-90f1-c7ff498aad5e" />


🐛 Bug Fix: File Browser Icon View Layout Issue
## Problem:
In the Assets panel under the 'Files' category, switching from List to Icon view mode displayed all files in a single column instead of a responsive grid layout.

### Root Cause:
The grid container structure had wrapper divs that were interfering with CSS Grid layout, and the InfiniteScroll component wasn't properly applying grid classes to create the multi-column layout.

### Solution:

Applied CSS Grid classes directly to the InfiniteScroll container when in icon view mode
Used grid-cols-[repeat(auto-fill,minmax(140px,1fr))] for responsive column layout
Removed redundant wrapper divs that were breaking the grid structure
Ensured proper width inheritance throughout the component hierarchy
### Testing:

✅ List view mode continues to work correctly
✅ Icon view mode now displays files in multiple columns
✅ Grid is responsive and adapts to container width
✅ File interactions (click, drag, context menu) remain functional
### References
closes Jira ticket [IR-11779](https://tsu.atlassian.net/browse/IR-11779)


[IR-11779]: https://tsu.atlassian.net/browse/IR-11779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ