### PR TITLE
IR-11725  fix rotating camera on Mobile viewer

### DIFF
--- a/packages/hyperflux/src/media/MediaStreamState.ts
+++ b/packages/hyperflux/src/media/MediaStreamState.ts
@@ -55,7 +55,7 @@ export const MediaStreamState = defineState({
     /** Whether the audio is enabled or not. */
     microphoneEnabled: false,
     /** Whether the face tracking is enabled or not. */
-    /** @deprecated face tracking has been disabled */
+    /** @deprecated - face tracking has been disabled */
     faceTracking: false,
     /** Video stream for streaming data. */
     webcamMediaStream: null as MediaStream | null,
@@ -295,6 +295,31 @@ export const MediaStreamService = {
       return false
     }
     console.log('Cycle camera')
+
+    const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+    const currentStream = state.webcamMediaStream.value
+    const currentTrack = currentStream.getVideoTracks()[0]
+    const currentFacingMode = currentTrack.getSettings().facingMode || 'environment'
+
+    currentStream.getTracks().forEach((track) => track.stop())
+
+    /**
+     * in mobile devices, switching between cameras could mean going from different lens (in different
+     * zoom levels) instead of actual different, cameras, so we look for the facing mode here
+     * (forward & back facing)
+     */
+    if (isMobile) {
+      const newFacingMode = currentFacingMode === 'user' ? 'environment' : 'user'
+      try {
+        const newStream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: { exact: newFacingMode } } })
+        state.webcamMediaStream.set(newStream)
+        return true
+      } catch (e) {
+        console.error('Unable to switch camera mode.', e)
+        return false
+      }
+    }
+
     // find "next" device in device list
     const deviceId = await MediaStreamService.getCurrentDeviceId('video')
     const allDevices = await navigator.mediaDevices.enumerateDevices()


### PR DESCRIPTION
## Summary
Description: On iOS mobile, it seems that pressing the rotate camera button option, it is instead going through all the camera zoom levels prior to rotating the camera.

Expected: Pressing rotate button switches between the user-facing and the forward facing camera on iPhone.
Actual: Pressing the rotate button seems to go from user facing, to forwards facing, to then zooming multiple times and then finally back to user facing.

Reproduction:
Enter published scene on iOS.
Enable camera
Press rotate camera button
Rotate camera to forward camera
Rotate camera to face camera
Rotate camera to forward camera again.
Observe that camera will go through different zoom levels prior to rotating back to face camera.

## Subtasks Checklist

## Breaking Changes

## References
[IR-11725](https://tsu.atlassian.net/browse/IR-11725)

## QA Steps
- Go to a location on mobile
- Enable camera
- Toggle between camera switch
- It should only be displaying forward and back facing camera


[IR-11725]: https://tsu.atlassian.net/browse/IR-11725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ